### PR TITLE
Troubleshoot: radio internal issues

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -38,7 +38,7 @@ export class NysCheckbox extends LitElement {
   }
 
   public async getInputElement(): Promise<HTMLInputElement | null> {
-    await this.updateComplete;
+    await this.updateComplete; // Wait for the component to finish rendering
     return this.shadowRoot?.querySelector("input") || null;
   }
 

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -95,6 +95,7 @@ export class NysCheckboxgroup extends LitElement {
     const firstCheckboxInput = firstCheckbox
       ? await (firstCheckbox as any).getInputElement()
       : null;
+
     if (firstCheckboxInput) {
       // Focus only if this is the first invalid element (top-down approach)
       const form = this._internals.form;

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -113,15 +113,17 @@ export class NysRadiogroup extends LitElement {
       ? await (firstRadio as any).getInputElement()
       : null;
 
-    if (this.required && !this.selectedValue) {
-      this._internals.setValidity(
-        { valueMissing: true },
-        message,
-        firstRadioInput,
-      );
-    } else {
-      this.showError = false;
-      this._internals.setValidity({}, "", firstRadioInput);
+    if (firstRadioInput) {
+      if (this.required && !this.selectedValue) {
+        this._internals.setValidity(
+          { valueMissing: true },
+          message,
+          firstRadioInput,
+        );
+      } else {
+        this.showError = false;
+        this._internals.setValidity({}, "", firstRadioInput);
+      }
     }
   }
 


### PR DESCRIPTION

<!---
Step 1 - Title this PR with the following format:
NYSDS - [Component]: [Brief statement describing what this pull request solves]
eg: "NYSDS - Button: Update hover states"
-->

# Summary

This quick "fix" is more of an attempt to resolve the issue experienced by the "Child Support Enrollment" app team related to using NYSDS in Angular, where radiobutton/group is having an issue processing dynamic labels from an API.

```
An error occurred: TypeError: Failed to execute 'setValidity' on 'ElementInternals': parameter 3 is not of type 'HTMLElement'. at t1.<anonymous> (nysds.es.js:6086:60) at Generator.next (<anonymous>) at chunk-QIXTR7PE.js:84:61 at new ZoneAwarePromise (zone.js:2702:25) at __async (chunk-QIXTR7PE.js:68:10) at t1.manageRequire (nysds.es.js:6082:26) at t1.updated (nysds.es.js:6064:59) at t1.$didUpdate (reactive-element.js:852:10) at t1.performUpdate (reactive-element.js:819:12) at t1.scheduleUpdate (reactive-element.js:729:25)
```

<!--
A good summary is written in the past tense and includes:
- What was changed
- Why it was changed
- The benefit from the update
-->

## Breaking change

_Indicate if this update is a breaking change with **one** of the following statements:_
This is **not** a breaking change.  