### PR TITLE
Update button click function to be accessible

### DIFF
--- a/packages/nys-alert/src/nys-alert.stories.ts
+++ b/packages/nys-alert/src/nys-alert.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components";
 import "./nys-alert";
+import "@nysds/nys-button";
 
 // Define the structure of the args used in the stories
 interface NysAlertArgs {
@@ -73,9 +74,9 @@ export const Basic: Story = {
     docs: {
       source: {
         code: `
-<nys-alert 
-  type="info" 
-  heading="Information status" 
+<nys-alert
+  type="info"
+  heading="Information status"
   text="Adirondack peaks auctor Hudson River flows semper Statue of Liberty est.">
 </nys-alert>
         `,
@@ -148,9 +149,9 @@ export const AlertType: Story = {
     docs: {
       source: {
         code: `
-<nys-alert 
- type="info" 
- heading="Information status" 
+<nys-alert
+ type="info"
+ heading="Information status"
  text="Adirondack peaks auctor Hudson River flows semper Statue of Liberty est.">
 </nys-alert>
 `.trim(),
@@ -232,9 +233,9 @@ export const Dismissible: Story = {
     docs: {
       source: {
         code: `
-<nys-alert 
-  type="info" 
-  heading="Information status" 
+<nys-alert
+  type="info"
+  heading="Information status"
   dismissible>
   <p>Adirondack peaks auctor Hudson River flows semper Statue of Liberty est. <br/>Click here for more info: <a href="https://www.ny.gov/" target="_blank">https://www.ny.gov/</a> for more info.</p>
 </nys-alert>
@@ -271,33 +272,11 @@ export const Duration: Story = {
 
     return html`
       <div class="alert-duration-container">
-        <button
+        <nys-button
           id="show-alert"
-          type="button"
-          @click=${showAlert}
-          @keydown="${(e: KeyboardEvent) => {
-            if (
-              e.code === "Enter" ||
-              e.code === "Space" ||
-              e.key === "Enter" ||
-              e.key === " "
-            ) {
-              showAlert();
-            }
-          }}"
-          style="
-          background-color: #154973; 
-          color: white; 
-          border: none; 
-          padding: 10px 20px; 
-          margin-bottom: 10px;
-          font-size: 16px; 
-          border-radius: 5px; 
-          cursor: pointer;
-          "
-        >
-          Show Alert
-        </button>
+          label="Show Alert"
+          .onClick=${() => showAlert()}
+        ></nys-button>
         <div class="alert-container"></div>
       </div>
     `;
@@ -306,9 +285,9 @@ export const Duration: Story = {
     docs: {
       source: {
         code: `
-<nys-alert 
-  type="info" 
-  heading="Information status" 
+<nys-alert
+  type="info"
+  heading="Information status"
   text="This alert will disappear after 3 seconds."
   duration="3000">
 </nys-alert>
@@ -346,10 +325,10 @@ export const CustomIcon: Story = {
     docs: {
       source: {
         code: `
-<nys-alert 
-  type="emergency" 
+<nys-alert
+  type="emergency"
   heading="Winter storm warning: Dec 10th, 2024."
-  text="A major snowfall is expected across the state of New York for the weekend of Dec 7th. Stay home if possible and use extreme caution when driving." 
+  text="A major snowfall is expected across the state of New York for the weekend of Dec 7th. Stay home if possible and use extreme caution when driving."
   icon="help">
 </nys-alert>
 `.trim(),
@@ -385,7 +364,7 @@ export const HeadingOnly: Story = {
     docs: {
       source: {
         code: `
-<nys-alert 
+<nys-alert
   type="info"
   heading="Adirondack peaks auctor Hudson River flows semper Statue of Liberty est."
 >
@@ -427,8 +406,8 @@ export const ActionLinks: Story = {
     docs: {
       source: {
         code: `
-<nys-alert 
-  type="emergency" 
+<nys-alert
+  type="emergency"
   heading="Winter storm warning: Dec 10th, 2024."
   text= "A major snowfall is expected across the state of New York for the weekend of Dec 7th. Stay home if possible and use extreme caution when driving."
   primaryAction="https://www.ny.gov/"

--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -214,17 +214,7 @@ export class NysAlert extends LitElement {
                   size="sm"
                   ?inverted=${this.type === "emergency"}
                   ariaLabel="close button"
-                  @click=${this._closeAlert}
-                  @keydown="${(e: KeyboardEvent) => {
-                    if (
-                      e.code === "Enter" ||
-                      e.code === "Space" ||
-                      e.key === "Enter" ||
-                      e.key === " "
-                    ) {
-                      this._closeAlert();
-                    }
-                  }}"
+                  .onClick=${() => this._closeAlert()}
                 ></nys-button>`
               : ""}
           </div>`

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -116,17 +116,7 @@ export class NysUnavHeader extends LitElement {
                 variant="ghost"
                 size="sm"
                 suffixIcon="slotted"
-                @click="${this._toggleTrustbar}"
-                @keydown="${(e: KeyboardEvent) => {
-                  if (
-                    e.code === "Enter" ||
-                    e.code === "Space" ||
-                    e.key === "Enter" ||
-                    e.key === " "
-                  ) {
-                    this._toggleTrustbar();
-                  }
-                }}"
+                .onClick="${() => this._toggleTrustbar()}"
               >
                 <nys-icon
                   slot="suffix-icon"
@@ -143,17 +133,7 @@ export class NysUnavHeader extends LitElement {
                   prefixIcon="close"
                   size="sm"
                   ariaLabel="Close trustbar"
-                  @click="${this._toggleTrustbar}"
-                  @keydown="${(e: KeyboardEvent) => {
-                    if (
-                      e.code === "Enter" ||
-                      e.code === "Space" ||
-                      e.key === "Enter" ||
-                      e.key === " "
-                    ) {
-                      this._toggleTrustbar();
-                    }
-                  }}"
+                  .onClick="${() => this._toggleTrustbar()}"
                 ></nys-button>`
               : null}
           </div>
@@ -208,17 +188,7 @@ export class NysUnavHeader extends LitElement {
                     size="sm"
                     suffixIcon="slotted"
                     ariaLabel="Here's how you know"
-                    @click="${this._toggleTrustbar}"
-                    @keydown="${(e: KeyboardEvent) => {
-                      if (
-                        e.code === "Enter" ||
-                        e.code === "Space" ||
-                        e.key === "Enter" ||
-                        e.key === " "
-                      ) {
-                        this._toggleTrustbar();
-                      }
-                    }}"
+                    .onClick="${() => this._toggleTrustbar()}"
                   >
                     <nys-icon
                       slot="suffix-icon"
@@ -243,17 +213,7 @@ export class NysUnavHeader extends LitElement {
                         ariaLabel="Translate"
                         id="nys-unavheader__translate"
                         class="nys-unavheader__iconbutton"
-                        @click="${this._toggleLanguageList}"
-                        @keydown="${(e: KeyboardEvent) => {
-                          if (
-                            e.code === "Enter" ||
-                            e.code === "Space" ||
-                            e.key === "Enter" ||
-                            e.key === " "
-                          ) {
-                            this._toggleLanguageList();
-                          }
-                        }}"
+                        .onClick="${() => this._toggleLanguageList()}"
                       ></nys-button>
                     </div>
                     <div class="nys-unavheader__lg nys-unavheader__xl">
@@ -266,17 +226,7 @@ export class NysUnavHeader extends LitElement {
                           : "chevron_down"}
                         ariaLabel="Translate"
                         id="nys-unavheader__translate"
-                        @click="${this._toggleLanguageList}"
-                        @keydown="${(e: KeyboardEvent) => {
-                          if (
-                            e.code === "Enter" ||
-                            e.code === "Space" ||
-                            e.key === "Enter" ||
-                            e.key === " "
-                          ) {
-                            this._toggleLanguageList();
-                          }
-                        }}"
+                        .onClick="${() => this._toggleLanguageList()}"
                       ></nys-button>
                     </div>
                     <div
@@ -307,17 +257,7 @@ export class NysUnavHeader extends LitElement {
                         ariaLabel="Search"
                         id="nys-unavheader__searchbutton"
                         class="nys-unavheader__iconbutton"
-                        @click="${this._toggleSearchDropdown}"
-                        @keydown="${(e: KeyboardEvent) => {
-                          if (
-                            e.code === "Enter" ||
-                            e.code === "Space" ||
-                            e.key === "Enter" ||
-                            e.key === " "
-                          ) {
-                            this._toggleSearchDropdown();
-                          }
-                        }}"
+                        .onClick="${() => this._toggleSearchDropdown()}"
                       ></nys-button>
                     </div>
                     <div class="nys-unavheader__lg nys-unavheader__xl">
@@ -365,17 +305,7 @@ export class NysUnavHeader extends LitElement {
                 prefixIcon="close"
                 size="sm"
                 ariaLabel="Close trustbar"
-                @click="${this._toggleTrustbar}"
-                @keydown="${(e: KeyboardEvent) => {
-                  if (
-                    e.code === "Enter" ||
-                    e.code === "Space" ||
-                    e.key === "Enter" ||
-                    e.key === " "
-                  ) {
-                    this._toggleTrustbar();
-                  }
-                }}"
+                .onClick="${() => this._toggleTrustbar()}"
               ></nys-button>
             </div>
           </div>


### PR DESCRIPTION
Refactor `<nys-button>` instances used in other components to not need the function called on both `@click` and `@keydown` since we learned about triggering it with `.onClick`

Closes #509 