### PR TITLE
Hotfix: Button subcomponent not clickable via keyboard

### DIFF
--- a/packages/nys-alert/src/nys-alert.stories.ts
+++ b/packages/nys-alert/src/nys-alert.stories.ts
@@ -276,7 +276,12 @@ export const Duration: Story = {
           type="button"
           @click=${showAlert}
           @keydown="${(e: KeyboardEvent) => {
-            if (e.key === "Enter" || e.key === " ") {
+            if (
+              e.code === "Enter" ||
+              e.code === "Space" ||
+              e.key === "Enter" ||
+              e.key === " "
+            ) {
               showAlert();
             }
           }}"

--- a/packages/nys-alert/src/nys-alert.stories.ts
+++ b/packages/nys-alert/src/nys-alert.stories.ts
@@ -275,6 +275,11 @@ export const Duration: Story = {
           id="show-alert"
           type="button"
           @click=${showAlert}
+          @keydown="${(e: KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              showAlert();
+            }
+          }}"
           style="
           background-color: #154973; 
           color: white; 

--- a/packages/nys-alert/src/nys-alert.styles.ts
+++ b/packages/nys-alert/src/nys-alert.styles.ts
@@ -122,11 +122,6 @@ export default css`
     margin: 0;
   }
 
-  .close-container {
-    margin-left: auto;
-    margin-top: -5px;
-  }
-
   /* Centered variant: For no descriptions, we remove the <slot name="text"> via JS logic. In styling, centers the icon for a compact layout. */
   .nys-alert--centered {
     display: flex;

--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -207,22 +207,20 @@ export class NysAlert extends LitElement {
                 : ""}
             </div>
             ${this.dismissible
-              ? html`<div class="close-container">
-                  <nys-button
-                    id="dismiss-btn"
-                    variant="ghost"
-                    prefixIcon="close"
-                    size="sm"
-                    ?inverted=${this.type === "emergency"}
-                    ariaLabel="close button"
-                    @click=${this._closeAlert}
-                    @keydown="${(e: KeyboardEvent) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        this._closeAlert();
-                      }
-                    }}"
-                  ></nys-button>
-                </div>`
+              ? html` <nys-button
+                  id="dismiss-btn"
+                  variant="ghost"
+                  prefixIcon="close"
+                  size="sm"
+                  ?inverted=${this.type === "emergency"}
+                  ariaLabel="close button"
+                  @click=${this._closeAlert}
+                  @keydown="${(e: KeyboardEvent) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      this._closeAlert();
+                    }
+                  }}"
+                ></nys-button>`
               : ""}
           </div>`
         : ""}

--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -216,7 +216,12 @@ export class NysAlert extends LitElement {
                   ariaLabel="close button"
                   @click=${this._closeAlert}
                   @keydown="${(e: KeyboardEvent) => {
-                    if (e.key === "Enter" || e.key === " ") {
+                    if (
+                      e.code === "Enter" ||
+                      e.code === "Space" ||
+                      e.key === "Enter" ||
+                      e.key === " "
+                    ) {
                       this._closeAlert();
                     }
                   }}"

--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -206,30 +206,24 @@ export class NysAlert extends LitElement {
                   </div> `
                 : ""}
             </div>
-            ${this.dismissible && this.type !== "emergency"
+            ${this.dismissible
               ? html`<div class="close-container">
                   <nys-button
                     id="dismiss-btn"
                     variant="ghost"
                     prefixIcon="close"
                     size="sm"
+                    ?inverted=${this.type === "emergency"}
                     ariaLabel="close button"
                     @click=${this._closeAlert}
+                    @keydown="${(e: KeyboardEvent) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        this._closeAlert();
+                      }
+                    }}"
                   ></nys-button>
                 </div>`
-              : this.dismissible && this.type === "emergency"
-                ? html`<div class="close-container">
-                    <nys-button
-                      id="dismiss-btn"
-                      variant="ghost"
-                      prefixIcon="close"
-                      size="sm"
-                      inverted
-                      ariaLabel="close button"
-                      @click=${this._closeAlert}
-                    ></nys-button>
-                  </div>`
-                : ""}
+              : ""}
           </div>`
         : ""}
     `;

--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -156,7 +156,12 @@ export class NysButton extends LitElement {
 
   // Handle keydown for keyboard accessibility
   private _handleKeydown(e: KeyboardEvent) {
-    if (e.code === "Space" || e.code === "Enter") {
+    if (
+      e.code === "Space" ||
+      e.code === "Enter" ||
+      e.key === " " ||
+      e.key === "Enter"
+    ) {
       e.preventDefault();
       if (!this.disabled) {
         this._manageFormAction(e);

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -116,6 +116,11 @@ export class NysUnavHeader extends LitElement {
                 size="sm"
                 suffixIcon="slotted"
                 @click="${this._toggleTrustbar}"
+                @keydown="${(e: KeyboardEvent) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    this._toggleTrustbar();
+                  }
+                }}"
               >
                 <nys-icon
                   slot="suffix-icon"
@@ -132,6 +137,11 @@ export class NysUnavHeader extends LitElement {
                   prefixIcon="close"
                   size="sm"
                   @click="${this._toggleTrustbar}"
+                  @keydown="${(e: KeyboardEvent) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      this._toggleTrustbar();
+                    }
+                  }}"
                 ></nys-button>`
               : null}
           </div>
@@ -186,6 +196,11 @@ export class NysUnavHeader extends LitElement {
                     size="sm"
                     suffixIcon="slotted"
                     @click="${this._toggleTrustbar}"
+                    @keydown="${(e: KeyboardEvent) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        this._toggleTrustbar();
+                      }
+                    }}"
                   >
                     <nys-icon
                       slot="suffix-icon"
