### PR TITLE
Took out `id.startWith("@nysds/")` from vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,8 +13,7 @@ const banner = `
 `;
 
 // Externalize Lit and all NYSDS internal packages
-const external = (id) =>
-  id === "lit" || id.startsWith("lit/") || id.startsWith("@nysds/");
+const external = (id) => id === "lit" || id.startsWith("lit/");
 
 export default defineConfig({
   build: {


### PR DESCRIPTION
# Summary
The bundle issue caused the first known problem in Dan's React demo.
Based on Eric's insight, I can confirm that taking out the `id.startWith("@nysds/")` in the main `vite.config.js` fixes the React problem as it removes the extra imports.

# Related Issues
https://github.com/ITS-HCD/nysds/issues/448 🎟️

# Screenshots
BEFORE:
![image](https://github.com/user-attachments/assets/84a95b7f-f692-4f14-8da5-11e0452417b5)
![image](https://github.com/user-attachments/assets/d07a21b1-c630-4d5e-a0b0-6a99e09c322e)
AFTER:
![image](https://github.com/user-attachments/assets/46eb6fbe-7946-449d-b817-5c726fb5ed0e)
