### PR TITLE
Enhancement: new tokens colors

### DIFF
--- a/packages/styles/src/core/tokens.css
+++ b/packages/styles/src/core/tokens.css
@@ -14,8 +14,8 @@
   --nys-color-accent: var(--nys-color-yellow-400);
   
   /* Intent: Neutral */
-  --nys-color-neutral: var(--nys-color-neutral-600);
-  --nys-color-neutral-weak: var(--nys-color-neutral-10);
+  --nys-color-base: var(--nys-color-neutral-600);
+  --nys-color-base-weak: var(--nys-color-neutral-10);
   
   /* Intent: Success */
   --nys-color-success: var(--nys-color-green-600);


### PR DESCRIPTION
# Summary

Update the semantic color variable from old "neutral" to "base". Not deleting `--nys-color-neutral-#`.

```
  --nys-color-neutral
  --nys-color-neutral-weak
  
  TO
  --nys-color-base
  --nys-color-base-weak
  ```
  


## Breaking change
This is **not** a breaking change.  


## Related issues
Ticket https://github.com/ITS-HCD/nysds-site/issues/174 🎟️ is reliant on this change.