### PR TITLE
Hotfix/usage blocks sizing

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -11,6 +11,12 @@ body {
     background-color: rgb(171, 251, 171);
 }
 
+.usage-wrapper {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+
 .usagedos {
     display: inline-block;
     width: 45%;


### PR DESCRIPTION
Add a wrapper class to the usagedos section so the boxes appear the same size. 

In existing mdx files we will need to wrap the useagedos divs to look like this:
```
<div class="usage-wrapper">   
    <div class="usagedos do">   
        content
    </div>   
    <div class="usagedos dont">   
        content
    </div>
</div>
```

Before:
![image](https://github.com/user-attachments/assets/fa3506b3-d56c-4541-8775-5cec142a6cee)
After: 
![image](https://github.com/user-attachments/assets/080f465a-1146-40c1-8354-51258b6ac134)