@@ -210,6 +225,11 @@ export class NysUnavHeader extends LitElement {
                         id="nys-unavheader__translate"
                         class="nys-unavheader__iconbutton"
                         @click="${this._toggleLanguageList}"
+                        @keydown="${(e: KeyboardEvent) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            this._toggleLanguageList();
+                          }
+                        }}"
                       ></nys-button>
                     </div>
                     <div class="nys-unavheader__lg nys-unavheader__xl">
@@ -222,6 +242,11 @@ export class NysUnavHeader extends LitElement {
                           : "chevron_down"}
                         id="nys-unavheader__translate"
                         @click="${this._toggleLanguageList}"
+                        @keydown="${(e: KeyboardEvent) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            this._toggleLanguageList();
+                          }
+                        }}"
                       ></nys-button>
                     </div>
                     <div
@@ -252,6 +277,11 @@ export class NysUnavHeader extends LitElement {
                         id="nys-unavheader__searchbutton"
                         class="nys-unavheader__iconbutton"
                         @click="${this._toggleSearchDropdown}"
+                        @keydown="${(e: KeyboardEvent) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            this._toggleSearchDropdown();
+                          }
+                        }}"
                       ></nys-button>
                     </div>
                     <div class="nys-unavheader__lg nys-unavheader__xl">
@@ -299,6 +329,11 @@ export class NysUnavHeader extends LitElement {
                 prefixIcon="close"
                 size="sm"
                 @click="${this._toggleTrustbar}"
+                @keydown="${(e: KeyboardEvent) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    this._toggleTrustbar();
+                  }
+                }}"
               ></nys-button>
             </div>
           </div>

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -117,7 +117,12 @@ export class NysUnavHeader extends LitElement {
                 suffixIcon="slotted"
                 @click="${this._toggleTrustbar}"
                 @keydown="${(e: KeyboardEvent) => {
-                  if (e.key === "Enter" || e.key === " ") {
+                  if (
+                    e.code === "Enter" ||
+                    e.code === "Space" ||
+                    e.key === "Enter" ||
+                    e.key === " "
+                  ) {
                     this._toggleTrustbar();
                   }
                 }}"
@@ -138,7 +143,12 @@ export class NysUnavHeader extends LitElement {
                   size="sm"
                   @click="${this._toggleTrustbar}"
                   @keydown="${(e: KeyboardEvent) => {
-                    if (e.key === "Enter" || e.key === " ") {
+                    if (
+                      e.code === "Enter" ||
+                      e.code === "Space" ||
+                      e.key === "Enter" ||
+                      e.key === " "
+                    ) {
                       this._toggleTrustbar();
                     }
                   }}"
@@ -197,7 +207,12 @@ export class NysUnavHeader extends LitElement {
                     suffixIcon="slotted"
                     @click="${this._toggleTrustbar}"
                     @keydown="${(e: KeyboardEvent) => {
-                      if (e.key === "Enter" || e.key === " ") {
+                      if (
+                        e.code === "Enter" ||
+                        e.code === "Space" ||
+                        e.key === "Enter" ||
+                        e.key === " "
+                      ) {
                         this._toggleTrustbar();
                       }
                     }}"
@@ -226,7 +241,12 @@ export class NysUnavHeader extends LitElement {
                         class="nys-unavheader__iconbutton"
                         @click="${this._toggleLanguageList}"
                         @keydown="${(e: KeyboardEvent) => {
-                          if (e.key === "Enter" || e.key === " ") {
+                          if (
+                            e.code === "Enter" ||
+                            e.code === "Space" ||
+                            e.key === "Enter" ||
+                            e.key === " "
+                          ) {
                             this._toggleLanguageList();
                           }
                         }}"
@@ -243,7 +263,12 @@ export class NysUnavHeader extends LitElement {
                         id="nys-unavheader__translate"
                         @click="${this._toggleLanguageList}"
                         @keydown="${(e: KeyboardEvent) => {
-                          if (e.key === "Enter" || e.key === " ") {
+                          if (
+                            e.code === "Enter" ||
+                            e.code === "Space" ||
+                            e.key === "Enter" ||
+                            e.key === " "
+                          ) {
                             this._toggleLanguageList();
                           }
                         }}"
@@ -278,7 +303,12 @@ export class NysUnavHeader extends LitElement {
                         class="nys-unavheader__iconbutton"
                         @click="${this._toggleSearchDropdown}"
                         @keydown="${(e: KeyboardEvent) => {
-                          if (e.key === "Enter" || e.key === " ") {
+                          if (
+                            e.code === "Enter" ||
+                            e.code === "Space" ||
+                            e.key === "Enter" ||
+                            e.key === " "
+                          ) {
                             this._toggleSearchDropdown();
                           }
                         }}"
@@ -330,7 +360,12 @@ export class NysUnavHeader extends LitElement {
                 size="sm"
                 @click="${this._toggleTrustbar}"
                 @keydown="${(e: KeyboardEvent) => {
-                  if (e.key === "Enter" || e.key === " ") {
+                  if (
+                    e.code === "Enter" ||
+                    e.code === "Space" ||
+                    e.key === "Enter" ||
+                    e.key === " "
+                  ) {
                     this._toggleTrustbar();
                   }
                 }}"


### PR DESCRIPTION
Fix issue where `<nys-button>` inside other components are not interactable with the keyboard. The button itself can be clicked, but the "enter" or "space" key but does not register in unavheader and alert


Closes #510