### PR TITLE
Fix/package-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # New York State Design System
 
-This repository contains a library of reusable code components for building New York State applications and websites. These components are built using LitElement and styled with custon CSS properties (variables) for easy customization.
+This repository contains a library of reusable code components for building New York State applications and websites. These components are built using LitElement and styled with custom CSS properties (variables) for easy customization.
 
 ## About the New York State Design System
 Our mission is to standardize and elevate digital experiences across New York State by providing scalable, accessible tools for building applications.
@@ -11,27 +11,23 @@ Our mission is to standardize and elevate digital experiences across New York St
  - **Themes**: Customizable agency-specific themes for adapting designs to organizational branding.
  - **Figma Libraries**: Design libraries for prototyping that mirror the components and variables in code, promoting consistency between design and development.
 
-## Why Use NYSDS?
-### Key Benefits
+### Why Use NYSDS?
+
+#### Key Benefits
  - **Accessibility**: Every component is tested to meet WCAG 2.2 standards.
  - **Lit-based Web Components**: Built on the powerful and lightweight Lit framework, web components are native code designed to work seamlessly across modern frameworks or standalone applications.
  - **Customizable Design Tokens**: CSS variables that serve as a foundation for consistently building new components.
  - **Override-Friendly Architecture**: Components are designed with built-in overrides, making it easy to styles and behavior to meet specific application needs.
 
-<!-- TODO: Additionally, corresponding Figma components and variables are available for prototyping. -->
-
-## Install NYSDS
-To start using NYSDS in your project, you need to install the core libraries:
+## Install the NYSDS
+To start using the NYSDS in your project, you need to install the core libraries:
 
 ```bash
 npm install @nysds/components @nysds/styles
 ```
 
-## Reference the files in your application
+### Reference the files in your application
 ```html
 <script type="module" src="[path-to-dir]/nysds.js"></script>
 <link rel="stylesheet" href="[path-to-dir]/nysds-full.min.css" />
 ```
-
-## Storybook access
-[View the storybook for the New York State Design System](https://its-hcd.github.io/nysds)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.4",
         "@open-wc/testing": "^3.2.2",
-        "@rollup/plugin-node-resolve": "^15.3.0",
         "@storybook/addon-a11y": "^8.6.0",
         "@storybook/addon-essentials": "^8.6.0",
         "@storybook/addon-links": "^8.6.0",
@@ -43,6 +42,7 @@
         "lit": "^3.2.1",
         "npm": "^10.9.0",
         "plop": "^4.0.1",
+        "rollup-plugin-visualizer": "^5.14.0",
         "sinon": "^19.0.2",
         "storybook": "^8.6.0",
         "tslib": "^2.7.0",
@@ -12330,6 +12330,37 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
+      "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
@@ -14046,6 +14077,7 @@
       "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
+        "@nysds/nys-errormessage": "^1.1.1",
         "@nysds/nys-icon": "^1.1.1",
         "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1",
@@ -14064,11 +14096,13 @@
       "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.3"
       },
       "peerDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13998,16 +13998,16 @@
       "name": "@nysds/nys-alert",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
-        "@nysds/nys-button": "^1.1.1",
-        "@nysds/nys-icon": "^1.1.1"
-      },
       "devDependencies": {
+        "@nysds/nys-button": "^1.1.1",
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-button": "^1.1.1",
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14015,15 +14015,14 @@
       "name": "@nysds/nys-avatar",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
-        "@nysds/nys-icon": "^1.1.1"
-      },
       "devDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14031,15 +14030,14 @@
       "name": "@nysds/nys-button",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
-        "@nysds/nys-icon": "^1.1.1"
-      },
       "devDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14047,17 +14045,17 @@
       "name": "@nysds/nys-checkbox",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
-        "@nysds/nys-errormessage": "^1.1.1",
-        "@nysds/nys-icon": "^1.1.1",
-        "@nysds/nys-label": "^1.1.1"
-      },
       "devDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-errormessage": "^1.1.1",
+        "@nysds/nys-icon": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14091,15 +14089,14 @@
       "name": "@nysds/nys-globalheader",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
-        "@nysds/nys-icon": "^1.1.1"
-      },
       "devDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14133,16 +14130,16 @@
       "name": "@nysds/nys-radiobutton",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
