### PR TITLE
Reflect "name" prop and fix showErrrrorr on radiogroup

### DIFF
--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -8,7 +8,7 @@ let buttonIdCounter = 0; // Counter for generating unique IDs
 
 export class NysButton extends LitElement {
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   // size
   private static readonly VALID_SIZES = ["sm", "md", "lg"] as const;
   private _size: (typeof NysButton.VALID_SIZES)[number] = "md";

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -14,7 +14,7 @@ export class NysCheckbox extends LitElement {
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   @property({ type: String }) value = "";
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -8,7 +8,7 @@ let checkboxgroupIdCounter = 0; // Counter for generating unique IDs
 
 export class NysCheckboxgroup extends LitElement {
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";

--- a/packages/nys-icon/src/nys-icon.ts
+++ b/packages/nys-icon/src/nys-icon.ts
@@ -4,7 +4,7 @@ import iconLibrary from "./nys-icon.library";
 import styles from "./nys-icon.styles";
 
 export class NysIcon extends LitElement {
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   @property({ type: String }) label = "";
   @property({ type: String }) rotate = "0";
   @property({ type: String }) flip = "";

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -13,7 +13,7 @@ export class NysRadiobutton extends LitElement {
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   @property({ type: String }) value = "";
   private static readonly VALID_SIZES = ["sm", "md"] as const;
   private _size: (typeof NysRadiobutton.VALID_SIZES)[number] = "md";

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -8,7 +8,7 @@ let radiogroupIdCounter = 0; // Counter for generating unique IDs
 
 export class NysRadiogroup extends LitElement {
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
@@ -119,6 +119,7 @@ export class NysRadiogroup extends LitElement {
         firstRadioInput || this,
       );
     } else {
+      this.showError = false;
       this._internals.setValidity({});
     }
   }

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -10,7 +10,7 @@ let selectIdCounter = 0; // Counter for generating unique IDs
 
 export class NysSelect extends LitElement {
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: String }) value = "";

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -10,7 +10,7 @@ let textareaIdCounter = 0; // Counter for generating unique IDs
 
 export class NysTextarea extends LitElement {
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: String }) placeholder = "";

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -10,7 +10,7 @@ let textinputIdCounter = 0; // Counter for generating unique IDs
 
 export class NysTextinput extends LitElement {
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   private static readonly VALID_TYPES = [
     "email",
     "number",

--- a/packages/nys-toggle/src/nys-toggle.ts
+++ b/packages/nys-toggle/src/nys-toggle.ts
@@ -11,7 +11,7 @@ export class NysToggle extends LitElement {
 
   /********************** Properties **********************/
   @property({ type: String }) id = "";
-  @property({ type: String }) name = "";
+  @property({ type: String, reflect: true }) name = "";
   @property({ type: String }) value = "";
   @property({ type: Boolean, reflect: true }) checked = false;
   @property({ type: Boolean, reflect: true }) disabled = false;


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success and we are glad you're here.

This pull request (PR) template exists to help speed up the integration process.
The Design System team reviews and approves each PR before we merge it into the public
code base, so please provide as much detail as possible to help us understand your changes.
On other words: we love clear explanations!
-->

<!---
Step 1 - Title this PR with the following format:
NYSDS - [Component]: [Brief statement describing what this pull request solves]
eg: "NYSDS - Button: Update hover states"
-->

# Summary

Reflect "name" prop on components and fix showError issue on `nys-radiogroup`

## Breaking change

This is **not** a breaking change.  

## Solution
This is to solve the issue of React demo not submitting the form.

## Feedback needed 
I remember Jesse in the prev weeks had pointed out what to reflect or not, so my question is should the "name" prop be reflected (even though it fixes the React form submission issue)?
https://lit.dev/docs/components/properties/#reflected-attributes
<img width="245" alt="Screenshot 2025-03-05 at 12 12 26 PM" src="https://github.com/user-attachments/assets/30aa0e02-85a9-4fb6-a8c1-49e46695a514" />


