### PR TITLE
Add password eye toggle

### DIFF
--- a/packages/nys-textinput/src/nys-textinput.styles.ts
+++ b/packages/nys-textinput/src/nys-textinput.styles.ts
@@ -11,6 +11,10 @@ export default css`
     --_nys-textinput-color-border: var(--nys-color-neutral-400, #909395);
     --_nys-textinput-padding: var(--nys-space-100, 8px);
     --_nys-textinput-gap: var(--nys-space-50, 4px);
+    --_nys-textinput-background-color: var(
+      --nys-color-ink-reverse,
+      var(--nys-color-white, #ffffff)
+    );
 
     /* Hovered */
     --_nys-textinput-hover-color-outline: var(--nys-color-neutral-900, #1b1b1b);
@@ -94,6 +98,20 @@ export default css`
     box-sizing: border-box;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
+    background-color: var(--_nys-textinput-background-color);
+  }
+
+  /* This container exist to mainly style the type="password" eye icon */
+  .nys-input-container {
+    position: relative;
+  }
+  .eye-icon {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+    background-color: var(--_nys-textinput-background-color);
   }
 
   /* Hovered */
@@ -112,7 +130,9 @@ export default css`
   }
 
   /* Disabled */
-  .nys-textinput__input:disabled {
+  .nys-textinput__input:disabled,
+  .nys-input-container.disabled,
+  .nys-input-container.disabled .eye-icon {
     background-color: var(--_nys-textinput-disabled-color);
     border-color: var(--_nys-textinput-disabled-color-border);
     color: var(--_nys-textinput-disabled-color-text);

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import styles from "./nys-textinput.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
 import "@nysds/nys-icon";
@@ -66,6 +66,7 @@ export class NysTextinput extends LitElement {
   @property({ type: Number }) max = null;
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
+  @state() private showPassword = false;
 
   static styles = styles;
 
@@ -189,6 +190,10 @@ export class NysTextinput extends LitElement {
     this._validate();
   }
 
+  private _togglePasswordVisibility() {
+    this.showPassword = !this.showPassword;
+  }
+
   /******************** Event Handlers ********************/
   // Handle input event to check pattern validity
   private _handleInput(event: Event) {
@@ -241,33 +246,48 @@ export class NysTextinput extends LitElement {
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>
-        <input
-          class="nys-textinput__input"
-          type=${this.type}
-          name=${this.name}
-          id=${this.id}
-          ?disabled=${this.disabled}
-          ?required=${this.required}
-          ?readonly=${this.readonly}
-          aria-disabled="${this.disabled}"
-          aria-label="${this.label} ${this.description}"
-          .value=${this.value}
-          placeholder=${ifDefined(
-            this.placeholder ? this.placeholder : undefined,
-          )}
-          pattern=${ifDefined(this.pattern ? this.pattern : undefined)}
-          min=${ifDefined(this.min !== "" ? this.min : undefined)}
-          maxlength=${ifDefined(
-            this.maxlength !== "" ? this.maxlength : undefined,
-          )}
-          step=${ifDefined(this.step !== "" ? this.step : undefined)}
-          max=${ifDefined(this.max !== "" ? this.max : undefined)}
-          form=${ifDefined(this.form ? this.form : undefined)}
-          @input=${this._handleInput}
-          @focus="${this._handleFocus}"
-          @blur="${this._handleBlur}"
-          @change="${this._handleChange}"
-        />
+        <div class="nys-input-container ${this.disabled ? "disabled" : ""}">
+          <input
+            class="nys-textinput__input"
+            type=${this.type === "password"
+              ? this.showPassword
+                ? "text"
+                : "password"
+              : this.type}
+            name=${this.name}
+            id=${this.id}
+            ?disabled=${this.disabled}
+            ?required=${this.required}
+            ?readonly=${this.readonly}
+            aria-disabled="${this.disabled}"
+            aria-label="${this.label} ${this.description}"
+            .value=${this.value}
+            placeholder=${ifDefined(
+              this.placeholder ? this.placeholder : undefined,
+            )}
+            pattern=${ifDefined(this.pattern ? this.pattern : undefined)}
+            min=${ifDefined(this.min !== "" ? this.min : undefined)}
+            maxlength=${ifDefined(
+              this.maxlength !== "" ? this.maxlength : undefined,
+            )}
+            step=${ifDefined(this.step !== "" ? this.step : undefined)}
+            max=${ifDefined(this.max !== "" ? this.max : undefined)}
+            form=${ifDefined(this.form ? this.form : undefined)}
+            @input=${this._handleInput}
+            @focus="${this._handleFocus}"
+            @blur="${this._handleBlur}"
+            @change="${this._handleChange}"
+          />
+          ${this.type === "password"
+            ? html`<nys-icon
+                class="eye-icon"
+                @click=${() =>
+                  !this.disabled && this._togglePasswordVisibility()}
+                name=${this.showPassword ? "visibility_off" : "visibility"}
+                size="3xl"
+              ></nys-icon>`
+            : ""}
+        </div>
         <nys-errormessage
           ?showError=${this.showError}
           errorMessage=${this.errorMessage}


### PR DESCRIPTION

# Summary

Added a "password eye" icon to the TextInput component to allow users to toggle password visibility.
<!--
A good summary is written in the past tense and includes:
- What was changed
- Why it was changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  


## Screenshots (if applicable)
<img width="808" alt="Screenshot 2025-03-13 at 4 01 57 PM" src="https://github.com/user-attachments/assets/16c771cf-70ad-4254-ae4b-84f3e0abe061" />

<img width="805" alt="Screenshot 2025-03-13 at 4 02 28 PM" src="https://github.com/user-attachments/assets/a9748c67-669a-4460-ad03-30b8dca3caa7" />