-        "@nysds/nys-errormessage": "^1.1.1",
-        "@nysds/nys-label": "^1.1.1"
-      },
       "devDependencies": {
+        "@nysds/nys-errormessage": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-errormessage": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14150,17 +14147,18 @@
       "name": "@nysds/nys-select",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@nysds/nys-errormessage": "^1.1.1",
         "@nysds/nys-icon": "^1.1.1",
-        "@nysds/nys-label": "^1.1.1"
-      },
-      "devDependencies": {
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-errormessage": "^1.1.1",
+        "@nysds/nys-icon": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14168,17 +14166,18 @@
       "name": "@nysds/nys-textarea",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@nysds/nys-errormessage": "^1.1.1",
         "@nysds/nys-icon": "^1.1.1",
-        "@nysds/nys-label": "^1.1.1"
-      },
-      "devDependencies": {
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-errormessage": "^1.1.1",
+        "@nysds/nys-icon": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14186,17 +14185,18 @@
       "name": "@nysds/nys-textinput",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@nysds/nys-errormessage": "^1.1.1",
         "@nysds/nys-icon": "^1.1.1",
-        "@nysds/nys-label": "^1.1.1"
-      },
-      "devDependencies": {
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-errormessage": "^1.1.1",
+        "@nysds/nys-icon": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14204,15 +14204,14 @@
       "name": "@nysds/nys-toggle",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
-        "@nysds/nys-icon": "^1.1.1"
-      },
       "devDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-icon": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14233,17 +14232,18 @@
       "name": "@nysds/nys-unavheader",
       "version": "1.1.1",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@nysds/nys-button": "^1.1.1",
         "@nysds/nys-icon": "^1.1.1",
-        "@nysds/nys-textinput": "^1.1.1"
-      },
-      "devDependencies": {
+        "@nysds/nys-textinput": "^1.1.1",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
       },
       "peerDependencies": {
+        "@nysds/nys-button": "^1.1.1",
+        "@nysds/nys-icon": "^1.1.1",
+        "@nysds/nys-textinput": "^1.1.1",
         "lit": "^3.2.1"
       }
     },
@@ -14252,8 +14252,6 @@
       "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
-        "lit": "^3.2.1",
-        "typescript": "^5.7.2",
         "vite": "^6.0.11"
       }
     }

--- a/package.json
+++ b/package.json
@@ -52,10 +52,28 @@
     "url": "https://github.com/ITS-HCD/nysds/issues"
   },
   "homepage": "https://github.com/ITS-HCD/nysds/blob/main/README.md",
+  "dependencies": {
+    "@figma/code-connect": "^1.3.1",
+    "@nysds/nys-alert": "workspace:*",
+    "@nysds/nys-avatar": "workspace:*",
+    "@nysds/nys-button": "workspace:*",
+    "@nysds/nys-checkbox": "workspace:*",
+    "@nysds/nys-errormessage": "workspace:*",
+    "@nysds/nys-icon": "workspace:*",
+    "@nysds/nys-label": "workspace:*",
+    "@nysds/nys-radiobutton": "workspace:*",
+    "@nysds/nys-select": "workspace:*",
+    "@nysds/nys-textarea": "workspace:*",
+    "@nysds/nys-textinput": "workspace:*",
+    "@nysds/nys-toggle": "workspace:*",
+    "@nysds/nys-unavheader": "workspace:*",
+    "@nysds/nys-globalheader": "workspace:*",
+    "@nysds/nys-globalfooter": "workspace:*",
+    "@nysds/nys-unavfooter": "workspace:*"
+  },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.4",
     "@open-wc/testing": "^3.2.2",
-    "@rollup/plugin-node-resolve": "^15.3.0",
     "@storybook/addon-a11y": "^8.6.0",
     "@storybook/addon-essentials": "^8.6.0",
     "@storybook/addon-links": "^8.6.0",
@@ -81,6 +99,7 @@
     "lit": "^3.2.1",
     "npm": "^10.9.0",
     "plop": "^4.0.1",
+    "rollup-plugin-visualizer": "^5.14.0",
     "sinon": "^19.0.2",
     "storybook": "^8.6.0",
     "tslib": "^2.7.0",
