### PR TITLE
Fix/optional flag

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.mdx
+++ b/packages/nys-checkbox/src/nys-checkbox.mdx
@@ -36,6 +36,9 @@ Set the `size` prop of the **`nys-checkboxgroup`** to have all **`nys-checkbox`*
 <Canvas of={NysCheckboxStories.Size} />
 #### Required
 <Canvas of={NysCheckboxStories.Required} />
+#### Optional
+Adding the `optional` prop will add an optional flag to the input.
+<Canvas of={NysCheckboxStories.Optional} />
 #### Error Message
 The error message will appear **ONLY** when the `showError` attribute is set to `true`. Setting `errorMessage` will not display the error message by default.
 <Canvas of={NysCheckboxStories.ErrorMessage} />

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -13,6 +13,7 @@ interface NysCheckboxArgs {
   disabled: boolean;
   value: string;
   required: boolean;
+  optional: boolean;
   showError: boolean;
   errorMessage: string;
 }
@@ -29,6 +30,7 @@ const meta: Meta<NysCheckboxArgs> = {
     size: { control: "select", options: ["sm", "md"] },
     disabled: { control: "boolean" },
     required: { control: "boolean" },
+    optional: { control: "boolean" },
     value: { control: "text" },
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
@@ -71,6 +73,7 @@ export const Basic: Story = {
         .checked=${args.checked}
         .disabled=${args.disabled}
         .required=${args.required}
+        .optional=${args.optional}
         .label=${args.label}
         .description=${args.description}
         .name=${args.name}
@@ -154,6 +157,7 @@ export const Grouping: Story = {
         .showError=${args.showError}
         .errorMessage=${args.errorMessage}
         .required=${args.required}
+        .optional=${args.optional}
       >
         <nys-checkbox
           name="benefits"
@@ -270,6 +274,7 @@ export const Disabled: Story = {
       .checked=${args.checked}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .label=${args.label}
       .description=${args.description}
       .name=${args.name}
@@ -281,6 +286,7 @@ export const Disabled: Story = {
       checked
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .label=${args.label}
       .description=${args.description}
       .name=${args.name}
@@ -335,6 +341,7 @@ export const Size: Story = {
         .checked=${args.checked}
         .disabled=${args.disabled}
         .required=${args.required}
+        .optional=${args.optional}
         .label=${args.label}
         .description=${args.description}
         .name=${args.name}
@@ -419,6 +426,7 @@ export const Required: Story = {
       .checked=${args.checked}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .label=${args.label}
       .description=${args.description}
       .id=${args.id}
@@ -465,6 +473,7 @@ export const ErrorMessage: Story = {
       .checked=${args.checked}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .label=${args.label}
       .description=${args.description}
       .id=${args.id}
@@ -512,6 +521,7 @@ export const Slot: Story = {
       .checked=${args.checked}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .label=${args.label}
       .id=${args.id}
       .name=${args.name}

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -553,3 +553,98 @@ export const Slot: Story = {
     },
   },
 };
+
+export const Optional: Story = {
+  args: {
+    checked: true,
+    disabled: false,
+    label: "Adirondacks",
+    description: "",
+    name: "landmarks",
+    value: "adirondacks",
+    showError: false,
+    errorMessage: "",
+    optional: true,
+  },
+
+  render: (args) => html`
+    <nys-checkboxgroup
+      label="Select your favorite New York landmarks"
+      description="Choose from the options below"
+      size=${args.size}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+      .required=${args.required}
+      .optional=${args.optional}
+    >
+      <nys-checkbox
+        .checked=${args.checked}
+        .disabled=${args.disabled}
+        .label=${args.label}
+        .description=${args.description}
+        .name=${args.name}
+        .value=${args.value}
+      ></nys-checkbox>
+      <nys-checkbox
+        name="landmarks"
+        value="finger-lakes"
+        label="Finger Lakes"
+        checked
+      ></nys-checkbox>
+      <nys-checkbox
+        name="landmarks"
+        value="catskills"
+        label="Catskills"
+        checked
+      ></nys-checkbox>
+      <nys-checkbox
+        name="landmarks"
+        value="niagara-falls"
+        label="Niagara Falls"
+        checked
+      ></nys-checkbox>
+      <nys-checkbox
+        name="landmarks"
+        value="coney-island"
+        label="Coney Island"
+      ></nys-checkbox>
+      <nys-checkbox
+        name="landmarks"
+        value="mount-greylock"
+        label="Mount Greylock"
+        description="This is disabled because it's not in New York."
+        disabled
+      ></nys-checkbox>
+    </nys-checkboxgroup>
+  `,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-checkboxgroup
+  label="Select your favorite New York landmarks"
+  description="Choose from the options below"
+  optional
+>
+  <nys-checkbox
+    label="Adirondacks"
+    name="landmarks"
+    value="adirondacks"
+    errorMessage="You must select this box to continue"
+    checked
+  ></nys-checkbox>
+  <nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="catskills" label="Catskills" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="niagara-falls" label="Niagara Falls" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="coney-island" label="Coney Island"></nys-checkbox>
+  <nys-checkbox label="Mount Greylock" description="This is disabled because it's not in New York." disabled></nys-checkbox>
+</nys-checkboxgroup>
+
+        `,
+
+        type: "auto",
+      },
+    },
+  },
+};

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -10,6 +10,7 @@ export class NysCheckboxgroup extends LitElement {
   @property({ type: String }) id = "";
   @property({ type: String }) name = "";
   @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
   @property({ type: String }) label = "";
@@ -143,7 +144,7 @@ export class NysCheckboxgroup extends LitElement {
       <nys-label
         label=${this.label}
         description=${this.description}
-        flag=${this.required ? "required" : ""}
+        flag=${this.required ? "required" : this.optional ? "optional" : ""}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -31,6 +31,9 @@ The **`nys-radiobutton`** component is a reusable web component for use in New Y
 <Canvas of={NysRadiobuttonStories.DisabledOptions} />
 #### Required
 <Canvas of={NysRadiobuttonStories.Required} />
+#### Optional
+Adding the `optional` prop will add an optional flag to the input.
+<Canvas of={NysRadiobuttonStories.Optional} />
 #### Size
 Set the `size` prop of the **`nys-radiogroup`** to have all **`nys-radiobutton`** be the same size. Our current sizes are:
 - `sm`: Set to 24px in width and height

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -14,8 +14,8 @@ interface NysRadiobuttonArgs {
   disabled: boolean;
   value: string;
   form: string;
-  //radiogroup - not including id, name, label, description
   required: boolean;
+  optional: boolean;
   showError: boolean;
   errorMessage: string;
 }
@@ -34,6 +34,7 @@ const meta: Meta<NysRadiobuttonArgs> = {
     value: { control: "text" },
     form: { control: "text" },
     required: { control: "boolean" },
+    optional: { control: "boolean" },
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
   },
@@ -66,6 +67,7 @@ export const Basic: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .required=${args.required}
+      .optional=${args.optional}
     >
       <nys-radiobutton
         .name=${args.name}
@@ -277,6 +279,7 @@ export const Required: Story = {
       description="This is the location you use for your in office days."
       size=${args.size}
       .required=${args.required}
+      .optional=${args.optional}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -344,6 +347,7 @@ export const Size: Story = {
       description="This is the agency, department, or office you work for."
       size=${args.size}
       .required=${args.required}
+      .optional=${args.optional}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -418,6 +422,7 @@ export const ErrorMessage: Story = {
       description="This is the location you use for your in office days."
       size=${args.size}
       .required=${args.required}
+      .optional=${args.optional}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -548,3 +548,71 @@ export const Slot: Story = {
     },
   },
 };
+
+export const Optional: Story = {
+  args: {
+    name: "office",
+    label: "Albany",
+    description: "Upstate New York",
+    value: "albany",
+    optional: true,
+  },
+
+  render: (args) => html`
+    <nys-radiogroup
+      label="What is your primary work location?"
+      description="This is the location you use for your in office days."
+      size=${args.size}
+      .required=${args.required}
+      .optional=${args.optional}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    >
+      <nys-radiobutton
+        .name=${args.name}
+        .checked=${args.checked}
+        .label=${args.label}
+        .description=${args.description}
+        .disabled=${args.disabled}
+        .value=${args.value}
+      ></nys-radiobutton>
+      <nys-radiobutton
+        .name=${args.name}
+        .checked=${false}
+        .label=${"Manhattan"}
+        .description=${"New York City"}
+        .disabled=${args.disabled}
+        .value=${"manhattan"}
+      ></nys-radiobutton>
+    </nys-radiogroup>
+  `,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-radiogroup 
+  label="What is your primary work location?"
+  description="This is the location you use for your in office days."
+  optional
+>
+  <nys-radiobutton
+    name="office"
+    label="Albany"
+    description="Upstate New York"
+    value="albany"
+  ></nys-radiobutton>
+  <nys-radiobutton
+    name="office"
+    label="Manhattan"
+    description="New York City"
+    value="manhattan"
+  ></nys-radiobutton>
+</nys-radiogroup>
+`.trim(),
+
+        type: "auto",
+      },
+    },
+  },
+};

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -10,6 +10,7 @@ export class NysRadiogroup extends LitElement {
   @property({ type: String }) id = "";
   @property({ type: String }) name = "";
   @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
   @property({ type: String }) label = "";
@@ -166,7 +167,7 @@ export class NysRadiogroup extends LitElement {
       <nys-label
         label=${this.label}
         description=${this.description}
-        flag=${this.required ? "required" : ""}
+        flag=${this.required ? "required" : this.optional ? "optional" : ""}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-select/src/nys-select.mdx
+++ b/packages/nys-select/src/nys-select.mdx
@@ -25,6 +25,9 @@ The `nys-option` can have the label set as either the label property or the inne
 <Canvas of={NysSelectStories.Disabled} />
 #### Required
 <Canvas of={NysSelectStories.Required} />
+#### Optional
+Adding the `optional` prop will add an optional flag to the input.
+<Canvas of={NysSelectStories.Optional} />
 #### Width
 The following width options are available:
 - `sm` (Small): 88px, ideal for compact layouts.

--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -11,6 +11,7 @@ interface NysSelectArgs {
   value: string;
   disabled: boolean;
   required: boolean;
+  optional: boolean;
   form: string;
   width: string;
   options: string;
@@ -29,6 +30,7 @@ const meta: Meta<NysSelectArgs> = {
     value: { control: "text" },
     disabled: { control: "boolean" },
     required: { control: "boolean" },
+    optional: { control: "boolean" },
     form: { control: "text" },
     width: { control: "select", options: ["sm", "md", "lg", "full"] },
     showError: { control: "boolean" },
@@ -61,6 +63,7 @@ export const Basic: Story = {
       .value=${args.value}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -113,6 +116,7 @@ export const OptionsLabelSlot: Story = {
       .value=${args.value}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -156,6 +160,7 @@ export const DescriptionSlot: Story = {
       .value=${args.value}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -202,6 +207,7 @@ export const Disabled: Story = {
       .value=${args.value}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -246,6 +252,7 @@ export const Required: Story = {
       .value=${args.value}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -291,6 +298,7 @@ export const Width: Story = {
       .value=${args.value}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -340,6 +348,7 @@ export const ErrorMessage: Story = {
       .value=${args.value}
       .disabled=${args.disabled}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}

--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -381,3 +381,51 @@ export const ErrorMessage: Story = {
     },
   },
 };
+
+export const Optional: Story = {
+  args: {
+    label: "Select your favorite borough",
+    value: "",
+    optional: true,
+  },
+
+  render: (args) => html`
+    <nys-select
+      .id=${args.id}
+      .name=${args.name}
+      .label=${args.label}
+      .description=${args.description}
+      .value=${args.value}
+      .disabled=${args.disabled}
+      .required=${args.required}
+      .optional=${args.optional}
+      .form=${args.form}
+      .width=${args.width}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    >
+      <nys-option value="bronx" label="The Bronx"></nys-option>
+      <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+      <nys-option value="manhattan" label="Manhattan"></nys-option>
+      <nys-option value="staten_island" label="Staten Island"></nys-option>
+      <nys-option value="queens" label="Queens"></nys-option>
+    </nys-select>
+  `,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-select label="Select your favorite borough" optional>
+  <nys-option value="bronx" label="The Bronx"></nys-option>
+  <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+  <nys-option value="manhattan" label="Manhattan"></nys-option>
+  <nys-option value="staten_island" label="Staten Island"></nys-option>
+  <nys-option value="queens" label="Queens"></nys-option>  
+</nys-select>`,
+
+        type: "auto",
+      },
+    },
+  },
+};

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -16,6 +16,7 @@ export class NysSelect extends LitElement {
   @property({ type: String }) value = "";
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String }) form = "";
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
@@ -221,7 +222,7 @@ export class NysSelect extends LitElement {
         <nys-label
           label=${this.label}
           description=${this.description}
-          flag=${this.required ? "required" : ""}
+          flag=${this.required ? "required" : this.optional ? "optional" : ""}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textarea/src/nys-textarea.mdx
+++ b/packages/nys-textarea/src/nys-textarea.mdx
@@ -47,6 +47,9 @@ You can supply a description via our `description` prop for plain text or by emb
 <Canvas of={NysTextareaStories.Maxlength} />
 #### Required
 <Canvas of={NysTextareaStories.Required} />
+#### Optional
+Adding the `optional` prop will add an optional flag to the input.
+<Canvas of={NysTextareaStories.Optional} />
 #### Error Message
 <Canvas of={NysTextareaStories.ErrorMessage} />
 

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -492,3 +492,41 @@ export const ErrorMessage: Story = {
     },
   },
 };
+
+export const Optional: Story = {
+  args: {
+    label: "Label",
+    value: "",
+    optional: true,
+  },
+
+  render: (args) =>
+    html` <nys-textarea
+      .id=${args.id}
+      .name=${args.name}
+      .label=${args.label}
+      .description=${args.description}
+      .placeholder=${args.placeholder}
+      .value=${args.value}
+      .disabled=${args.disabled}
+      .readonly=${args.readonly}
+      .required=${args.required}
+      .optional=${args.optional}
+      .form=${args.form}
+      .maxlength=${args.maxlength}
+      .width=${args.width}
+      .rows=${args.rows}
+      .resize=${args.resize}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    ></nys-textarea>`,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `<nys-textarea optional label="label"></nys-textarea>`,
+        type: "auto",
+      },
+    },
+  },
+};

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -13,6 +13,7 @@ interface NysTextareaArgs {
   disabled: boolean;
   readonly: boolean;
   required: boolean;
+  optional: boolean;
   form: string;
   maxlength: string;
   width: string;
@@ -35,6 +36,7 @@ const meta: Meta<NysTextareaArgs> = {
     disabled: { control: "boolean" },
     readonly: { control: "boolean" },
     required: { control: "boolean" },
+    optional: { control: "boolean" },
     form: { control: "text" },
     maxlength: { control: "text" },
     width: {
@@ -76,6 +78,7 @@ export const Basic: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -108,6 +111,7 @@ export const Width: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -142,6 +146,7 @@ export const Rows: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -179,6 +184,7 @@ export const Resize: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -211,6 +217,7 @@ export const DescriptionSlot: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -229,6 +236,7 @@ export const DescriptionSlot: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -272,6 +280,7 @@ export const ValueAndPlaceholder: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -309,6 +318,7 @@ export const Disabled: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -343,6 +353,7 @@ export const Readonly: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -382,6 +393,7 @@ export const Maxlength: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -420,6 +432,7 @@ export const Required: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -456,6 +469,7 @@ export const ErrorMessage: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -18,6 +18,7 @@ export class NysTextarea extends LitElement {
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) readonly = false;
   @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String }) form = "";
   @property({ type: Number }) maxlength = null;
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
@@ -223,7 +224,7 @@ export class NysTextarea extends LitElement {
         <nys-label
           label=${this.label}
           description=${this.description}
-          flag=${this.required ? "required" : ""}
+          flag=${this.required ? "required" : this.optional ? "optional" : ""}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -45,6 +45,9 @@ Note: Takes in valid regex
 <Canvas of={NysTextinputStories.Pattern} />
 #### Required
 <Canvas of={NysTextinputStories.Required} />
+#### Optional
+Adding the `optional` prop will add an optional flag to the input.
+<Canvas of={NysTextinputStories.Optional} />
 #### Description Slot
 You can supply a description via our `description` prop for plain text or by embedding HTML within our component via our slot for higher customization.
 <Canvas of={NysTextinputStories.DescriptionSlot} />

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -14,6 +14,7 @@ interface NysTextinputArgs {
   disabled: boolean;
   readonly: boolean;
   required: boolean;
+  optional: boolean;
   form: string;
   pattern: string;
   maxlength: string;
@@ -42,6 +43,7 @@ const meta: Meta<NysTextinputArgs> = {
     disabled: { control: "boolean" },
     readonly: { control: "boolean" },
     required: { control: "boolean" },
+    optional: { control: "boolean" },
     form: { control: "text" },
     pattern: { control: "text" },
     maxlength: { control: "text" },
@@ -87,6 +89,7 @@ export const Basic: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -127,6 +130,7 @@ export const Width: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -173,6 +177,7 @@ export const DifferentTypes: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -220,6 +225,7 @@ export const ValueAndPlaceholder: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -267,6 +273,7 @@ export const Disabled: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -309,6 +316,7 @@ export const Readonly: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -359,6 +367,7 @@ export const MaxMinAndStep: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -410,6 +419,7 @@ export const Maxlength: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -463,6 +473,7 @@ export const Pattern: Story = {
         .disabled=${args.disabled}
         .readonly=${args.readonly}
         .required=${args.required}
+        .optional=${args.optional}
         .form=${args.form}
         .pattern=${args.pattern}
         .maxlength=${args.maxlength}
@@ -512,6 +523,7 @@ export const Required: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -551,6 +563,7 @@ export const DescriptionSlot: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -572,6 +585,7 @@ export const DescriptionSlot: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -623,6 +637,7 @@ export const ErrorMessage: Story = {
       .disabled=${args.disabled}
       .readonly=${args.readonly}
       .required=${args.required}
+      .optional=${args.optional}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -664,3 +664,46 @@ export const ErrorMessage: Story = {
     },
   },
 };
+
+export const Optional: Story = {
+  args: {
+    name: "myTextInput7",
+    label: "label",
+    value: "",
+    optional: true,
+  },
+
+  render: (args) => html`
+    <nys-textinput
+      .id=${args.id}
+      .name=${args.name}
+      .type=${args.type}
+      .label=${args.label}
+      .description=${args.description}
+      .placeholder=${args.placeholder}
+      .value=${args.value}
+      .disabled=${args.disabled}
+      .readonly=${args.readonly}
+      .required=${args.required}
+      .optional=${args.optional}
+      .form=${args.form}
+      .pattern=${args.pattern}
+      .maxlength=${args.maxlength}
+      .width=${args.width}
+      .step=${args.step}
+      .min=${args.min}
+      .max=${args.max}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    ></nys-textinput>
+  `,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `<nys-textinput name="myTextInput7" optional label="label"></nys-textinput>`,
+        type: "auto",
+      },
+    },
+  },
+};

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -44,6 +44,7 @@ export class NysTextinput extends LitElement {
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) readonly = false;
   @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String }) form = "";
   @property({ type: String }) pattern = "";
   @property({ type: Number }) maxlength = null;
@@ -232,7 +233,7 @@ export class NysTextinput extends LitElement {
         <nys-label
           label=${this.label}
           description=${this.description}
-          flag=${this.required ? "required" : ""}
+          flag=${this.required ? "required" : this.optional ? "optional" : ""}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>


### PR DESCRIPTION
add the `optional` attribute to form components to allow the developer to visually indicate form components as unrequired to users
ie: 
![image](https://github.com/user-attachments/assets/fa09669b-a112-40a2-9197-097f4350dabb)
