### PR TITLE
Fix: Unav Header - clicking logo should open link in same tab

### DIFF
--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -188,7 +188,6 @@ export class NysUnavHeader extends LitElement {
             <div class="nys-unavheader__left">
               <a
                 href="https://ny.gov"
-                target="_blank"
                 id="nys-unavheader__logolink"
                 aria-label="logo of New York State"
               >


### PR DESCRIPTION
Have clicking logo open ny.gov in same tab not new tab per issue #600 

closes #600 