### PR TITLE
Feature: form textarea internal

### DIFF
--- a/packages/nys-textarea/src/nys-textarea.mdx
+++ b/packages/nys-textarea/src/nys-textarea.mdx
@@ -88,7 +88,7 @@ The `nys-textarea` component includes the following accessibility-focused featur
 
 The `nys-textarea` component emits the following events:
 
-1. **`nys-checkValidity`** – Fired when the input text changes.
+1. **`input`** – Fired when the input text changes.
 2. **`focus`** – Fired when the input gains focus.
 3. **`blur`** – Fired when the input loses focus.
 
@@ -99,8 +99,8 @@ You can listen to these events using JavaScript:
 // Select the textarea component
 const textarea = document.querySelector('nys-textarea');
 
-// Listen for the 'nys-checkValidity' event
-textarea.addEventListener('nys-checkValidity', (event) => {
+// Listen for the 'input' event
+textarea.addEventListener('input', (event) => {
   console.log('Text input changed:', event.target.value);
 });
 

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -220,8 +220,12 @@ export class NysTextarea extends LitElement {
           ?readonly=${this.readonly}
           aria-disabled="${this.disabled}"
           .value=${this.value}
-          placeholder=${ifDefined(this.placeholder ? this.placeholder : undefined)}
-          maxlength=${ifDefined(this.maxlength !== "" ? this.maxlength : undefined)}
+          placeholder=${ifDefined(
+            this.placeholder ? this.placeholder : undefined,
+          )}
+          maxlength=${ifDefined(
+            this.maxlength !== "" ? this.maxlength : undefined,
+          )}
           .rows=${this.rows}
           form=${ifDefined(this.form || undefined)}
           @input=${this._handleInput}

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -134,7 +134,6 @@ export class NysTextarea extends LitElement {
   private _handleInput(event: Event) {
     const textarea = event.target as HTMLInputElement;
     this.value = textarea.value;
-    console.log(this.value);
     this._internals.setFormValue(this.value);
 
     // Field is invalid after unfocused, validate aggressively on each input (e.g. Eager mode: a combination of aggressive and lazy.)

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -1,7 +1,10 @@
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import styles from "./nys-textarea.styles";
+import { ifDefined } from "lit/directives/if-defined.js";
 import "@nysds/nys-icon";
+
+let textareaIdCounter = 0; // Counter for generating unique IDs
 
 export class NysTextarea extends LitElement {
   @property({ type: String }) id = "";
@@ -53,21 +56,95 @@ export class NysTextarea extends LitElement {
 
   static styles = styles;
 
+  private _hasUserInteracted = false; // need this flag for "eager mode"
+  private _internals: ElementInternals;
+
+  /********************** Lifecycle updates **********************/
+  static formAssociated = true; // allows use of elementInternals' API
+
+  constructor() {
+    super();
+    this._internals = this.attachInternals();
+  }
+
+  // Generate a unique ID if one is not provided
+  connectedCallback() {
+    super.connectedCallback();
+    if (!this.id) {
+      this.id = `nys-textarea-${Date.now()}-${textareaIdCounter++}`;
+    }
+  }
+
+  firstUpdated() {
+    // This ensures our element always participates in the form
+    this._setValue();
+    this._manageRequire();
+  }
+
+  /********************** Form Integration **********************/
+  private _setValue() {
+    this._internals.setFormValue(this.value);
+  }
+
+  private _manageRequire() {
+    const textarea = this.shadowRoot?.querySelector("textarea");
+    const message = this.errorMessage
+      ? this.errorMessage
+      : "This field is required";
+    if (!textarea) return;
+
+    if (this.required && !this.value) {
+      this._internals.ariaRequired = "true";
+      this._internals.setValidity({ valueMissing: true }, message, textarea);
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  private _setValidityMessage(message: string = "") {
+    const textarea = this.shadowRoot?.querySelector("textarea");
+    if (!textarea) return;
+
+    // Toggle the HTML <div> tag error message
+    this.showError = !!message;
+    // If user sets errorMessage, this will always override the native validation message
+    if (this.errorMessage.trim() && message !== "") {
+      message = this.errorMessage;
+    }
+
+    this._internals.setValidity(
+      message ? { customError: true } : {},
+      message,
+      textarea,
+    );
+  }
+
+  private _validate() {
+    const textarea = this.shadowRoot?.querySelector("textarea");
+    if (!textarea) return;
+
+    // Get the native validation state
+    let message = textarea.validationMessage;
+
+    this._setValidityMessage(message);
+  }
+
+  /******************** Event Handlers ********************/
   // Handle input event to check pattern validity
   private _handleInput(event: Event) {
-    const input = event.target as HTMLInputElement;
-    this.value = input.value;
+    const textarea = event.target as HTMLInputElement;
+    this.value = textarea.value;
+    console.log(this.value);
+    this._internals.setFormValue(this.value);
+
+    // Field is invalid after unfocused, validate aggressively on each input (e.g. Eager mode: a combination of aggressive and lazy.)
+    if (this._hasUserInteracted) {
+      this._validate();
+    }
+
     this.dispatchEvent(
       new CustomEvent("input", {
         detail: { value: this.value },
-        bubbles: true,
-        composed: true,
-      }),
-    );
-    const checkValidity = input.checkValidity();
-    this.dispatchEvent(
-      new CustomEvent("nys-checkValidity", {
-        detail: { checkValidity },
         bubbles: true,
         composed: true,
       }),
@@ -81,20 +158,15 @@ export class NysTextarea extends LitElement {
 
   // Handle blur event
   private _handleBlur() {
+    this._hasUserInteracted = true; // At initial unfocus: if textarea is invalid, start aggressive mode
+    this._validate();
+
     this.dispatchEvent(new Event("blur"));
   }
 
   // Handle change event to bubble up selected value
-  private _handleChange(e: Event) {
-    const select = e.target as HTMLSelectElement;
-    this.value = select.value;
-    this.dispatchEvent(
-      new CustomEvent("change", {
-        detail: { value: this.value },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+  private _handleChange() {
+    this.dispatchEvent(new Event("change"));
   }
 
   private _handleSelect(e: Event) {
@@ -148,10 +220,10 @@ export class NysTextarea extends LitElement {
           ?readonly=${this.readonly}
           aria-disabled="${this.disabled}"
           .value=${this.value}
-          placeholder=${this.placeholder}
-          maxlength=${this.maxlength}
+          placeholder=${ifDefined(this.placeholder ? this.placeholder : undefined)}
+          maxlength=${ifDefined(this.maxlength !== "" ? this.maxlength : undefined)}
           .rows=${this.rows}
-          form=${this.form}
+          form=${ifDefined(this.form || undefined)}
           @input=${this._handleInput}
           @focus="${this._handleFocus}"
           @blur="${this._handleBlur}"
@@ -159,10 +231,10 @@ export class NysTextarea extends LitElement {
           @select="${this._handleSelect}"
           @selectionchange="${this._handleSelectionChange}"
         ></textarea>
-        ${this.showError && this.errorMessage
+        ${this.showError
           ? html`<div class="nys-textarea__error">
               <nys-icon name="error" size="xl"></nys-icon>
-              ${this.errorMessage}
+              ${this._internals.validationMessage || this.errorMessage}
             </div>`
           : ""}
       </label>

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -230,10 +230,14 @@ export class NysTextinput extends LitElement {
           aria-disabled="${this.disabled}"
           aria-label="${this.label} ${this.description}"
           .value=${this.value}
-          placeholder=${ifDefined(this.placeholder ? this.placeholder : undefined)}
+          placeholder=${ifDefined(
+            this.placeholder ? this.placeholder : undefined,
+          )}
           pattern=${ifDefined(this.pattern ? this.pattern : undefined)}
           min=${ifDefined(this.min !== "" ? this.min : undefined)}
-          maxlength=${ifDefined(this.maxlength !== "" ? this.maxlength : undefined)}
+          maxlength=${ifDefined(
+            this.maxlength !== "" ? this.maxlength : undefined,
+          )}
           step=${ifDefined(this.step !== "" ? this.step : undefined)}
           max=${ifDefined(this.max !== "" ? this.max : undefined)}
           form=${ifDefined(this.form ? this.form : undefined)}

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -230,24 +230,12 @@ export class NysTextinput extends LitElement {
           aria-disabled="${this.disabled}"
           aria-label="${this.label} ${this.description}"
           .value=${this.value}
-          placeholder=${this.placeholder}
+          placeholder=${ifDefined(this.placeholder ? this.placeholder : undefined)}
           pattern=${ifDefined(this.pattern ? this.pattern : undefined)}
-          min=${ifDefined(
-            this.min !== null && this.min !== undefined ? this.min : undefined,
-          )}
-          maxlength=${ifDefined(
-            this.maxlength !== null && this.maxlength !== undefined
-              ? this.maxlength
-              : undefined,
-          )}
-          step=${ifDefined(
-            this.step !== null && this.step !== undefined
-              ? this.step
-              : undefined,
-          )}
-          max=${ifDefined(
-            this.max !== null && this.max !== undefined ? this.max : undefined,
-          )}
+          min=${ifDefined(this.min !== "" ? this.min : undefined)}
+          maxlength=${ifDefined(this.maxlength !== "" ? this.maxlength : undefined)}
+          step=${ifDefined(this.step !== "" ? this.step : undefined)}
+          max=${ifDefined(this.max !== "" ? this.max : undefined)}
           form=${ifDefined(this.form ? this.form : undefined)}
           @input=${this._handleInput}
           @focus="${this._handleFocus}"


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success and we are glad you're here.

This pull request (PR) template exists to help speed up the integration process.
The Design System team reviews and approves each PR before we merge it into the public
code base, so please provide as much detail as possible to help us understand your changes.
On other words: we love clear explanations!
-->

<!---
Step 1 - Title this PR with the following format:
NYSDS - [Component]: [Brief statement describing what this pull request solves]
eg: "NYSDS - Button: Update hover states"
-->

# Summary

Implement elementInternal on `nys-textarea` to replace the old form controller branch code. The purpose of this is to allow custom components to interact with native form and submissions' 

<!--
A good summary is written in the past tense and includes:
- What was changed
- Why it was changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to the JavaScript API of a component
  - Changes to the HTML/markup required for a component
  - Major design changes or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

See ticket https://github.com/ITS-HCD/nysds/issues/311 🎟️

## Major changes

_For complex or multi-part PRs, list significant changes made:_

- **Modified components**: textarea implements elementInternal

## Testing and review
Testing environment: https://github.com/ITS-HCD/nysds-vanilla-webcomponents-demo

### Browser testing

_Indicate whether you have tested your changes in multiple browsers (e.g., Chrome, Firefox, Safari)._  
Tested on:

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge/IE

### Accessibility testing

_Indicate the accessibility checks you have completed:_

- [x] Screen reader testing
- [x] Keyboard navigation testing
- [ ] Color contrast checks
- [ ] Other: _[describe]_

