### PR TITLE
make undefined components invisible

### DIFF
--- a/packages/styles/src/nysds.css
+++ b/packages/styles/src/nysds.css
@@ -21,5 +21,8 @@
 
 /* TODO: Include Global Styles (default typography and body styles) */
 /* @import "./core/globals.css"; */
-  
-  
+
+/* Hide unstyled components until they are fully loaded */
+:not(:defined) {
+   visibility: hidden;
+}


### PR DESCRIPTION
Make components invisible while JS loads to avoid flashing unstyled components on screen