### PR TITLE
fix linting error appearing on windows dev

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,12 @@ export default [
     },
     rules: {
       "@typescript-eslint/no-unused-vars": "warn",
-      "prettier/prettier": "warn",
+      "prettier/prettier": [
+        "warn",
+        {
+          endOfLine: "auto",
+        },
+      ],
       "lit/no-invalid-html": "error",
     },
     ignores: [


### PR DESCRIPTION
End of line char on windows is different than on mac which throws a linting error if you are developing on windows. this fixes that