### PR TITLE
Fix/description slot

### DIFF
--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -145,7 +145,7 @@ export class NysCheckboxgroup extends LitElement {
         description=${this.description}
         flag=${this.required ? "required" : ""}
       >
-        <slot name="description" slot="description"></slot>
+        <slot name="description" slot="description">${this.description}</slot>
       </nys-label>
       <div class="nys-checkboxgroup__content">
         <slot></slot>

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -144,7 +144,9 @@ export class NysCheckboxgroup extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : ""}
-      ></nys-label>
+      >
+        <slot name="description" slot="description"></slot>
+      </nys-label>
       <div class="nys-checkboxgroup__content">
         <slot></slot>
       </div>

--- a/packages/nys-label/src/nys-label.mdx
+++ b/packages/nys-label/src/nys-label.mdx
@@ -29,6 +29,7 @@ The **`nys-label`** is a reusable web component for use in New York State digita
 
 #### Description
 <Canvas of={NysLabelStories.Description} />
+<Canvas of={NysLabelStories.DescriptionSlot} />
 #### Required
 <Canvas of={NysLabelStories.Required} />
 #### Optional

--- a/packages/nys-label/src/nys-label.stories.ts
+++ b/packages/nys-label/src/nys-label.stories.ts
@@ -92,11 +92,11 @@ export const DescriptionSlot: Story = {
   },
   render: (args) =>
     html`<nys-label label=${args.label} flag=${args.flag}>
-      <span slot="description"
+      <label slot="description"
         >${args.description}
         <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a"
           >You can embed links</a
-        ></span
+        ></label
       >
     </nys-label>`,
   parameters: {
@@ -104,7 +104,7 @@ export const DescriptionSlot: Story = {
       source: {
         code: `
 <nys-label label="This is a basic nys-label">
-  <span slot="description">This is a slot description</span>    
+  <label slot="description">This is a slot description</label>    
 </nys-label>`,
         type: "auto",
       },

--- a/packages/nys-label/src/nys-label.stories.ts
+++ b/packages/nys-label/src/nys-label.stories.ts
@@ -84,6 +84,34 @@ export const Description: Story = {
   },
 };
 
+export const DescriptionSlot: Story = {
+  args: {
+    label: "This is a basic nys-label",
+    description: "This is a slot description",
+    flag: null,
+  },
+  render: (args) =>
+    html`<nys-label label=${args.label} flag=${args.flag}>
+      <span slot="description"
+        >${args.description}
+        <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a"
+          >You can embed links</a
+        ></span
+      >
+    </nys-label>`,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-label label="This is a basic nys-label">
+  <span slot="description">This is a slot description</span>    
+</nys-label>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
 export const Required: Story = {
   args: {
     label: "This form is required",

--- a/packages/nys-label/src/nys-label.ts
+++ b/packages/nys-label/src/nys-label.ts
@@ -23,7 +23,7 @@ export class NysLabel extends LitElement {
             : ""}</label
         >
         <label for=${this.id} class="nys-label__description">
-          ${this.description}
+          <slot name="description">${this.description}</slot>
         </label>
       </div>
     `;

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -169,7 +169,8 @@ export class NysRadiogroup extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : ""}
-      ></nys-label>
+        ><slot name="description" slot="description"></slot>
+      </nys-label>
       <div class="nys-radiogroup__content">
         <slot></slot>
       </div>

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -169,7 +169,8 @@ export class NysRadiogroup extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : ""}
-        ><slot name="description" slot="description"></slot>
+      >
+        <slot name="description" slot="description">${this.description}</slot>
       </nys-label>
       <div class="nys-radiogroup__content">
         <slot></slot>

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -224,7 +224,8 @@ export class NysSelect extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : ""}
-        ></nys-label>
+          ><slot name="description" slot="description"></slot>
+        </nys-label>
         <div class="nys-select__selectwrapper">
           <select
             class="nys-select__select"

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -224,7 +224,8 @@ export class NysSelect extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : ""}
-          ><slot name="description" slot="description"></slot>
+        >
+          <slot name="description" slot="description">${this.description}</slot>
         </nys-label>
         <div class="nys-select__selectwrapper">
           <select

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -237,7 +237,7 @@ export const DescriptionSlot: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
-      <p>Slot: ${args.description}</p>
+      <label slot="description">Slot: ${args.description}</label>
     </nys-textarea>
   `,
   parameters: {
@@ -246,7 +246,7 @@ export const DescriptionSlot: Story = {
         code: `
 <nys-textarea label="Label" description="Prop: description"></nys-textarea>
 <nys-textarea label="Label">
-  <p> Slot: description</p>
+  <label slot="description">Slot: description</label>
 </nys-textarea>
         `,
         type: "auto",

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -226,7 +226,8 @@ export class NysTextarea extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : ""}
-        ></nys-label>
+          ><slot name="description" slot="description"></slot>
+        </nys-label>
         <textarea
           class="nys-textarea__textarea ${this.resize}"
           name=${this.name}

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -226,7 +226,8 @@ export class NysTextarea extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : ""}
-          ><slot name="description" slot="description"></slot>
+        >
+          <slot name="description" slot="description">${this.description}</slot>
         </nys-label>
         <textarea
           class="nys-textarea__textarea ${this.resize}"

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -582,7 +582,7 @@ export const DescriptionSlot: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
-      <p>Slot: description</p>
+      <label slot="description">Slot: description</label>
     </nys-textinput>
   `,
   parameters: {
@@ -595,7 +595,7 @@ export const DescriptionSlot: Story = {
   description="Slot: description"
 ></nys-textinput>
 <nys-textinput name="descriptionSlot" label="Label">
-  <p>Slot: description</p>
+  <label slot="description">Slot: description</label>
 </nys-textinput>`,
         type: "auto",
       },

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -235,7 +235,8 @@ export class NysTextinput extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : ""}
-        ></nys-label>
+          ><slot name="description" slot="description"></slot>
+        </nys-label>
         <input
           class="nys-textinput__input"
           type=${this.type}

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -235,7 +235,8 @@ export class NysTextinput extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : ""}
-          ><slot name="description" slot="description"></slot>
+        >
+          <slot name="description" slot="description">${this.description}</slot>
         </nys-label>
         <input
           class="nys-textinput__input"


### PR DESCRIPTION
# Summary

Allow the description to be added to the label as a slot rather than a prop to allow for rich text and links. The feature was originally lost when replacing the labels with a component.

This is **not** a breaking change.  
