### PR TITLE
Removed another redundant test

### DIFF
--- a/.github/workflows/test-node-js.yaml
+++ b/.github/workflows/test-node-js.yaml
@@ -31,4 +31,4 @@ jobs:
     - name: Test Components
       run: npm run test:build
     - name: Build Storybook
-      run: npm run build-storybook
+      run: npm run storybook:cibuild

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build:all": "npm run build:all && storybook dev -p 6006",
     "build-storybook": "npm run build:packages && storybook build",
+    "storybook:cibuild": "storybook build",
     "clean:node": "rm -rf node_modules && rm -rf packages/*/node_modules",
     "clean:dist": "rm -rf dist && rm -rf packages/*/dist",
     "clean:all": "npm run clean:dist && npm run clean:node"


### PR DESCRIPTION
added a new `storybook:cibuild` for testing the build in CI. This no longer re-compiles the scripts before firing up the storybook build.