### PR TITLE
Fix: Button accessibility + Alert's Button

### DIFF
--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -210,6 +210,7 @@ export class NysAlert extends LitElement {
                     variant="ghost"
                     prefixIcon="close"
                     size="sm"
+                    ariaLabel="close button"
                     @click=${this._closeAlert}
                   ></nys-button>
                 </div>`
@@ -221,6 +222,7 @@ export class NysAlert extends LitElement {
                       prefixIcon="close"
                       size="sm"
                       inverted
+                      ariaLabel="close button"
                       @click=${this._closeAlert}
                     ></nys-button>
                   </div>`

--- a/packages/nys-button/src/nys-button.mdx
+++ b/packages/nys-button/src/nys-button.mdx
@@ -67,6 +67,7 @@ Set the `variant` prop of the **`nys-button`** to adjust the appearance of the b
 Set the `prefixIcon` prop of the **`nys-button`** to include an icon in the button. The icon will appear to the left of the label.\
 Set the `suffixIcon` prop of the **`nys-button`** to include an icon in the button. The icon will appear to the right of the label.
 
+If you wish to create a button with just an icon and no text, you can set the `ariaLabel` prop. This will allow users who rely on screen readers to understand the purpose of the button even though there is no visible label.
 <Canvas of={NysButtonStories.Icons} />
 ### Disabled
 <Canvas of={NysButtonStories.Disabled} />

--- a/packages/nys-button/src/nys-button.mdx
+++ b/packages/nys-button/src/nys-button.mdx
@@ -22,9 +22,8 @@ If an id is not passed, a unique id will be generated.
 
 <Controls />
 
-<div style={{ display: "flex", gap: "10px", verticalAlign: "middle", alignItems: "center" }}>
-	{" "}
-	<nys-icon size="xl" name="info"></nys-icon>The button component takes the property `onClick`, which is a function that is called when the button is clicked.{" "}
+<div style={{ display: 'flex', gap: '10px', verticalAlign: 'middle', alignItems: 'center' }}>  
+	<nys-icon size="xl" name="info"></nys-icon> The button component takes the property `onClick`, which is a function that is called when the button is clicked.
 </div>
 ```html
 <nys-button onClick={() => alert("Button clicked")} label="Click Me"></nys-button>
@@ -67,7 +66,9 @@ Set the `variant` prop of the **`nys-button`** to adjust the appearance of the b
 Set the `prefixIcon` prop of the **`nys-button`** to include an icon in the button. The icon will appear to the left of the label.\
 Set the `suffixIcon` prop of the **`nys-button`** to include an icon in the button. The icon will appear to the right of the label.
 
-If you wish to create a button with just an icon and no text, you can set the `ariaLabel` prop. This will allow users who rely on screen readers to understand the purpose of the button even though there is no visible label.
+If you wish to create a button with just an icon and no text, you can set the `ariaLabel` prop. This will allow users who rely on screen readers to understand the purpose of the button even though there is no visible label. 
+
+<div style={{ display: 'flex', gap: '10px', verticalAlign: 'middle', alignItems: 'center' }}>  <nys-icon size="xl" name="info"></nys-icon> The `aria-label` is automatically set to the label prop if provided, or defaults to "button"."</div>
 <Canvas of={NysButtonStories.Icons} />
 ### Disabled
 <Canvas of={NysButtonStories.Disabled} />
@@ -105,10 +106,9 @@ Set the `inverted` prop of the **`nys-button`** to adjust the appearance of the 
 
 The `nys-button` component includes the following accessibility-focused features:
 
-- Proper ARIA roles and attributes to ensure screen readers can interpret the checkbox correctly.
+- ARIA roles and aria-label attribute: Properly set to ensure screen readers interpret the button correctly. The `aria-label` is automatically set to the label prop if provided, or defaults to "button".
 - Keyboard navigation support, allowing users to use the keyboard to click the button.
 - Visual focus indicators to help users navigate the component.
-
 ## Events
 
 The `nys-button` component emits the following events:

--- a/packages/nys-button/src/nys-button.stories.ts
+++ b/packages/nys-button/src/nys-button.stories.ts
@@ -60,7 +60,10 @@ type Story = StoryObj<NysButtonArgs>;
 
 export const Basic: Story = {
   args: {
+    id: "button1",
+    name: "button1",
     label: "Click Me",
+    ariaLabel: "click me",
   },
   render: (args) => html`
     <nys-button
@@ -78,6 +81,7 @@ export const Basic: Story = {
       .value=${args.value}
       .href=${args.href}
       .type=${args.type}
+      .ariaLabel=${args.ariaLabel}
       .onClick=${() => alert("Button clicked")}
     ></nys-button>
   `,
@@ -119,6 +123,7 @@ export const Size: Story = {
           .value=${args.value}
           .href=${args.href}
           .type=${args.type}
+          .ariaLabel=${args.ariaLabel}
         ></nys-button>
         <nys-button
           .id=${args.id}
@@ -134,6 +139,7 @@ export const Size: Story = {
           .value=${args.value}
           .href=${args.href}
           .type=${args.type}
+          .ariaLabel=${args.ariaLabel}
         ></nys-button>
         <nys-button
           .id=${args.id}
@@ -149,6 +155,7 @@ export const Size: Story = {
           .value=${args.value}
           .href=${args.href}
           .type=${args.type}
+          .ariaLabel=${args.ariaLabel}
         ></nys-button>
       </div>
       <nys-button
@@ -166,6 +173,7 @@ export const Size: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -182,6 +190,7 @@ export const Size: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -198,6 +207,7 @@ export const Size: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
     </div>
   `,
@@ -267,6 +277,7 @@ export const Variants: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -282,6 +293,7 @@ export const Variants: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -297,6 +309,7 @@ export const Variants: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -312,6 +325,7 @@ export const Variants: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
     </div>
   `,
@@ -372,6 +386,7 @@ export const Icons: Story = {
       .value=${args.value}
       .href=${args.href}
       .type=${args.type}
+      .ariaLabel=${args.ariaLabel}
     ></nys-button>
   `,
 
@@ -383,6 +398,7 @@ export const Icons: Story = {
   id="button1"
   name="button1"
   label="Click Me"
+  ariaLabel="click me"
   prefixIcon="chevron_left"
   suffixIcon="chevron_right"
 ></nys-button>`,
@@ -415,6 +431,7 @@ export const Disabled: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -430,6 +447,7 @@ export const Disabled: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -445,6 +463,7 @@ export const Disabled: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -460,6 +479,7 @@ export const Disabled: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
     </div>
   `,
@@ -525,6 +545,7 @@ export const Link: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
     </div>
   `,
@@ -567,6 +588,7 @@ export const Inverted: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -582,6 +604,7 @@ export const Inverted: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -597,6 +620,7 @@ export const Inverted: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
       <nys-button
         .id=${args.id}
@@ -612,6 +636,7 @@ export const Inverted: Story = {
         .value=${args.value}
         .href=${args.href}
         .type=${args.type}
+        .ariaLabel=${args.ariaLabel}
       ></nys-button>
     </div>
   `,

--- a/packages/nys-button/src/nys-button.stories.ts
+++ b/packages/nys-button/src/nys-button.stories.ts
@@ -18,6 +18,7 @@ interface NysButtonArgs {
   value: string;
   type: string;
   href: string;
+  ariaLabel: string;
   onClick: () => void;
 }
 
@@ -41,6 +42,7 @@ const meta: Meta<NysButtonArgs> = {
     form: { control: "text" },
     value: { control: "text" },
     href: { control: "text" },
+    ariaLabel: { control: "text" },
     type: { control: "select", options: ["submit", "reset", "button"] },
   },
   parameters: {
@@ -352,6 +354,7 @@ export const Icons: Story = {
     label: "Click Me",
     prefixIcon: "chevron_left",
     suffixIcon: "chevron_right",
+    ariaLabel: "click me",
   },
 
   render: (args) => html`

--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -159,7 +159,7 @@ export class NysButton extends LitElement {
                 value=${ifDefined(this.value ? this.value : undefined)}
                 href=${this.href}
                 target="_blank"
-                aria-label=${this.ariaLabel || this.label || 'Button'}
+                aria-label=${this.ariaLabel || this.label || 'button'}
                 @click=${this._handleClick}
                 @focus="${this._handleFocus}"
                 @blur="${this._handleBlur}"
@@ -189,7 +189,7 @@ export class NysButton extends LitElement {
               form=${ifDefined(this.form ? this.form : undefined)}
               value=${ifDefined(this.value ? this.value : undefined)}
               type=${this.type}
-              aria-label=${this.ariaLabel || this.label || 'Button'}
+              aria-label=${this.ariaLabel || this.label || 'button'}
               @click=${this._handleClick}
               @focus="${this._handleFocus}"
               @blur="${this._handleBlur}"

--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -45,6 +45,7 @@ export class NysButton extends LitElement {
   }
   @property({ type: Boolean, reflect: true }) inverted = false; //used on dark text
   @property({ type: String }) label = "";
+  @property({ type: String }) ariaLabel = "";
   @property({ type: String }) prefixIcon = "";
   @property({ type: String }) suffixIcon = "";
   @property({ type: Boolean, reflect: true }) disabled = false;
@@ -158,6 +159,7 @@ export class NysButton extends LitElement {
                 value=${ifDefined(this.value ? this.value : undefined)}
                 href=${this.href}
                 target="_blank"
+                aria-label=${this.ariaLabel || this.label || 'Button'}
                 @click=${this._handleClick}
                 @focus="${this._handleFocus}"
                 @blur="${this._handleBlur}"
@@ -187,6 +189,7 @@ export class NysButton extends LitElement {
               form=${ifDefined(this.form ? this.form : undefined)}
               value=${ifDefined(this.value ? this.value : undefined)}
               type=${this.type}
+              aria-label=${this.ariaLabel || this.label || 'Button'}
               @click=${this._handleClick}
               @focus="${this._handleFocus}"
               @blur="${this._handleBlur}"


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success and we are glad you're here.

This pull request (PR) template exists to help speed up the integration process.
The Design System team reviews and approves each PR before we merge it into the public
code base, so please provide as much detail as possible to help us understand your changes.
On other words: we love clear explanations!
-->

<!---
Step 1 - Title this PR with the following format:
NYSDS - [Component]: [Brief statement describing what this pull request solves]
eg: "NYSDS - Button: Update hover states"
-->

# Summary
Based on Shamia's feedback on accessibility in the component's [Excel sheet](https://nysemail.sharepoint.com/:x:/r/teams/its.grp.UX-Design-Team/_layouts/15/Doc.aspx?sourcedoc=%7BCD05CADE-C27B-47E6-A96B-60806C1D88A1%7D&file=Design%20Component%20page%20detail%20A11y%20testing.xlsx&action=default&mobileredirect=true&isSPOFile=1&ovuser=f46cb8ea-7900-4d10-8ceb-80e8c1c81ee7%2CRobert.Chen%40its.ny.gov&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI1MC8yNTAzMTMyMTAxNCIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D)

Button is now updated to have `ariaLabel` to consider aria-label to make text discernible to screen reader users and handles the non-empty aria-label attribute.

## Breaking change
This is **not** a breaking change.  

@emilygorelik 
@esteinborn 
☢️ BUT PLEASE REVIEW the accessibility coverage just in case I missed anything. Thank you!