### PR TITLE
Set storybook font to Arial

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,4 @@
+body {
+    font-family: 'Arial', sans-serif;
+}
+  

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/web-components";
+import "./preview.css";
 
 const preview: Preview = {
   parameters: {


### PR DESCRIPTION

# Summary
Default font in stories was Times New Roman. This PR changes it to Arial to match our component library.

This is **not** a breaking change.  

## Major changes

_For complex or multi-part PRs, list significant changes made:_

- created `preview.css` file in `.storybook` folder

## Screenshots (if applicable)

before:
![image](https://github.com/user-attachments/assets/a67e99d7-f28a-4617-927f-f337aa4b6b5a)

after: 
![image](https://github.com/user-attachments/assets/e84f3f07-f742-4909-9fa1-fe2273a1542d)

(I know Manhattan is spelled wrong, that'll get fixed when `nys-radiobutton` is refactored)