### PR TITLE
Enhancement/margin and padding utility classes

### DIFF
--- a/packages/styles/src/nysds-full.css
+++ b/packages/styles/src/nysds-full.css
@@ -8,3 +8,5 @@
 @import "./utilities/opacity.css";
 @import "./utilities/flex.css";
 @import "./utilities/zindex.css";
+@import "./utilities/padding.css";
+@import "./utilities/margin.css";

--- a/packages/styles/src/utilities/margin.css
+++ b/packages/styles/src/utilities/margin.css
@@ -1,0 +1,328 @@
+/* Uniform Margins */
+.nys-margin-1px {
+  margin: 1px;
+}
+.nys-margin-2px {
+  margin: 2px;
+}
+.nys-margin-50 {
+  margin: 4px;
+}
+.nys-margin-100 {
+  margin: 8px;
+}
+.nys-margin-150 {
+  margin: 12px;
+}
+.nys-margin-200 {
+  margin: 16px;
+}
+.nys-margin-250 {
+  margin: 20px;
+}
+.nys-margin-300 {
+  margin: 24px;
+}
+.nys-margin-400 {
+  margin: 32px;
+}
+.nys-margin-500 {
+  margin: 40px;
+}
+.nys-margin-600 {
+  margin: 48px;
+}
+.nys-margin-700 {
+  margin: 56px;
+}
+.nys-margin-800 {
+  margin: 64px;
+}
+.nys-margin-1200 {
+  margin: 96px;
+}
+/* Horizontal Margins */
+.nys-margin-x-1px {
+  margin-left: 1px;
+  margin-right: 1px;
+}
+.nys-margin-x-2px {
+  margin-left: 2px;
+  margin-right: 2px;
+}
+.nys-margin-x-50 {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+.nys-margin-x-100 {
+  margin-left: 8px;
+  margin-right: 8px;
+}
+.nys-margin-x-150 {
+  margin-left: 12px;
+  margin-right: 12px;
+}
+.nys-margin-x-200 {
+  margin-left: 16px;
+  margin-right: 16px;
+}
+.nys-margin-x-250 {
+  margin-left: 20px;
+  margin-right: 20px;
+}
+.nys-margin-x-300 {
+  margin-left: 24px;
+  margin-right: 24px;
+}
+.nys-margin-x-400 {
+  margin-left: 32px;
+  margin-right: 32px;
+}
+.nys-margin-x-500 {
+  margin-left: 40px;
+  margin-right: 40px;
+}
+.nys-margin-x-600 {
+  margin-left: 48px;
+  margin-right: 48px;
+}
+.nys-margin-x-700 {
+  margin-left: 56px;
+  margin-right: 56px;
+}
+.nys-margin-x-800 {
+  margin-left: 64px;
+  margin-right: 64px;
+}
+.nys-margin-x-1200 {
+  margin-left: 96px;
+  margin-right: 96px;
+}
+/* Vertical Margins */
+.nys-margin-y-1px {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+.nys-margin-y-2px {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+.nys-margin-y-50 {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+.nys-margin-y-100 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+.nys-margin-y-150 {
+  margin-top: 12px;
+  margin-bottom: 12px;
+}
+.nys-margin-y-200 {
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+.nys-margin-y-250 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+.nys-margin-y-300 {
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+.nys-margin-y-400 {
+  margin-top: 32px;
+  margin-bottom: 32px;
+}
+.nys-margin-y-500 {
+  margin-top: 40px;
+  margin-bottom: 40px;
+}
+.nys-margin-y-600 {
+  margin-top: 48px;
+  margin-bottom: 48px;
+}
+.nys-margin-y-700 {
+  margin-top: 56px;
+  margin-bottom: 56px;
+}
+.nys-margin-y-800 {
+  margin-top: 64px;
+  margin-bottom: 64px;
+}
+.nys-margin-y-1200 {
+  margin-top: 96px;
+  margin-bottom: 96px;
+}
+/* Single Margins */
+.nys-margin-t-1px {
+  margin-top: 1px;
+}
+.nys-margin-r-1px {
+  margin-right: 1px;
+}
+.nys-margin-b-1px {
+  margin-bottom: 1px;
+}
+.nys-margin-l-1px {
+  margin-left: 1px;
+}
+.nys-margin-t-2px {
+  margin-top: 2px;
+}
+.nys-margin-r-2px {
+  margin-right: 2px;
+}
+.nys-margin-b-2px {
+  margin-bottom: 2px;
+}
+.nys-margin-l-2px {
+  margin-left: 2px;
+}
+.nys-margin-t-50 {
+  margin-top: 4px;
+}
+.nys-margin-r-50 {
+  margin-right: 4px;
+}
+.nys-margin-b-50 {
+  margin-bottom: 4px;
+}
+.nys-margin-l-50 {
+  margin-left: 4px;
+}
+.nys-margin-t-100 {
+  margin-top: 8px;
+}
+.nys-margin-r-100 {
+  margin-right: 8px;
+}
+.nys-margin-b-100 {
+  margin-bottom: 8px;
+}
+.nys-margin-l-100 {
+  margin-left: 8px;
+}
+.nys-margin-t-150 {
+  margin-top: 12px;
+}
+.nys-margin-r-150 {
+  margin-right: 12px;
+}
+.nys-margin-b-150 {
+  margin-bottom: 12px;
+}
+.nys-margin-l-150 {
+  margin-left: 12px;
+}
+.nys-margin-t-200 {
+  margin-top: 16px;
+}
+.nys-margin-r-200 {
+  margin-right: 16px;
+}
+.nys-margin-b-200 {
+  margin-bottom: 16px;
+}
+.nys-margin-l-200 {
+  margin-left: 16px;
+}
+.nys-margin-t-250 {
+  margin-top: 20px;
+}
+.nys-margin-r-250 {
+  margin-right: 20px;
+}
+.nys-margin-b-250 {
+  margin-bottom: 20px;
+}
+.nys-margin-l-250 {
+  margin-left: 20px;
+}
+.nys-margin-t-300 {
+  margin-top: 24px;
+}
+.nys-margin-r-300 {
+  margin-right: 24px;
+}
+.nys-margin-b-300 {
+  margin-bottom: 24px;
+}
+.nys-margin-l-300 {
+  margin-left: 24px;
+}
+.nys-margin-t-400 {
+  margin-top: 32px;
+}
+.nys-margin-r-400 {
+  margin-right: 32px;
+}
+.nys-margin-b-400 {
+  margin-bottom: 32px;
+}
+.nys-margin-l-400 {
+  margin-left: 32px;
+}
+.nys-margin-t-500 {
+  margin-top: 40px;
+}
+.nys-margin-r-500 {
+  margin-right: 40px;
+}
+.nys-margin-b-500 {
+  margin-bottom: 40px;
+}
+.nys-margin-l-500 {
+  margin-left: 40px;
+}
+.nys-margin-t-600 {
+  margin-top: 48px;
+}
+.nys-margin-r-600 {
+  margin-right: 48px;
+}
+.nys-margin-b-600 {
+  margin-bottom: 48px;
+}
+.nys-margin-l-600 {
+  margin-left: 48px;
+}
+.nys-margin-t-700 {
+  margin-top: 56px;
+}
+.nys-margin-r-700 {
+  margin-right: 56px;
+}
+.nys-margin-b-700 {
+  margin-bottom: 56px;
+}
+.nys-margin-l-700 {
+  margin-left: 56px;
+}
+.nys-margin-t-800 {
+  margin-top: 64px;
+}
+.nys-margin-r-800 {
+  margin-right: 64px;
+}
+.nys-margin-b-800 {
+  margin-bottom: 64px;
+}
+.nys-margin-l-800 {
+  margin-left: 64px;
+}
+.nys-margin-t-1200 {
+  margin-top: 96px;
+}
+.nys-margin-r-1200 {
+  margin-right: 96px;
+}
+.nys-margin-b-1200 {
+  margin-bottom: 96px;
+}
+.nys-margin-l-1200 {
+  margin-left: 96px;
+}
+
+

--- a/packages/styles/src/utilities/padding.css
+++ b/packages/styles/src/utilities/padding.css
@@ -1,0 +1,328 @@
+/* Uniform Padding */
+.nys-padding-1px {
+  padding: 1px;
+}
+.nys-padding-2px {
+  padding: 2px;
+}
+.nys-padding-50 {
+  padding: 4px;
+}
+.nys-padding-100 {
+  padding: 8px;
+}
+.nys-padding-150 {
+  padding: 12px;
+}
+.nys-padding-200 {
+  padding: 16px;
+}
+.nys-padding-250 {
+  padding: 20px;
+}
+.nys-padding-300 {
+  padding: 24px;
+}
+.nys-padding-400 {
+  padding: 32px;
+}
+.nys-padding-500 {
+  padding: 40px;
+}
+.nys-padding-600 {
+  padding: 48px;
+}
+.nys-padding-700 {
+  padding: 56px;
+}
+.nys-padding-800 {
+  padding: 64px;
+}
+.nys-padding-1200 {
+  padding: 96px;
+}
+/* Horizontal Padding */
+.nys-padding-x-1px {
+  padding-left: 1px;
+  padding-right: 1px;
+}
+.nys-padding-x-2px {
+  padding-left: 2px;
+  padding-right: 2px;
+}
+.nys-padding-x-50 {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+.nys-padding-x-100 {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.nys-padding-x-150 {
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.nys-padding-x-200 {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+.nys-padding-x-250 {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+.nys-padding-x-300 {
+  padding-left: 24px;
+  padding-right: 24px;
+}
+.nys-padding-x-400 {
+  padding-left: 32px;
+  padding-right: 32px;
+}
+.nys-padding-x-500 {
+  padding-left: 40px;
+  padding-right: 40px;
+}
+.nys-padding-x-600 {
+  padding-left: 48px;
+  padding-right: 48px;
+}
+.nys-padding-x-700 {
+  padding-left: 56px;
+  padding-right: 56px;
+}
+.nys-padding-x-800 {
+  padding-left: 64px;
+  padding-right: 64px;
+}
+.nys-padding-x-1200 {
+  padding-left: 96px;
+  padding-right: 96px;
+}
+/* Vertical Padding */
+.nys-padding-y-1px {
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+.nys-padding-y-2px {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+.nys-padding-y-50 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+.nys-padding-y-100 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+.nys-padding-y-150 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+.nys-padding-y-200 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+.nys-padding-y-250 {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+.nys-padding-y-300 {
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+.nys-padding-y-400 {
+  padding-top: 32px;
+  padding-bottom: 32px;
+}
+.nys-padding-y-500 {
+  padding-top: 40px;
+  padding-bottom: 40px;
+}
+.nys-padding-y-600 {
+  padding-top: 48px;
+  padding-bottom: 48px;
+}
+.nys-padding-y-700 {
+  padding-top: 56px;
+  padding-bottom: 56px;
+}
+.nys-padding-y-800 {
+  padding-top: 64px;
+  padding-bottom: 64px;
+}
+.nys-padding-y-1200 {
+  padding-top: 96px;
+  padding-bottom: 96px;
+}
+/* Single Padding */
+.nys-padding-t-1px {
+  padding-top: 1px;
+}
+.nys-padding-r-1px {
+  padding-right: 1px;
+}
+.nys-padding-b-1px {
+  padding-bottom: 1px;
+}
+.nys-padding-l-1px {
+  padding-left: 1px;
+}
+.nys-padding-t-2px {
+  padding-top: 2px;
+}
+.nys-padding-r-2px {
+  padding-right: 2px;
+}
+.nys-padding-b-2px {
+  padding-bottom: 2px;
+}
+.nys-padding-l-2px {
+  padding-left: 2px;
+}
+.nys-padding-t-50 {
+  padding-top: 4px;
+}
+.nys-padding-r-50 {
+  padding-right: 4px;
+}
+.nys-padding-b-50 {
+  padding-bottom: 4px;
+}
+.nys-padding-l-50 {
+  padding-left: 4px;
+}
+.nys-padding-t-100 {
+  padding-top: 8px;
+}
+.nys-padding-r-100 {
+  padding-right: 8px;
+}
+.nys-padding-b-100 {
+  padding-bottom: 8px;
+}
+.nys-padding-l-100 {
+  padding-left: 8px;
+}
+.nys-padding-t-150 {
+  padding-top: 12px;
+}
+.nys-padding-r-150 {
+  padding-right: 12px;
+}
+.nys-padding-b-150 {
+  padding-bottom: 12px;
+}
+.nys-padding-l-150 {
+  padding-left: 12px;
+}
+.nys-padding-t-200 {
+  padding-top: 16px;
+}
+.nys-padding-r-200 {
+  padding-right: 16px;
+}
+.nys-padding-b-200 {
+  padding-bottom: 16px;
+}
+.nys-padding-l-200 {
+  padding-left: 16px;
+}
+.nys-padding-t-250 {
+  padding-top: 20px;
+}
+.nys-padding-r-250 {
+  padding-right: 20px;
+}
+.nys-padding-b-250 {
+  padding-bottom: 20px;
+}
+.nys-padding-l-250 {
+  padding-left: 20px;
+}
+.nys-padding-t-300 {
+  padding-top: 24px;
+}
+.nys-padding-r-300 {
+  padding-right: 24px;
+}
+.nys-padding-b-300 {
+  padding-bottom: 24px;
+}
+.nys-padding-l-300 {
+  padding-left: 24px;
+}
+.nys-padding-t-400 {
+  padding-top: 32px;
+}
+.nys-padding-r-400 {
+  padding-right: 32px;
+}
+.nys-padding-b-400 {
+  padding-bottom: 32px;
+}
+.nys-padding-l-400 {
+  padding-left: 32px;
+}
+.nys-padding-t-500 {
+  padding-top: 40px;
+}
+.nys-padding-r-500 {
+  padding-right: 40px;
+}
+.nys-padding-b-500 {
+  padding-bottom: 40px;
+}
+.nys-padding-l-500 {
+  padding-left: 40px;
+}
+.nys-padding-t-600 {
+  padding-top: 48px;
+}
+.nys-padding-r-600 {
+  padding-right: 48px;
+}
+.nys-padding-b-600 {
+  padding-bottom: 48px;
+}
+.nys-padding-l-600 {
+  padding-left: 48px;
+}
+.nys-padding-t-700 {
+  padding-top: 56px;
+}
+.nys-padding-r-700 {
+  padding-right: 56px;
+}
+.nys-padding-b-700 {
+  padding-bottom: 56px;
+}
+.nys-padding-l-700 {
+  padding-left: 56px;
+}
+.nys-padding-t-800 {
+  padding-top: 64px;
+}
+.nys-padding-r-800 {
+  padding-right: 64px;
+}
+.nys-padding-b-800 {
+  padding-bottom: 64px;
+}
+.nys-padding-l-800 {
+  padding-left: 64px;
+}
+.nys-padding-t-1200 {
+  padding-top: 96px;
+}
+.nys-padding-r-1200 {
+  padding-right: 96px;
+}
+.nys-padding-b-1200 {
+  padding-bottom: 96px;
+}
+.nys-padding-l-1200 {
+  padding-left: 96px;
+}
+
+


### PR DESCRIPTION
Added margin and padding utility classes for uniform, vertical, horizontal, and individual directions using our standard spacing values.

`.nys-padding-50` uniform
`.nys-padding-x-50` horizontal
`.nys-padding-y-50` vertical
`.nys-padding-t-50` top
`.nys-padding-l-50` left
`.nys-padding-b-50` bottom
`.nys-padding-r-50` right

Once this is released with 1.1.9 we will need to add examples for these on the https://designsystem.ny.gov/foundations/utilities/ page