### PR TITLE
Fix: globalfooter/header link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3940,7 +3940,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",

--- a/packages/nys-globalfooter/src/nys-globalfooter.mdx
+++ b/packages/nys-globalfooter/src/nys-globalfooter.mdx
@@ -21,7 +21,7 @@ The **`nys-globalfooter`** component is a reusable web component for use in New 
 
 ## Variants
 ## Without Links
-Use the prop `homepageLink` to link your `agencyName` to your homepage. If `homepageLink` is not provided, default fallback is [window.location.origin](https://developer.mozilla.org/en-US/docs/Web/API/Location/origin) otherwise (use `disableHomepageLink` to disable this).
+Use the prop `homepageLink` to link your `agencyName` to your homepage.
 <Canvas of={NysGlobalFooterStories.WithoutMenuLinks} />
 
 ## With Links

--- a/packages/nys-globalfooter/src/nys-globalfooter.stories.ts
+++ b/packages/nys-globalfooter/src/nys-globalfooter.stories.ts
@@ -6,7 +6,6 @@ import "./nys-globalfooter";
 interface NysGlobalFooterArgs {
   agencyName: string;
   homepageLink: string;
-  disableHomepageLink: boolean;
 }
 
 const meta: Meta<NysGlobalFooterArgs> = {
@@ -15,7 +14,6 @@ const meta: Meta<NysGlobalFooterArgs> = {
   argTypes: {
     agencyName: { control: "text" },
     homepageLink: { control: "text" },
-    disableHomepageLink: { control: "boolean" },
   },
   parameters: {
     docs: {
@@ -40,7 +38,6 @@ export const Basic: Story = {
     <nys-globalfooter
       .agencyName=${args.agencyName}
       .homepageLink=${args.homepageLink}
-      ?disableHomepageLink=${args.disableHomepageLink}
     >
       <ul>
         <li><a href="https://its.ny.gov">ITS Home</a></li>
@@ -75,7 +72,6 @@ export const WithoutMenuLinks: Story = {
     <nys-globalfooter
       .agencyName=${args.agencyName}
       .homepageLink=${args.homepageLink}
-      ?disableHomepageLink=${args.disableHomepageLink}
     ></nys-globalfooter>
   `,
   parameters: {
@@ -100,7 +96,6 @@ export const WithMenuLinks: Story = {
     <nys-globalfooter
       .agencyName=${args.agencyName}
       .homepageLink=${args.homepageLink}
-      ?disableHomepageLink=${args.disableHomepageLink}
     >
       <ul>
         <li><a href="https://its.ny.gov">ITS Home</a></li>

--- a/packages/nys-globalfooter/src/nys-globalfooter.ts
+++ b/packages/nys-globalfooter/src/nys-globalfooter.ts
@@ -73,9 +73,7 @@ export class NysGlobalFooter extends LitElement {
         <div class="nys-globalfooter__main-container">
           ${!this.homepageLink?.trim()
             ? html`<p class="nys-globalfooter__name">${this.agencyName}</p>`
-            : html`<a
-                href=${this.homepageLink?.trim()}
-              >
+            : html`<a href=${this.homepageLink?.trim()}>
                 <p class="nys-globalfooter__name">${this.agencyName}</p>
               </a>`}
           ${this.slotHasContent

--- a/packages/nys-globalfooter/src/nys-globalfooter.ts
+++ b/packages/nys-globalfooter/src/nys-globalfooter.ts
@@ -7,8 +7,7 @@ export class NysGlobalFooter extends LitElement {
 
   /********************** Properties **********************/
   @property({ type: String }) agencyName = "";
-  @property({ type: String }) homepageLink = window.location.origin;
-  @property({ type: Boolean }) disableHomepageLink = false;
+  @property({ type: String }) homepageLink = "";
   @state() private slotHasContent = true;
 
   /**************** Lifecycle Methods ****************/
@@ -72,10 +71,10 @@ export class NysGlobalFooter extends LitElement {
     return html`
       <footer class="nys-globalfooter">
         <div class="nys-globalfooter__main-container">
-          ${this.disableHomepageLink
+          ${!this.homepageLink?.trim()
             ? html`<p class="nys-globalfooter__name">${this.agencyName}</p>`
             : html`<a
-                href=${this.homepageLink?.trim() || window.location.origin}
+                href=${this.homepageLink?.trim()}
               >
                 <p class="nys-globalfooter__name">${this.agencyName}</p>
               </a>`}

--- a/packages/nys-globalheader/src/nys-globalheader.stories.ts
+++ b/packages/nys-globalheader/src/nys-globalheader.stories.ts
@@ -7,7 +7,6 @@ interface NysGlobalHeaderArgs {
   appName: string;
   agencyName: string;
   homepageLink: string;
-  disableHomepageLink: boolean;
 }
 
 const meta: Meta<NysGlobalHeaderArgs> = {
@@ -17,7 +16,6 @@ const meta: Meta<NysGlobalHeaderArgs> = {
     appName: { control: "text" },
     agencyName: { control: "text" },
     homepageLink: { control: "text" },
-    disableHomepageLink: { control: "boolean" },
   },
   parameters: {
     docs: {
@@ -44,7 +42,6 @@ export const Basic: Story = {
       .agencyName=${args.agencyName}
       .appName=${args.appName}
       .homepageLink=${args.homepageLink}
-      ?disableHomepageLink=${args.disableHomepageLink}
     >
     </nys-globalheader>
   `,
@@ -72,7 +69,6 @@ export const OnlyAgencyName: Story = {
       .agencyName=${args.agencyName}
       .appName=${args.appName}
       .homepageLink=${args.homepageLink}
-      ?disableHomepageLink=${args.disableHomepageLink}
     >
     </nys-globalheader>
   `,
@@ -99,7 +95,6 @@ export const OnlyAppName: Story = {
       .agencyName=${args.agencyName}
       .appName=${args.appName}
       .homepageLink=${args.homepageLink}
-      ?disableHomepageLink=${args.disableHomepageLink}
     >
     </nys-globalheader>
   `,
@@ -127,7 +122,6 @@ export const WithBothNames: Story = {
       .agencyName=${args.agencyName}
       .appName=${args.appName}
       .homepageLink=${args.homepageLink}
-      ?disableHomepageLink=${args.disableHomepageLink}
     >
     </nys-globalheader>
   `,
@@ -154,7 +148,6 @@ export const WithLinks: Story = {
       .agencyName=${args.agencyName}
       .appName=${args.appName}
       .homepageLink=${args.homepageLink}
-      ?disableHomepageLink=${args.disableHomepageLink}
     >
       <ul>
         <li><a href="https://its.ny.gov/services">Services</a></li>

--- a/packages/nys-globalheader/src/nys-globalheader.ts
+++ b/packages/nys-globalheader/src/nys-globalheader.ts
@@ -10,7 +10,6 @@ export class NysGlobalHeader extends LitElement {
   @property({ type: String }) appName = "";
   @property({ type: String }) agencyName = "";
   @property({ type: String }) homepageLink = "";
-  @property({ type: Boolean }) disableHomepageLink = false;
   @state() private slotHasContent = true;
   @state() private isMobileMenuOpen = false;
 
@@ -96,7 +95,7 @@ export class NysGlobalHeader extends LitElement {
                 </button>
               </div>`
             : ""}
-          ${this.disableHomepageLink || !this.homepageLink
+          ${!this.homepageLink?.trim()
             ? html`
                 <div class="nys-globalheader__name-container">
                   ${this.appName?.trim().length > 0

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -116,7 +116,8 @@ export class NysTextinput extends LitElement {
     if (!input) return;
 
     const message = this.errorMessage || "This field is required";
-    const isInvalid = this.required && (!this.value || this.value.trim() === ""); // Check for blank as well
+    const isInvalid =
+      this.required && (!this.value || this.value.trim() === ""); // Check for blank as well
 
     if (isInvalid) {
       this._internals.ariaRequired = "true";


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success and we are glad you're here.

This pull request (PR) template exists to help speed up the integration process.
The Design System team reviews and approves each PR before we merge it into the public
code base, so please provide as much detail as possible to help us understand your changes.
On other words: we love clear explanations!
-->

<!---
Step 1 - Title this PR with the following format:
NYSDS - [Component]: [Brief statement describing what this pull request solves]
eg: "NYSDS - Button: Update hover states"
-->

# Summary

Removed default linking from [window.location.origin](https://developer.mozilla.org/en-US/docs/Web/API/Location/origin) to no link on the global footer's agency name.

Revise global header storybook

<!--
A good summary is written in the past tense and includes:
- What was changed
- Why it was changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to the JavaScript API of a component
  - Changes to the HTML/markup required for a component
  - Major design changes or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->