### PR TITLE
Fix package scope for nys-alert

### DIFF
--- a/packages/nys-alert/package.json
+++ b/packages/nys-alert/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@excelsior/nys-alert",
+  "name": "@nys-excelsior/nys-alert",
   "version": "0.0.7-alpha",
   "description": "An alert component from the NYS Design System.",
   "module": "dist/nys-alert.js",


### PR DESCRIPTION
Simple fix to update the package scope for the nys-alert component.