### PR TITLE
Feature: form radio internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5113,7 +5113,8 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -40,7 +40,7 @@ Set the `size` prop of the **`nys-radiogroup`** to have all **`nys-radiobutton`*
 Note: in order to display an error message, you must pass in `showError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysRadiobuttonStories.ErrorMessage} />
 #### Slots
-When the description requires more complexity than a simple `string` value, use the slot `description` to hold the text. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`\
+When the description requires more complexity than a simple `string` value, use the `slot="description"` to hold the text. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`\
 Note: Both `nys-radiobutton` and `nys-radiogroup` support the description slot.
 <Canvas of={NysRadiobuttonStories.Slot} />
 

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -505,7 +505,7 @@ export const Slot: Story = {
         .disabled=${args.disabled}
         .value=${"manhattan"}
       >
-        <label slot="description">
+        <label>
           New York City
           <a href="https://www.ny.gov/" target="__blank">(slot)</a></label
         >
@@ -533,10 +533,7 @@ export const Slot: Story = {
     label="Manhattan"
     value="manhattan"
   >
-    <label slot="description"> 
-      New York City
-      <a href="https://www.ny.gov/" target="__blank">(slot)</a></label
-    >      
+    <label> New York City <a href="https://www.ny.gov/" target="__blank">(slot)</a></label>      
   </nys-radiobutton>
 </nys-radiogroup>
 `.trim(),

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -35,10 +35,7 @@ export class NysRadiobutton extends LitElement {
 
   public async getInputElement(): Promise<HTMLInputElement | null> {
     await this.updateComplete; // Wait for the component to finish rendering
-    console.log("inside radiobutton getInputElement~~!");
-    const wow = this.shadowRoot?.querySelector("input") || null;
-    console.log("wow: ", wow);
-    return wow;
+    return this.shadowRoot?.querySelector("input") || null;
   }
 
   static buttonGroup: Record<string, NysRadiobutton> = {};

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -168,7 +168,7 @@ export class NysRadiobutton extends LitElement {
           </div>
           <label for=${this.id} class="nys-radiobutton__description">
             ${this.description}
-            <slot name="description"></slot>
+            <slot></slot>
           </label>
         </div>`}
       </label>

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -33,9 +33,26 @@ export class NysRadiobutton extends LitElement {
       : "md";
   }
 
+  public async getInputElement(): Promise<HTMLInputElement | null> {
+    await this.updateComplete; // Wait for the component to finish rendering
+    console.log("inside radiobutton getInputElement~~!");
+    const wow = this.shadowRoot?.querySelector("input") || null;
+    console.log("wow: ", wow);
+    return wow;
+  }
+  
   static buttonGroup: Record<string, NysRadiobutton> = {};
 
   static styles = styles;
+  // private _internals: ElementInternals;
+  
+  /********************** Lifecycle updates **********************/
+  // static formAssociated = true; // allows use of elementInternals' API
+
+  // constructor() {
+  //   super();
+  //   this._internals = this.attachInternals();
+  // }
 
   // Generate a unique ID if one is not provided
   connectedCallback() {
@@ -55,9 +72,16 @@ export class NysRadiobutton extends LitElement {
   }
 
   updated(changedProperties: Map<string | number | symbol, unknown>) {
-    // Watch for changes to `checked` and ensure only one is selected per group
-    if (changedProperties.has("checked") && this.checked) {
-      if (NysRadiobutton.buttonGroup[this.name] !== this) {
+    // When "checked" changes, update the internals.
+    if (changedProperties.has("checked")) {
+      // if (this.checked) {
+      //   this._internals.setFormValue(this.value);
+      // } else {
+      //   this._internals.setFormValue(null);
+      // }
+
+      // Ensure only one radiobutton per group is checked.
+      if (this.checked && NysRadiobutton.buttonGroup[this.name] !== this) {
         if (NysRadiobutton.buttonGroup[this.name]) {
           NysRadiobutton.buttonGroup[this.name].checked = false;
           NysRadiobutton.buttonGroup[this.name].requestUpdate();
@@ -67,6 +91,28 @@ export class NysRadiobutton extends LitElement {
     }
   }
 
+  // firstUpdated() {
+  //   // This ensures our element always participates in the form
+  //   this._manageRequire();
+  // }
+
+  /********************** Form Integration **********************/
+  // private _manageRequire() {
+  //   const input = this.shadowRoot?.querySelector("input");
+  //   const message = "This field is required";
+  //   if (!input) return;
+
+  //   console.log("inside radiobutton REQUIRE")
+
+  //   if (this.required && this.checked) {
+  //     this._internals.ariaRequired = "true";
+  //     this._internals.setValidity({ valueMissing: true }, message, input);
+  //   } else {
+  //     this._internals.setValidity({});
+  //   }
+  // }
+
+  /******************** Event Handlers ********************/
   // Handle radiobutton change event & unselection of other options in group
   private _handleChange() {
     if (!this.checked) {

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -44,16 +44,8 @@ export class NysRadiobutton extends LitElement {
   static buttonGroup: Record<string, NysRadiobutton> = {};
 
   static styles = styles;
-  // private _internals: ElementInternals;
   
   /********************** Lifecycle updates **********************/
-  // static formAssociated = true; // allows use of elementInternals' API
-
-  // constructor() {
-  //   super();
-  //   this._internals = this.attachInternals();
-  // }
-
   // Generate a unique ID if one is not provided
   connectedCallback() {
     super.connectedCallback();
@@ -74,12 +66,6 @@ export class NysRadiobutton extends LitElement {
   updated(changedProperties: Map<string | number | symbol, unknown>) {
     // When "checked" changes, update the internals.
     if (changedProperties.has("checked")) {
-      // if (this.checked) {
-      //   this._internals.setFormValue(this.value);
-      // } else {
-      //   this._internals.setFormValue(null);
-      // }
-
       // Ensure only one radiobutton per group is checked.
       if (this.checked && NysRadiobutton.buttonGroup[this.name] !== this) {
         if (NysRadiobutton.buttonGroup[this.name]) {
@@ -90,27 +76,6 @@ export class NysRadiobutton extends LitElement {
       }
     }
   }
-
-  // firstUpdated() {
-  //   // This ensures our element always participates in the form
-  //   this._manageRequire();
-  // }
-
-  /********************** Form Integration **********************/
-  // private _manageRequire() {
-  //   const input = this.shadowRoot?.querySelector("input");
-  //   const message = "This field is required";
-  //   if (!input) return;
-
-  //   console.log("inside radiobutton REQUIRE")
-
-  //   if (this.required && this.checked) {
-  //     this._internals.ariaRequired = "true";
-  //     this._internals.setValidity({ valueMissing: true }, message, input);
-  //   } else {
-  //     this._internals.setValidity({});
-  //   }
-  // }
 
   /******************** Event Handlers ********************/
   // Handle radiobutton change event & unselection of other options in group

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -40,11 +40,11 @@ export class NysRadiobutton extends LitElement {
     console.log("wow: ", wow);
     return wow;
   }
-  
+
   static buttonGroup: Record<string, NysRadiobutton> = {};
 
   static styles = styles;
-  
+
   /********************** Lifecycle updates **********************/
   // Generate a unique ID if one is not provided
   connectedCallback() {

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -38,6 +38,11 @@ export class NysRadiobutton extends LitElement {
     return this.shadowRoot?.querySelector("input") || null;
   }
 
+  // This callback is automatically called when the parent form is reset.
+  public formResetUpdate() {
+    this.checked = false;
+  }
+
   static buttonGroup: Record<string, NysRadiobutton> = {};
 
   static styles = styles;

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -13,8 +13,7 @@ export class NysRadiogroup extends LitElement {
   @property({ type: String }) errorMessage = "";
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
-  // State for storing the selected name and value for form-controller use
-  @state() private selectedName: string | null = null;
+  // State for storing the selected value for form use
   @state() private selectedValue: string | null = null;
   private static readonly VALID_SIZES = ["sm", "md"] as const;
   private _size: (typeof NysRadiogroup.VALID_SIZES)[number] = "md";
@@ -35,6 +34,15 @@ export class NysRadiogroup extends LitElement {
   }
 
   static styles = styles;
+  private _internals: ElementInternals;
+
+  /********************** Lifecycle updates **********************/
+  static formAssociated = true; // allows use of elementInternals' API
+
+  constructor() {
+    super();
+    this._internals = this.attachInternals();
+  }
 
   // Generate a unique ID if one is not provided
   connectedCallback() {
@@ -43,30 +51,70 @@ export class NysRadiogroup extends LitElement {
       this.id = `nys-radiogroup-${Date.now()}-${radiogroupIdCounter++}`;
     }
     this.addEventListener("change", this._handleRadioButtonChange);
+    this.addEventListener("invalid", this._handleInvalid);
+
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener("change", this._handleRadioButtonChange);
+    this.removeEventListener("invalid", this._handleInvalid);
+  }
+
+  firstUpdated() {
+    const slot = this.shadowRoot?.querySelector("slot");
+    slot?.addEventListener("slotchange", () => {
+      this._manageRequire();
+    });
+    // Optionally, call _manageRequire() here as well, but it may be too early.
+    this._manageRequire();
+    // This ensures our element always participates in the form
+    this._setValue();
+    this.setRadioButtonRequire();
   }
 
   updated(changedProperties: Map<string | symbol, unknown>) {
-    if (changedProperties.has("required")) {
-      this.updateRadioButtonsRequire();
+    if (changedProperties.has("required") || changedProperties.has("selectedValue")) {
+      console.log('we are updating require')
+      this._manageRequire();
     }
     if (changedProperties.has("size")) {
+      console.log('inside changed, required')
+
       this.updateRadioButtonsSize();
     }
   }
 
+  /********************** Form Integration **********************/
+  private _setValue() {
+    this._internals.setFormValue(this.selectedValue);
+  }
+
   // Updates the "require" attribute of a radiobutton underneath a radiogroup to ensure requirement for all radiobutton under the same name/group
-  private updateRadioButtonsRequire() {
+  private setRadioButtonRequire() {
     const radioButtons = this.querySelectorAll("nys-radiobutton");
     radioButtons.forEach((radioButton, index) => {
       if (this.required && index === 0) {
         radioButton.setAttribute("required", "required");
       }
     });
+  }
+
+  private async _manageRequire() {
+    const message = this.errorMessage || "This field is required";
+
+    const firstRadio = this.querySelector("nys-radiobutton");
+    const firstRadioInput = firstRadio ? await (firstRadio as any).getInputElement() : null;
+
+    console.log("this is first radio", firstRadioInput)
+    if (this.required && !this.selectedValue) {
+      console.log('win in')
+      this._internals.setValidity({ valueMissing: true }, message, firstRadioInput ? firstRadioInput : this);
+    } else {
+      console.log('win in2')
+      this._internals.setValidity({});
+    }
+
   }
 
   // Updates the size of each radiobutton underneath a radiogroup to ensure size standardization
@@ -80,11 +128,23 @@ export class NysRadiogroup extends LitElement {
   // Keeps radiogroup informed of the name and value of its current selected radiobutton
   private _handleRadioButtonChange(event: Event) {
     const customEvent = event as CustomEvent;
-    const { name, value } = customEvent.detail;
+    const { value } = customEvent.detail;
 
-    this.selectedName = name;
     this.selectedValue = value;
-    console.log("you have selected:", this.selectedName, this.selectedValue);
+    this._internals.setFormValue(this.selectedValue);
+  }
+
+  private _handleInvalid() {
+    // event.preventDefault(); // Prevent default form validation messages
+    console.log("Form validation failed for radio group");
+    console.log(this._internals.validity.valueMissing);
+    console.log(this._internals.validity);
+    console.log(this._internals.validity.customError);
+  
+    // Check if the radio group is invalid and set `showError` accordingly
+    if (this._internals.validity.valueMissing) {
+      this.showError = true;
+    }
   }
 
   render() {
@@ -107,10 +167,10 @@ export class NysRadiogroup extends LitElement {
       <div class="nys-radiogroup__content">
         <slot></slot>
       </div>
-      ${this.showError && this.errorMessage
+      ${this.showError
         ? html`<div class="nys-radiobutton__error">
             <nys-icon name="error" size="xl"></nys-icon>
-            ${this.errorMessage}
+            ${this._internals.validationMessage || this.errorMessage}
           </div>`
         : ""}
     </div>`;

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -52,7 +52,6 @@ export class NysRadiogroup extends LitElement {
     }
     this.addEventListener("change", this._handleRadioButtonChange);
     this.addEventListener("invalid", this._handleInvalid);
-
   }
 
   disconnectedCallback() {
@@ -70,7 +69,10 @@ export class NysRadiogroup extends LitElement {
   }
 
   updated(changedProperties: Map<string | symbol, unknown>) {
-    if (changedProperties.has("required") || changedProperties.has("selectedValue")) {
+    if (
+      changedProperties.has("required") ||
+      changedProperties.has("selectedValue")
+    ) {
       this._manageRequire();
     }
     if (changedProperties.has("size")) {
@@ -97,10 +99,16 @@ export class NysRadiogroup extends LitElement {
     const message = this.errorMessage || "This field is required";
 
     const firstRadio = this.querySelector("nys-radiobutton");
-    const firstRadioInput = firstRadio ? await (firstRadio as any).getInputElement() : null;
+    const firstRadioInput = firstRadio
+      ? await (firstRadio as any).getInputElement()
+      : null;
 
     if (this.required && !this.selectedValue) {
-      this._internals.setValidity({ valueMissing: true }, message, firstRadioInput ? firstRadioInput : this);
+      this._internals.setValidity(
+        { valueMissing: true },
+        message,
+        firstRadioInput ? firstRadioInput : this,
+      );
     } else {
       this._internals.setValidity({});
       this.showError = false;

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -62,12 +62,8 @@ export class NysRadiogroup extends LitElement {
   }
 
   firstUpdated() {
-    const slot = this.shadowRoot?.querySelector("slot");
-    slot?.addEventListener("slotchange", () => {
-      this._manageRequire();
-    });
-    // Optionally, call _manageRequire() here as well, but it may be too early.
-    this._manageRequire();
+    // Ensure checked state is respected
+    this._initializeCheckedState();
     // This ensures our element always participates in the form
     this._setValue();
     this.setRadioButtonRequire();
@@ -75,12 +71,9 @@ export class NysRadiogroup extends LitElement {
 
   updated(changedProperties: Map<string | symbol, unknown>) {
     if (changedProperties.has("required") || changedProperties.has("selectedValue")) {
-      console.log('we are updating require')
       this._manageRequire();
     }
     if (changedProperties.has("size")) {
-      console.log('inside changed, required')
-
       this.updateRadioButtonsSize();
     }
   }
@@ -106,15 +99,20 @@ export class NysRadiogroup extends LitElement {
     const firstRadio = this.querySelector("nys-radiobutton");
     const firstRadioInput = firstRadio ? await (firstRadio as any).getInputElement() : null;
 
-    console.log("this is first radio", firstRadioInput)
     if (this.required && !this.selectedValue) {
-      console.log('win in')
       this._internals.setValidity({ valueMissing: true }, message, firstRadioInput ? firstRadioInput : this);
     } else {
-      console.log('win in2')
       this._internals.setValidity({});
+      this.showError = false;
     }
+  }
 
+  private _initializeCheckedState() {
+    const checkedRadio = this.querySelector("nys-radiobutton[checked]");
+    if (checkedRadio) {
+      this.selectedValue = checkedRadio.getAttribute("value");
+      this._internals.setFormValue(this.selectedValue);
+    }
   }
 
   // Updates the size of each radiobutton underneath a radiogroup to ensure size standardization
@@ -135,12 +133,6 @@ export class NysRadiogroup extends LitElement {
   }
 
   private _handleInvalid() {
-    // event.preventDefault(); // Prevent default form validation messages
-    console.log("Form validation failed for radio group");
-    console.log(this._internals.validity.valueMissing);
-    console.log(this._internals.validity);
-    console.log(this._internals.validity.customError);
-  
     // Check if the radio group is invalid and set `showError` accordingly
     if (this._internals.validity.valueMissing) {
       this.showError = true;

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -80,6 +80,14 @@ export class NysRadiogroup extends LitElement {
     }
   }
 
+  // This callback is automatically called when the parent form is reset.
+  formResetCallback() {
+    const radioButtons = this.querySelectorAll("nys-radiobutton");
+    radioButtons.forEach((radioButton) => {
+      (radioButton as any).formResetUpdate();
+    });
+  }
+
   /********************** Form Integration **********************/
   private _setValue() {
     this._internals.setFormValue(this.selectedValue);


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success and we are glad you're here.

This pull request (PR) template exists to help speed up the integration process.
The Design System team reviews and approves each PR before we merge it into the public
code base, so please provide as much detail as possible to help us understand your changes.
On other words: we love clear explanations!
-->

<!---
Step 1 - Title this PR with the following format:
NYSDS - [Component]: [Brief statement describing what this pull request solves]
eg: "NYSDS - Button: Update hover states"
-->

# Summary

Implement elementInternal on `nys-radiogroup` and `nys-radiobutton` to replace the old form controller branch code. The purpose of this is to allow custom components to interact with native form and submissions' 

<!--
A good summary is written in the past tense and includes:
- What was changed
- Why it was changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to the JavaScript API of a component
  - Changes to the HTML/markup required for a component
  - Major design changes or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

See ticket https://github.com/ITS-HCD/nysds/issues/311 🎟️

## Major changes

- **Modified components**: `nys-radiogroup` and `nys-radiobutton` implements elementInternal

## Testing and review
Testing environment: https://github.com/ITS-HCD/nysds-vanilla-webcomponents-demo

### Browser testing

_Indicate whether you have tested your changes in multiple browsers (e.g., Chrome, Firefox, Safari)._  
Tested on:

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge/IE

### Accessibility testing

_Indicate the accessibility checks you have completed:_

- [x] Screen reader testing
- [x] Keyboard navigation testing
- [ ] Color contrast checks
- [ ] Other: _[describe]_

