### PR TITLE
build components before running storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "release:dry-run": "npm run build:all && node src/scripts/publish-dry-run.js",
     "release": "npm run build:all && npm publish --workspaces --access public && npm publish --access public",
     "test": "wtr --node-resolve",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "npm run build:all && storybook dev -p 6006",
     "build-storybook": "npm run build:packages && storybook build",
     "clean:node": "rm -rf node_modules && rm -rf packages/*/node_modules",
     "clean:dist": "rm -rf dist && rm -rf packages/*/dist",


### PR DESCRIPTION
add `npm run build:all` before running storybook to ensure the packages exist