@@ -94,8 +113,5 @@
     "extends": [
       "plugin:storybook/recommended"
     ]
-  },
-  "dependencies": {
-    "@figma/code-connect": "^1.3.1"
   }
 }

--- a/packages/nys-alert/package.json
+++ b/packages/nys-alert/package.json
@@ -19,14 +19,16 @@
     "build": "tsc --emitDeclarationOnly && vite build"
   },
   "dependencies": {
+  },
+  "peerDependencies": {
+    "lit": "^3.2.1",
     "@nysds/nys-icon": "^1.1.1",
     "@nysds/nys-button": "^1.1.1"
   },
-  "peerDependencies": {
-    "lit": "^3.2.1"
-  },
   "devDependencies": {
     "lit": "^3.2.1",
+    "@nysds/nys-icon": "^1.1.1",
+    "@nysds/nys-button": "^1.1.1",    
     "typescript": "^5.7.2",
     "vite": "^6.0.11"
   },

--- a/packages/nys-alert/vite.config.js
+++ b/packages/nys-alert/vite.config.js
@@ -24,7 +24,8 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      // External deps declared manually (should match peerDependencies)
+      external: ["lit", "@nysds/nys-icon", "@nysds/nys-button"],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-avatar/package.json
+++ b/packages/nys-avatar/package.json
@@ -18,13 +18,14 @@
       "build": "tsc --emitDeclarationOnly && vite build"
    },
    "dependencies": {
-      "@nysds/nys-icon": "^1.1.1"
    },
    "peerDependencies": {
-      "lit": "^3.2.1"
+      "lit": "^3.2.1",
+      "@nysds/nys-icon": "^1.1.1"
    },
    "devDependencies": {
       "lit": "^3.2.1",
+      "@nysds/nys-icon": "^1.1.1",
       "typescript": "^5.7.2",
       "vite": "^6.0.11"
    },

--- a/packages/nys-avatar/vite.config.js
+++ b/packages/nys-avatar/vite.config.js
@@ -25,7 +25,8 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      // External deps declared manually (should match peerDependencies)
+      external: ["lit", "@nysds/nys-icon"],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-button/package.json
+++ b/packages/nys-button/package.json
@@ -18,14 +18,15 @@
         "dev": "tsc --emitDeclarationOnly && vite",
         "build": "tsc --emitDeclarationOnly && vite build"
     },
-    "peerDependencies": {
-        "lit": "^3.2.1"
-    },
     "dependencies": {
-        "@nysds/nys-icon": "^1.1.1"
-      },
+    },
+    "peerDependencies": {
+      "lit": "^3.2.1",
+      "@nysds/nys-icon": "^1.1.1"
+    },
     "devDependencies": {
       "lit": "^3.2.1",
+      "@nysds/nys-icon": "^1.1.1",
       "typescript": "^5.7.2",
       "vite": "^6.0.11"
     },

--- a/packages/nys-button/vite.config.js
+++ b/packages/nys-button/vite.config.js
@@ -25,7 +25,8 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      // External deps declared manually (should match peerDependencies)
+      external: ["lit", "@nysds/nys-icon"],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-checkbox/package.json
+++ b/packages/nys-checkbox/package.json
@@ -19,15 +19,17 @@
     "build": "tsc --emitDeclarationOnly && vite build"
   },
   "dependencies": {
+  },
+  "peerDependencies": {
+    "lit": "^3.2.1",
     "@nysds/nys-icon": "^1.1.1",
     "@nysds/nys-label": "^1.1.1",
     "@nysds/nys-errormessage": "^1.1.1"
   },
-  "peerDependencies": {
-    "lit": "^3.2.1"
-  },
   "devDependencies": {
     "lit": "^3.2.1",
+    "@nysds/nys-icon": "^1.1.1",
+    "@nysds/nys-label": "^1.1.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.11"
   },

--- a/packages/nys-checkbox/package.json
+++ b/packages/nys-checkbox/package.json
@@ -30,6 +30,7 @@
     "lit": "^3.2.1",
     "@nysds/nys-icon": "^1.1.1",
     "@nysds/nys-label": "^1.1.1",
+    "@nysds/nys-errormessage": "^1.1.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.11"
   },

