### PR TITLE
allow dev to customize target type of button when passing a URL

### DIFF
--- a/packages/nys-button/src/nys-button.mdx
+++ b/packages/nys-button/src/nys-button.mdx
@@ -73,7 +73,13 @@ If you wish to create a button with just an icon and no text, you can set the `a
 ### Disabled
 <Canvas of={NysButtonStories.Disabled} />
 ### Link
-Set the `href` prop of the **`nys-button`** when using the button to navigate to a different page. This will render the `<nys-button>` as an `<a>` tag.
+Set the `href` prop of the **`nys-button`** when using the button to navigate to a different page. This will render the `<nys-button>` as an `<a>` tag.\
+Set the `target` prop of the **`nys-button`** to specify where to open the linked document. The available targets are:
+- `_self`: Opens the link in the same frame as it was clicked (default).
+- `_blank`: Opens the link in a new tab or window.
+- `_parent`: Opens the link in the parent frame.
+- `_top`: Opens the link in the full body of the window.
+- `framename`: Opens the link in a named iframe.
 <Canvas of={NysButtonStories.Link} />
 ### Inverted
 Set the `inverted` prop of the **`nys-button`** to adjust the appearance of the button. Use this prop when the button is on a dark background.

--- a/packages/nys-button/src/nys-button.stories.ts
+++ b/packages/nys-button/src/nys-button.stories.ts
@@ -18,6 +18,7 @@ interface NysButtonArgs {
   value: string;
   type: string;
   href: string;
+  target: string;
   ariaLabel: string;
   onClick: () => void;
 }
@@ -42,6 +43,10 @@ const meta: Meta<NysButtonArgs> = {
     form: { control: "text" },
     value: { control: "text" },
     href: { control: "text" },
+    target: {
+      control: "select",
+      options: ["_self", "_blank", "_parent", "_top", "framename"],
+    },
     ariaLabel: { control: "text" },
     type: { control: "select", options: ["submit", "reset", "button"] },
   },
@@ -80,6 +85,7 @@ export const Basic: Story = {
       .form=${args.form}
       .value=${args.value}
       .href=${args.href}
+      .target=${args.target}
       .type=${args.type}
       .ariaLabel=${args.ariaLabel}
       .onClick=${() => alert("Button clicked")}
@@ -122,6 +128,7 @@ export const Size: Story = {
           .form=${args.form}
           .value=${args.value}
           .href=${args.href}
+          .target=${args.target}
           .type=${args.type}
           .ariaLabel=${args.ariaLabel}
         ></nys-button>
@@ -138,6 +145,7 @@ export const Size: Story = {
           .form=${args.form}
           .value=${args.value}
           .href=${args.href}
+          .target=${args.target}
           .type=${args.type}
           .ariaLabel=${args.ariaLabel}
         ></nys-button>
@@ -154,6 +162,7 @@ export const Size: Story = {
           .form=${args.form}
           .value=${args.value}
           .href=${args.href}
+          .target=${args.target}
           .type=${args.type}
           .ariaLabel=${args.ariaLabel}
         ></nys-button>
@@ -172,6 +181,7 @@ export const Size: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -189,6 +199,7 @@ export const Size: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -206,6 +217,7 @@ export const Size: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -276,6 +288,7 @@ export const Variants: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -292,6 +305,7 @@ export const Variants: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -308,6 +322,7 @@ export const Variants: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -324,6 +339,7 @@ export const Variants: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -385,6 +401,7 @@ export const Icons: Story = {
       .form=${args.form}
       .value=${args.value}
       .href=${args.href}
+      .target=${args.target}
       .type=${args.type}
       .ariaLabel=${args.ariaLabel}
     ></nys-button>
@@ -430,6 +447,7 @@ export const Disabled: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -446,6 +464,7 @@ export const Disabled: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -462,6 +481,7 @@ export const Disabled: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -478,6 +498,7 @@ export const Disabled: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -526,6 +547,7 @@ export const Link: Story = {
   args: {
     label: "Visit NY.gov",
     href: "https://www.ny.gov/",
+    target: "_blank",
   },
 
   render: (args) => html`
@@ -544,6 +566,7 @@ export const Link: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -559,6 +582,7 @@ export const Link: Story = {
   name="button1"
   label="Visit NY.gov"
   href="https://www.ny.gov/"
+  target="_blank"
 ></nys-button>`,
         type: "auto",
       },
@@ -587,6 +611,7 @@ export const Inverted: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -603,6 +628,7 @@ export const Inverted: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -619,6 +645,7 @@ export const Inverted: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>
@@ -635,6 +662,7 @@ export const Inverted: Story = {
         .form=${args.form}
         .value=${args.value}
         .href=${args.href}
+        .target=${args.target}
         .type=${args.type}
         .ariaLabel=${args.ariaLabel}
       ></nys-button>

--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -67,6 +67,26 @@ export class NysButton extends LitElement {
   }
   @property({ type: Function }) onClick: (event: Event) => void = () => {};
   @property({ type: String }) href = "";
+  // target
+  private static readonly VALID_TARGETS = [
+    "_self",
+    "_blank",
+    "_parent",
+    "_top",
+    "framename",
+  ] as const;
+  private _target: (typeof NysButton.VALID_TARGETS)[number] = "_self";
+  @property({ reflect: true })
+  get target(): (typeof NysButton.VALID_TARGETS)[number] {
+    return this._target;
+  }
+  set target(value: string) {
+    this._target = NysButton.VALID_TARGETS.includes(
+      value as (typeof NysButton.VALID_TARGETS)[number],
+    )
+      ? (value as (typeof NysButton.VALID_TARGETS)[number])
+      : "_self";
+  }
 
   static styles = styles;
   private _internals: ElementInternals;
@@ -158,7 +178,7 @@ export class NysButton extends LitElement {
                 form=${ifDefined(this.form ? this.form : undefined)}
                 value=${ifDefined(this.value ? this.value : undefined)}
                 href=${this.href}
-                target="_blank"
+                target=${this.target}
                 aria-label=${this.ariaLabel || this.label || "button"}
                 @click=${this._handleClick}
                 @focus="${this._handleFocus}"


### PR DESCRIPTION
Add `target` prop to allow devs to customize the url target. default is "_self"