### PR TITLE
cannot copy button text

### DIFF
--- a/packages/nys-button/src/nys-button.styles.ts
+++ b/packages/nys-button/src/nys-button.styles.ts
@@ -322,5 +322,6 @@ export default css`
   .nys-button__text {
     display: flex;
     align-items: center;
+    user-select: none;
   }
 `;


### PR DESCRIPTION
fix bug where label text in button was selectable
issue: 
![image](https://github.com/user-attachments/assets/0a6d3891-d145-4af1-a30d-65c187934de4)

