### PR TITLE
Feature: form select internal

### DIFF
--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -145,7 +145,7 @@ export class NysSelect extends LitElement {
     if (this._hasUserInteracted) {
       this._validate();
     }
-    
+
     this.dispatchEvent(
       new CustomEvent("change", {
         detail: { value: this.value },
@@ -154,7 +154,7 @@ export class NysSelect extends LitElement {
       }),
     );
   }
-  
+
   // Handle input changes by update the value as select changes
   private _handleInput() {
     this.dispatchEvent(new Event("input"));
@@ -169,7 +169,7 @@ export class NysSelect extends LitElement {
   private _handleBlur() {
     this._hasUserInteracted = true; // At initial unfocus: if textarea is invalid, start aggressive mode
     this._validate();
-    
+
     this.dispatchEvent(new Event("blur"));
   }
 


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success and we are glad you're here.

This pull request (PR) template exists to help speed up the integration process.
The Design System team reviews and approves each PR before we merge it into the public
code base, so please provide as much detail as possible to help us understand your changes.
On other words: we love clear explanations!
-->

<!---
Step 1 - Title this PR with the following format:
NYSDS - [Component]: [Brief statement describing what this pull request solves]
eg: "NYSDS - Button: Update hover states"
-->

# Summary

Implement elementInternal on `nys-select` to replace the old form controller branch code. The purpose of this is to allow custom components to interact with native form and submissions' 

<!--
A good summary is written in the past tense and includes:
- What was changed
- Why it was changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to the JavaScript API of a component
  - Changes to the HTML/markup required for a component
  - Major design changes or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

See ticket https://github.com/ITS-HCD/nysds/issues/311 🎟️

## Major changes

_For complex or multi-part PRs, list significant changes made:_

- **Modified components**: select implements elementInternal

## Testing and review
Testing environment: https://github.com/ITS-HCD/nysds-vanilla-webcomponents-demo

### Browser testing

_Indicate whether you have tested your changes in multiple browsers (e.g., Chrome, Firefox, Safari)._  
Tested on:

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge/IE

### Accessibility testing

_Indicate the accessibility checks you have completed:_

- [x] Screen reader testing
- [x] Keyboard navigation testing
- [ ] Color contrast checks
- [ ] Other: _[describe]_