--- a/packages/nys-checkbox/vite.config.js
+++ b/packages/nys-checkbox/vite.config.js
@@ -24,7 +24,13 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true,
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      // External deps declared manually (should match peerDependencies)
+      external: [
+        "lit",
+        "@nysds/nys-icon",
+        "@nysds/nys-label",
+        "@nysds/nys-errormessage",
+      ],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-errormessage/package.json
+++ b/packages/nys-errormessage/package.json
@@ -22,10 +22,12 @@
     "dependencies": {
     },
     "peerDependencies": {
-      "lit": "^3.2.1"
+      "lit": "^3.2.1",
+      "@nysds/nys-icon": "^1.1.1"
     },
     "devDependencies": {
       "lit": "^3.2.1",
+      "@nysds/nys-icon": "^1.1.1",
       "typescript": "^5.7.2",
       "vite": "^6.0.3"
     },

--- a/packages/nys-errormessage/vite.config.js
+++ b/packages/nys-errormessage/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      external: ["lit", "@nysds/nys-icon"],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-globalheader/package.json
+++ b/packages/nys-globalheader/package.json
@@ -19,13 +19,14 @@
     "build": "tsc --emitDeclarationOnly && vite build"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.1.1"
   },
   "peerDependencies": {
-    "lit": "^3.2.1"
+    "lit": "^3.2.1",
+    "@nysds/nys-icon": "^1.1.1"
   },
   "devDependencies": {
     "lit": "^3.2.1",
+    "@nysds/nys-icon": "^1.1.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.11"
   },

--- a/packages/nys-globalheader/vite.config.js
+++ b/packages/nys-globalheader/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      external: ["lit", "@nysds/nys-icon"],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-radiobutton/package.json
+++ b/packages/nys-radiobutton/package.json
@@ -19,14 +19,16 @@
     "build": "tsc --emitDeclarationOnly && vite build"
   },
   "dependencies": {
+  },
+  "peerDependencies": {
+    "lit": "^3.2.1",
     "@nysds/nys-label": "^1.1.1",
     "@nysds/nys-errormessage": "^1.1.1"
   },
-  "peerDependencies": {
-    "lit": "^3.2.1"
-  },
   "devDependencies": {
     "lit": "^3.2.1",
+    "@nysds/nys-label": "^1.1.1",
+    "@nysds/nys-errormessage": "^1.1.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.11"
 },

--- a/packages/nys-radiobutton/vite.config.js
+++ b/packages/nys-radiobutton/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true,
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      external: ["lit", "@nysds/nys-label", "@nysds/nys-errormessage"],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-select/package.json
+++ b/packages/nys-select/package.json
@@ -18,15 +18,18 @@
         "build": "tsc --emitDeclarationOnly && vite build"
     },
     "dependencies": {
+      },
+    "peerDependencies": {
+        "lit": "^3.2.1",
         "@nysds/nys-icon": "^1.1.1",
         "@nysds/nys-label": "^1.1.1",
         "@nysds/nys-errormessage": "^1.1.1"
-      },
-    "peerDependencies": {
-        "lit": "^3.2.1"
     },
     "devDependencies": {
         "lit": "^3.2.1",
+        "@nysds/nys-icon": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
+        "@nysds/nys-errormessage": "^1.1.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
     },

--- a/packages/nys-select/vite.config.js
+++ b/packages/nys-select/vite.config.js
@@ -24,7 +24,12 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      external: [
+        "lit",
+        "@nysds/nys-icon",
+        "@nysds/nys-label",
+        "@nysds/nys-errormessage",
+      ],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-textarea/package.json
+++ b/packages/nys-textarea/package.json
@@ -18,16 +18,19 @@
         "dev": "tsc --emitDeclarationOnly && vite",
         "build": "tsc --emitDeclarationOnly && vite build"
     },
-    "peerDependencies": {
-        "lit": "^3.2.1"
-    },
     "dependencies": {
-        "@nysds/nys-icon": "^1.1.1",
-        "@nysds/nys-label": "^1.1.1",
-        "@nysds/nys-errormessage": "^1.1.1"
-      },
+    },
+    "peerDependencies": {
+      "lit": "^3.2.1",
+      "@nysds/nys-icon": "^1.1.1",
+      "@nysds/nys-label": "^1.1.1",
+      "@nysds/nys-errormessage": "^1.1.1"
+    },
     "devDependencies": {
       "lit": "^3.2.1",
+      "@nysds/nys-icon": "^1.1.1",
+      "@nysds/nys-label": "^1.1.1",
+      "@nysds/nys-errormessage": "^1.1.1",
       "typescript": "^5.7.2",
       "vite": "^6.0.11"
     },

