### PR TITLE
Fix: skipnav radius and left transition out of bound

### DIFF
--- a/packages/nys-skipnav/src/nys-skipnav.styles.ts
+++ b/packages/nys-skipnav/src/nys-skipnav.styles.ts
@@ -47,7 +47,8 @@ export default css`
     gap: var(--_nys-skipnav-gap);
     background: var(--_nys-skipnav-color-background);
     color: var(--_nys-skipnav-color-link);
-    border: var(--_nys-skipnav-focus-border) solid var(--_nys-skipnav-color-link);
+    border: var(--_nys-skipnav-focus-border) solid
+      var(--_nys-skipnav-color-link);
     border-radius: var(--_nys-skipnav-focus-border-radius);
     font-family: var(--_nys-skipnav-font-family);
     font-size: var(--_nys-skipnav-font-size);

--- a/packages/nys-skipnav/src/nys-skipnav.styles.ts
+++ b/packages/nys-skipnav/src/nys-skipnav.styles.ts
@@ -7,6 +7,10 @@ export default css`
     --_nys-skipnav-padding-horizontal: var(--nys-space-200, 16px);
     --_nys-skipnav-gap: var(--nys-space-100, 8px);
 
+    /* Focus Styles */
+    --_nys-skipnav-focus-border: var(--nys-border-width-md, 2px);
+    --_nys-skipnav-focus-border-radius: var(--nys-radius-sm, 2px);
+
     /* Typography */
     --_nys-skipnav-font-size: var(--nys-font-size-ui-md, 16px);
     --_nys-skipnav-font-weight: var(--nys-font-weight-semibold, 600);
@@ -34,7 +38,7 @@ export default css`
 
   .nys-skipnav__link {
     position: absolute;
-    left: 0;
+    left: c;
     top: -4.8rem;
     display: inline-flex;
     padding: var(--_nys-skipnav-padding-vertical)
@@ -43,7 +47,8 @@ export default css`
     gap: var(--_nys-skipnav-gap);
     background: var(--_nys-skipnav-color-background);
     color: var(--_nys-skipnav-color-link);
-    border: 2px solid var(--_nys-skipnav-color-link);
+    border: var(--_nys-skipnav-focus-border) solid var(--_nys-skipnav-color-link);
+    border-radius: var(--_nys-skipnav-focus-border-radius);
     font-family: var(--_nys-skipnav-font-family);
     font-size: var(--_nys-skipnav-font-size);
     font-style: normal;
@@ -64,5 +69,6 @@ export default css`
   .nys-skipnav__link.show {
     top: 0;
     left: auto;
+    outline: none;
   }
 `;

--- a/packages/nys-skipnav/src/nys-skipnav.styles.ts
+++ b/packages/nys-skipnav/src/nys-skipnav.styles.ts
@@ -38,7 +38,7 @@ export default css`
 
   .nys-skipnav__link {
     position: absolute;
-    left: c;
+    left: auto;
     top: -4.8rem;
     display: inline-flex;
     padding: var(--_nys-skipnav-padding-vertical)


### PR DESCRIPTION
# Summary
Design noticed border radius in not rounded by 2px and I fixed an issue with transition slighting not left align.

## Breaking change
This is **not** a breaking change. 

## Component Changed
- `nys-skipnav`