### PR TITLE
Fix: nys-radiobutton and nys-checkbox slotted description

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -529,7 +529,7 @@ export const Slot: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
-      <label
+      <label slot="description"
         >${args.description}<a href="https://www.ny.gov/" target="__blank"
           >here</a
         ></label
@@ -546,7 +546,9 @@ export const Slot: Story = {
   name="subscribe"
   value="email-updates"
 >
-  <label Read about previous updates <a href="https://www.ny.gov/" target="__blank">here</a></label>
+  <label slot="description"> Read about previous updates 
+    <a href="https://www.ny.gov/" target="__blank">here</a>
+  </label>
 </nys-checkbox>
         `.trim(),
       },

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -225,8 +225,7 @@ export class NysCheckbox extends LitElement {
                 : ""}
             </div>
             <label for=${this.id} class="nys-checkbox__description">
-              ${this.description}
-              <slot></slot>
+              <slot name="description">${this.description}</slot>
             </label>
           </div>`}
         </label>

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -510,7 +510,7 @@ export const Slot: Story = {
         .disabled=${args.disabled}
         .value=${"manhattan"}
       >
-        <label>
+        <label slot="description">
           New York City
           <a href="https://www.ny.gov/" target="__blank">(slot)</a></label
         >

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -538,7 +538,7 @@ export const Slot: Story = {
     label="Manhattan"
     value="manhattan"
   >
-    <label> New York City <a href="https://www.ny.gov/" target="__blank">(slot)</a></label>      
+    <label slot="description"> New York City <a href="https://www.ny.gov/" target="__blank">(slot)</a></label>      
   </nys-radiobutton>
 </nys-radiogroup>
 `.trim(),

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -165,8 +165,7 @@ export class NysRadiobutton extends LitElement {
             >${this.label}</label
           >
           <label for=${this.id} class="nys-radiobutton__description">
-            ${this.description}
-            <slot></slot>
+            <slot name="description">${this.description}</slot>
           </label>
         </div>`}
       </label>


### PR DESCRIPTION
make sure slot is explicitly defined to `name="description`