--- a/packages/nys-textarea/vite.config.js
+++ b/packages/nys-textarea/vite.config.js
@@ -24,7 +24,12 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      external: [
+        "lit",
+        "@nysds/nys-icon",
+        "@nysds/nys-label",
+        "@nysds/nys-errormessage",
+      ],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-textinput/package.json
+++ b/packages/nys-textinput/package.json
@@ -17,16 +17,19 @@
         "dev": "tsc --emitDeclarationOnly && vite",
         "build": "tsc --emitDeclarationOnly && vite build"
     },
-    "peerDependencies": {
-        "lit": "^3.2.1"
-    },
     "dependencies": {
+    },
+    "peerDependencies": {
+        "lit": "^3.2.1",
         "@nysds/nys-icon": "^1.1.1",
         "@nysds/nys-label": "^1.1.1",
         "@nysds/nys-errormessage": "^1.1.1"
-      },
+    },
     "devDependencies": {
         "lit": "^3.2.1",
+        "@nysds/nys-icon": "^1.1.1",
+        "@nysds/nys-label": "^1.1.1",
+        "@nysds/nys-errormessage": "^1.1.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
     },

--- a/packages/nys-textinput/vite.config.js
+++ b/packages/nys-textinput/vite.config.js
@@ -24,7 +24,12 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      external: [
+        "lit",
+        "@nysds/nys-icon",
+        "@nysds/nys-label",
+        "@nysds/nys-errormessage",
+      ],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-toggle/package.json
+++ b/packages/nys-toggle/package.json
@@ -18,13 +18,14 @@
         "build": "tsc --emitDeclarationOnly && vite build"
     },
     "dependencies": {
-        "@nysds/nys-icon": "^1.1.1"
     },
     "peerDependencies": {
-        "lit": "^3.2.1"
+        "lit": "^3.2.1",
+        "@nysds/nys-icon": "^1.1.1"
     },
     "devDependencies": {
         "lit": "^3.2.1",
+        "@nysds/nys-icon": "^1.1.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.11"
     },

--- a/packages/nys-toggle/vite.config.js
+++ b/packages/nys-toggle/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      external: ["lit", "@nysds/nys-icon"],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/nys-unavheader/package.json
+++ b/packages/nys-unavheader/package.json
@@ -18,16 +18,19 @@
     "dev": "tsc --emitDeclarationOnly && vite",
     "build": "tsc --emitDeclarationOnly && vite build"
   },
-  "peerDependencies": {
-    "lit": "^3.2.1"
-  },
   "dependencies": {
+  },
+  "peerDependencies": {
+    "lit": "^3.2.1",
     "@nysds/nys-icon": "^1.1.1",
     "@nysds/nys-button": "^1.1.1",
     "@nysds/nys-textinput": "^1.1.1"
   },
   "devDependencies": {
     "lit": "^3.2.1",
+    "@nysds/nys-icon": "^1.1.1",
+    "@nysds/nys-button": "^1.1.1",
+    "@nysds/nys-textinput": "^1.1.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.11"
   },

--- a/packages/nys-unavheader/vite.config.js
+++ b/packages/nys-unavheader/vite.config.js
@@ -26,7 +26,12 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: false,
     sourcemap: true, // Enable sourcemaps
     rollupOptions: {
-      external: ["lit"], // Externalize Lit for ES build
+      external: [
+        "lit",
+        "@nysds/nys-icon",
+        "@nysds/nys-button",
+        "@nysds/nys-textinput",
+      ],
       output: {
         banner: mode === "production" ? banner : undefined, // Add banner only in production
         globals: {

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "version": "1.1.1",
   "description": "CSS variables, styles, and themes for the New York State Design System",
-  "main": "dist/nysds.css",
+  "main": "dist/nysds.min.css",
+  "style": "dist/nysds.min.css",
   "files": [
     "dist/"
   ],
@@ -27,8 +28,6 @@
     "clean": "rm -rf dist"
   },
   "devDependencies": {
-    "lit": "^3.2.1",
-    "typescript": "^5.7.2",
     "vite": "^6.0.11"
   },
   "keywords": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from "vite";
 
-// This banner will go at the top of our generated files
 const banner = `
 /*!
    * New York State Design System (v1.1.1)
@@ -10,18 +9,22 @@ const banner = `
  */
 `;
 
+// Externalize Lit and all NYSDS internal packages
+const external = (id) =>
+  id === "lit" || 
+  id.startsWith("lit/") || 
+  id.startsWith("@nysds/");
+
 export default defineConfig({
   build: {
     lib: {
-      // Entry file for our library that exports all components
       entry: ["./src/index.ts"],
     },
     sourcemap: true,
-    emptyOutDir: false, // Since we're building both ESM and UMD
+    emptyOutDir: false, // Since we're building both ES and UMD formats
     rollupOptions: {
-      external: (id) => id === "lit" || id.startsWith("lit/"),
+      external,
       output: [
-        // ESM Build for bundlers and modern tools
         {
           format: "es",
           banner,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,7 @@
 import { defineConfig } from "vite";
+import { visualizer } from "rollup-plugin-visualizer";
+
+const shouldAnalyze = process.env.ANALYZE === "true";
 
 const banner = `
 /*!
@@ -11,9 +14,7 @@ const banner = `
 
 // Externalize Lit and all NYSDS internal packages
 const external = (id) =>
-  id === "lit" || 
-  id.startsWith("lit/") || 
-  id.startsWith("@nysds/");
+  id === "lit" || id.startsWith("lit/") || id.startsWith("@nysds/");
 
 export default defineConfig({
   build: {
@@ -35,6 +36,10 @@ export default defineConfig({
           },
         },
       ],
+      plugins: [
+        shouldAnalyze &&
+          visualizer({ filename: "dist/stats-es.html", open: true }),
+      ].filter(Boolean),
     },
   },
 });

--- a/vite.config.umd.js
+++ b/vite.config.umd.js
@@ -1,10 +1,10 @@
 import { defineConfig } from "vite";
-import { nodeResolve } from "@rollup/plugin-node-resolve"; // Ensure bundled dependencies
-import path from "path";
+import { visualizer } from "rollup-plugin-visualizer";
+
+const shouldAnalyze = process.env.ANALYZE === "true";
 
 // This banner will go at the top of our generated files
 const banner = `
-
 /*!
    * New York State Design System (v1.1.1)
    * Description: A design system for New York State's digital products.
@@ -17,7 +17,7 @@ const banner = `
 export default defineConfig({
   build: {
     lib: {
-      entry: path.resolve(__dirname, "src/index.ts"),
+      entry: ["./src/index.ts"],
       name: "NYSDS", // Global variable for UMD
       fileName: () => "nysds.js", // Output as "nysds.js" for UMD
       formats: ["umd"], // UMD format
@@ -26,15 +26,15 @@ export default defineConfig({
     emptyOutDir: false, // Since we're building both ESM and UMD
     rollupOptions: {
       external: [], // Bundle all dependencies including Lit
-      plugins: [
-        nodeResolve(), // Resolves and bundles Lit and other dependencies
-      ],
       output: {
         banner,
         globals: {
           lit: "Lit", // Ensure compatibility with global Lit
         },
       },
+      plugins: [
+        shouldAnalyze && visualizer({ filename: "dist/stats-umd.html", open: true }),
+      ].filter(Boolean),
     },
   },
 });


### PR DESCRIPTION
# Summary

The compiled library is over 1mb for only 15 basic components — far too big for practical use. The compiling process is creating multiple versions of each component dependency. 

This build addresses the issues by: 

- Moving components dependencies to peerDependencies instead of dependencies
- Updating `vite.config.ts` in individual packages to mark those as external (so they don't get bundled for the ES build)

This basically tells Vite: “This component expects @nysds/nys-icon to be provided by whoever is importing me. Don’t bundle it here.”

## Breaking change

This is **not** a breaking change.  It should only impact the size of the final package.

## Related issues

_Closes #364_

## Major changes

- Every component declares components as peerDependencies