### PR TITLE
Fix: event documentation & bugs

### DIFF
--- a/packages/nys-alert/src/nys-alert.mdx
+++ b/packages/nys-alert/src/nys-alert.mdx
@@ -127,7 +127,7 @@ The `nys-alert` component includes the following accessibility-focused features:
 
 The `nys-alert` component emits the following events:
 
-1. `nys-alertClosed`: Emitted when the alert is dismissed by the user (e.g. via a close button). This event allows developers to respond to the dismissal — for example, saving the closed state locally to prevent the alert from showing again.
+1. `nys-alertClosed`: Fire when the alert is dismissed by the user (i.e. via a close button).
 
 You can listen to these events using JavaScript:
 
@@ -139,7 +139,8 @@ const alert = document.querySelector("nys-alert");
 alert.addEventListener("nys-alertClosed", (event) => {
   const { type, label } = event.detail;
   console.log(`Alert closed. Type: ${type}, Label: ${label}`);
-  // Optionally save this state to localStorage or analytics
+  // Optional: persist dismissal (e.g., to localStorage or analytics)
+  // This can be used to prevent the alert from appearing again
 });
 
 ```

--- a/packages/nys-alert/src/nys-alert.mdx
+++ b/packages/nys-alert/src/nys-alert.mdx
@@ -136,11 +136,13 @@ You can listen to these events using JavaScript:
 const alert = document.querySelector("nys-alert");
 
 // Listen for the 'nys-alertClosed' event
+/* 
+ * Consider persisting dismissal state (e.g., to localStorage or analytics)
+ * This can be used to prevent the alert from appearing again
+ */
 alert.addEventListener("nys-alertClosed", (event) => {
   const { type, label } = event.detail;
   console.log(`Alert closed. Type: ${type}, Label: ${label}`);
-  // Optional: persist dismissal (e.g., to localStorage or analytics)
-  // This can be used to prevent the alert from appearing again
 });
 
 ```

--- a/packages/nys-alert/src/nys-alert.mdx
+++ b/packages/nys-alert/src/nys-alert.mdx
@@ -123,6 +123,27 @@ The `nys-alert` component includes the following accessibility-focused features:
   </tbody>
 </table>
 
+## Events
+
+The `nys-alert` component emits the following events:
+
+1. `nys-alertClosed`: Emitted when the alert is dismissed by the user (e.g. via a close button). This event allows developers to respond to the dismissal — for example, saving the closed state locally to prevent the alert from showing again.
+
+You can listen to these events using JavaScript:
+
+```js
+// Select the alert component
+const alert = document.querySelector("nys-alert");
+
+// Listen for the 'nys-alertClosed' event
+alert.addEventListener("nys-alertClosed", (event) => {
+  const { type, label } = event.detail;
+  console.log(`Alert closed. Type: ${type}, Label: ${label}`);
+  // Optionally save this state to localStorage or analytics
+});
+
+```
+
 ## Dependencies
 This component automatically imports the following dependencies.
 

--- a/packages/nys-button/src/nys-button.mdx
+++ b/packages/nys-button/src/nys-button.mdx
@@ -127,13 +127,14 @@ The `nys-button` component includes the following accessibility-focused features
 - ARIA roles and aria-label attribute: Properly set to ensure screen readers interpret the button correctly. The `aria-label` is automatically set to the label prop if provided, or defaults to "button".
 - Keyboard navigation support, allowing users to use the keyboard to click the button.
 - Visual focus indicators to help users navigate the component.
+
 ## Events
 
 The `nys-button` component emits the following events:
 
-1. `click`: Emitted when the button is clicked.
-2. `focus`: Emitted when the button receives focus.
-3. `blur`: Emitted when the button loses focus.
+1. `nys-click`: Emitted when the button is clicked.
+2. `nys-focus`: Emitted when the button receives focus.
+3. `nys-blur`: Emitted when the button loses focus.
 
 You can listen to these events using JavaScript:
 
@@ -141,18 +142,18 @@ You can listen to these events using JavaScript:
 // Select the button component
 const button = document.querySelector("nys-button");
 
-// Listen for the 'click' event
-button.addEventListener("click", () => {
+// Listen for the 'nys-click' event
+button.addEventListener("nys-click", () => {
 	console.log("Button clicked");
 });
 
-// Listen for the 'focus' event
-button.addEventListener("focus", () => {
+// Listen for the 'nys-focus' event
+button.addEventListener("nys-focus", () => {
 	console.log("Button is focused");
 });
 
-// Listen for the 'blur' event
-button.addEventListener("blur", () => {
+// Listen for the 'nys-blur' event
+button.addEventListener("nys-blur", () => {
 	console.log("Button lost focus");
 });
 ```

--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -138,12 +138,12 @@ export class NysButton extends LitElement {
   /******************** Event Handlers ********************/
   // Handle focus event
   private _handleFocus() {
-    this.dispatchEvent(new Event("focus"));
+    this.dispatchEvent(new Event("nys-focus"));
   }
 
   // Handle blur event
   private _handleBlur() {
-    this.dispatchEvent(new Event("blur"));
+    this.dispatchEvent(new Event("nys-blur"));
   }
 
   private _handleClick(event: Event) {
@@ -152,6 +152,7 @@ export class NysButton extends LitElement {
       return;
     }
     this._manageFormAction(event);
+    this.dispatchEvent(new Event("nys-click"));
   }
 
   // Handle keydown for keyboard accessibility

--- a/packages/nys-checkbox/src/nys-checkbox.mdx
+++ b/packages/nys-checkbox/src/nys-checkbox.mdx
@@ -89,10 +89,9 @@ The `nys-checkbox` component includes the following accessibility-focused featur
 
 The `NysCheckbox` component emits three custom events:
 
-1. **`change`** – Fired when the checkbox state changes (checked/unchecked).
-2. **`focus`** – Fired when the checkbox gains focus.
-3. **`blur`** – Fired when the checkbox loses focus.
-4. **`keydown`** – Fired when a key is pressed while the checkbox is focused.
+1. **`nys-change`** – Fired when the checkbox state changes (checked/unchecked).
+2. **`nys-focus`** – Fired when the checkbox gains focus.
+3. **`nys-blur`** – Fired when the checkbox loses focus.
 
 You can listen to these events using JavaScript:
 
@@ -101,24 +100,19 @@ You can listen to these events using JavaScript:
   // Select the checkbox component
   const checkbox = document.querySelector('nys-checkbox');
 
-  // Listen for the 'change' event
-  checkbox.addEventListener('change', (event) => {
-    console.log('Checkbox changed:', event.target.checked);
+  // Listen for the 'nys-change' event
+  checkbox.addEventListener('nys-change', (event) => {
+    console.log('Checkbox changed:', event.detail.checked);
   });
 
-  // Listen for the 'focus' event
-  checkbox.addEventListener('focus', () => {
+  // Listen for the 'nys-focus' event
+  checkbox.addEventListener('nys-focus', () => {
     console.log('Checkbox is focused');
   });
 
-  // Listen for the 'blur' event
-  checkbox.addEventListener('blur', () => {
+  // Listen for the 'nys-blur' event
+  checkbox.addEventListener('nys-blur', () => {
     console.log('Checkbox lost focus');
-  });
-
-  // Listen for the 'keydown' event
-  checkbox.addEventListener('keydown', (event) => {
-    console.log('Key pressed:', event.key);
   });
 ```
 

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -52,13 +52,13 @@ export class NysCheckboxgroup extends LitElement {
     if (!this.id) {
       this.id = `nys-checkbox-${Date.now()}-${checkboxgroupIdCounter++}`;
     }
-    this.addEventListener("change", this._handleCheckboxChange);
+    this.addEventListener("nys-change", this._handleCheckboxChange);
     this.addEventListener("invalid", this._handleInvalid);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeEventListener("change", this._handleCheckboxChange);
+    this.removeEventListener("nys-change", this._handleCheckboxChange);
     this.removeEventListener("invalid", this._handleInvalid);
   }
 

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -93,43 +93,6 @@ The `nys-radiobutton` component includes the following accessibility-focused fea
 - Keyboard navigation support, allowing users to toggle the radiobutton using the keyboard.
 - Visual focus indicators to help users navigate the component.
 
-## Events
-
-The `NysRadiobutton` component emits four custom events:
-
-1. **`change`** – Fired when the radiobutton state changes (checked/unchecked).
-2. **`focus`** – Fired when the radiobutton gains focus.
-3. **`blur`** – Fired when the radiobutton loses focus.
-4. **`keydown`** – Fired when a key is pressed while the radiobutton is focused.
-
-You can listen to these events using JavaScript:
-
-```js
-
-  // Select the radiobutton component
-  const radiobutton = document.querySelector('nys-radiobutton');
-
-  // Listen for the 'change' event
-  radiobutton.addEventListener('change', (event) => {
-    console.log('Radiobutton changed:', event.target.checked);
-  });
-
-  // Listen for the 'focus' event
-  radiobutton.addEventListener('focus', () => {
-    console.log('Radiobutton is focused');
-  });
-
-  // Listen for the 'blur' event
-  radiobutton.addEventListener('blur', () => {
-    console.log('Radiobutton lost focus');
-  });
-
-  // Listen for the 'keydown' event
-  radiobutton.addEventListener('keydown', (event) => {
-    console.log('Key pressed:', event.key);
-  });
-```
-
 ## Slots
 
 <table>
@@ -148,3 +111,34 @@ You can listen to these events using JavaScript:
     </tr>
     </tbody>
 </table>
+
+## Events
+
+The `NysRadiobutton` component emits the following events:
+
+1. **`nys-change`** – Fired when the radiobutton state changes (checked/unchecked).
+2. **`nys-focus`** – Fired when the radiobutton gains focus.
+3. **`nys-blur`** – Fired when the radiobutton loses focus.
+
+You can listen to these events using JavaScript:
+
+```js
+
+  // Select the radiobutton component
+  const radiobutton = document.querySelector('nys-radiobutton');
+
+  // Listen for the 'nys-change' event
+  radiobutton.addEventListener('nys-change', (event) => {
+    console.log('Radiobutton changed:', event.detail.checked);
+  });
+
+  // Listen for the 'nys-focus' event
+  radiobutton.addEventListener('nys-focus', () => {
+    console.log('Radiobutton is focused');
+  });
+
+  // Listen for the 'nys-blur' event
+  radiobutton.addEventListener('nys-blur', () => {
+    console.log('Radiobutton lost focus');
+  });
+```

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -94,6 +94,20 @@ export class NysRadiobutton extends LitElement {
   }
 
   /******************** Event Handlers ********************/
+  private _emitChangeEvent() {
+    this.dispatchEvent(
+      new CustomEvent("nys-change", {
+        detail: {
+          checked: this.checked,
+          name: this.name,
+          value: this.value,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
   // Handle radiobutton change event & unselection of other options in group
   private _handleChange() {
     if (!this.checked) {
@@ -106,24 +120,18 @@ export class NysRadiobutton extends LitElement {
       this.checked = true;
 
       // Dispatch a change event with the name and value
-      this.dispatchEvent(
-        new CustomEvent("change", {
-          detail: { checked: this.checked, name: this.name, value: this.value },
-          bubbles: true,
-          composed: true,
-        }),
-      );
+      this._emitChangeEvent();
     }
   }
 
   // Handle focus event
   private _handleFocus() {
-    this.dispatchEvent(new Event("focus"));
+    this.dispatchEvent(new Event("nys-focus"));
   }
 
   // Handle blur event
   private _handleBlur() {
-    this.dispatchEvent(new Event("blur"));
+    this.dispatchEvent(new Event("nys-blur"));
   }
 
   // Handle keydown for keyboard accessibility
@@ -138,17 +146,7 @@ export class NysRadiobutton extends LitElement {
 
         NysRadiobutton.buttonGroup[this.name] = this;
         this.checked = true;
-        this.dispatchEvent(
-          new CustomEvent("change", {
-            detail: {
-              checked: this.checked,
-              name: this.name,
-              value: this.value,
-            },
-            bubbles: true,
-            composed: true,
-          }),
-        );
+        this._emitChangeEvent();
       }
     }
   }

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -53,13 +53,13 @@ export class NysRadiogroup extends LitElement {
     if (!this.id) {
       this.id = `nys-radiogroup-${Date.now()}-${radiogroupIdCounter++}`;
     }
-    this.addEventListener("change", this._handleRadioButtonChange);
+    this.addEventListener("nys-change", this._handleRadioButtonChange);
     this.addEventListener("invalid", this._handleInvalid);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeEventListener("change", this._handleRadioButtonChange);
+    this.removeEventListener("nys-change", this._handleRadioButtonChange);
     this.removeEventListener("invalid", this._handleInvalid);
   }
 

--- a/packages/nys-select/src/nys-select.mdx
+++ b/packages/nys-select/src/nys-select.mdx
@@ -80,37 +80,6 @@ The `nys-select` component includes the following accessibility-focused features
 - Keyboard navigation support, allowing users to tab to the `<nys-select>` using the keyboard and spacebar to select an option.
 - Visual focus indicators to help users navigate the component.
 
-## Events
-The `nys-select` component emits the following events:
-
-1. **`change`**: Emitted when the value of the select changes. The event detail includes the value of the selected option.
-2. **`focus`**: Emitted when the select gains focus.
-3. **`blur`**: Emitted when the select loses focus.
-
-You can listen for these events using the `addEventListener` method on the `nys-select` element.
-
-```js
-
-//Select the select component
-const select = document.querySelector('nys-select');
-
-//Listen for the 'change' event
-select.addEventListener('change', (event) => {
-  console.log('Select changed:', event.target.value);
-});
-
-//Listen for the 'focus' event
-select.addEventListener('focus', () => {
-  console.log('Select is focused');
-});
-
-//Listen for the 'blur' event
-select.addEventListener('blur', () => {
-  console.log('Select lost focus');
-});
-
-```
-
 ## Slots
 
 The `nys-select` component supports the following slots:
@@ -138,6 +107,37 @@ The `nys-select` component supports the following slots:
     </tr>
     </tbody>
 </table>
+
+## Events
+The `nys-select` component emits the following events:
+
+1. **`nys-change`**: Emitted when the value of the select changes. The event detail includes the value of the selected option.
+2. **`nys-focus`**: Emitted when the select gains focus.
+3. **`nys-blur`**: Emitted when the select loses focus.
+
+You can listen for these events using the `addEventListener` method on the `nys-select` element.
+
+```js
+
+//Select the select component
+const select = document.querySelector('nys-select');
+
+//Listen for the 'nys-change' event
+select.addEventListener('nys-change', (event) => {
+  console.log('Select changed:', event.target.value);
+});
+
+//Listen for the 'focus' event
+select.addEventListener('nys-focus', () => {
+  console.log('Select is focused');
+});
+
+//Listen for the 'nys-blur' event
+select.addEventListener('nys-blur', () => {
+  console.log('Select lost focus');
+});
+
+```
 
 ## Dependencies
 This component automatically imports the following dependencies.

--- a/packages/nys-select/src/nys-select.mdx
+++ b/packages/nys-select/src/nys-select.mdx
@@ -124,7 +124,7 @@ const select = document.querySelector('nys-select');
 
 //Listen for the 'nys-change' event
 select.addEventListener('nys-change', (event) => {
-  console.log('Select changed:', event.target.value);
+  console.log('Select changed:', event.detail.value);
 });
 
 //Listen for the 'focus' event

--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -167,11 +167,11 @@ export const DescriptionSlot: Story = {
       .errorMessage=${args.errorMessage}
     >
       <label slot="description">${args.description}</label>
-      <option value="bronx">The Bronx</option>
-      <option value="brooklyn">Brooklyn</option>
-      <option value="manhattan">Manhattan</option>
-      <option value="staten_island">Staten Island</option>
-      <option value="queens">Queens</option>
+      <nys-option value="bronx">The Bronx</nys-option>
+      <nys-option value="brooklyn">Brooklyn</nys-option>
+      <nys-option value="manhattan">Manhattan</nys-option>
+      <nys-option value="staten_island">Staten Island</nys-option>
+      <nys-option value="queens">Queens</nys-option>
     </nys-select>
   `,
   parameters: {
@@ -180,11 +180,11 @@ export const DescriptionSlot: Story = {
         code: `
 <nys-select label="Select your favorite borough">
   <label slot="description">This is a slot</label>
-  <option value="bronx">The Bronx</option>
-  <option value="brooklyn">Brooklyn</option>
-  <option value="manhattan">Manhattan</option>
-  <option value="staten_island">Staten Island</option>
-  <option value="queens">Queens</option>        
+  <nys-option value="bronx">The Bronx</nys-option>
+  <nys-option value="brooklyn">Brooklyn</nys-option>
+  <nys-option value="manhattan">Manhattan</nys-option>
+  <nys-option value="staten_island">Staten Island</nys-option>
+  <nys-option value="queens">Queens</nys-option>        
 </nys-select>`,
         type: "auto",
       },

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -214,14 +214,9 @@ export class NysSelect extends LitElement {
     );
   }
 
-  // Handle input changes by update the value as select changes
-  private _handleInput() {
-    this.dispatchEvent(new Event("input"));
-  }
-
   // Handle focus event
   private _handleFocus() {
-    this.dispatchEvent(new Event("focus"));
+    this.dispatchEvent(new Event("nys-focus"));
   }
 
   // Handle blur event
@@ -230,7 +225,7 @@ export class NysSelect extends LitElement {
       this._hasUserInteracted = true;
     }
     this._validate();
-    this.dispatchEvent(new Event("blur"));
+    this.dispatchEvent(new Event("nys-blur"));
   }
 
   // Check if the current value matches any option, and if so, set it as selected
@@ -272,7 +267,6 @@ export class NysSelect extends LitElement {
             @focus="${this._handleFocus}"
             @blur="${this._handleBlur}"
             @change="${this._handleChange}"
-            @input="${this._handleInput}"
           >
             <option hidden disabled selected value></option>
           </select>

--- a/packages/nys-skipnav/src/nys-skipnav.ts
+++ b/packages/nys-skipnav/src/nys-skipnav.ts
@@ -24,18 +24,14 @@ export class NysSkipnav extends LitElement {
   /**************** Event Handlers ****************/
   private _handleFocus() {
     const linkElement = this.shadowRoot?.querySelector(".nys-skipnav__link");
-    this.dispatchEvent(new Event("focus"));
 
     linkElement?.classList.add("show");
   }
 
   private _handleBlur() {
     const linkElement = this.shadowRoot?.querySelector(".nys-skipnav__link");
-    this.dispatchEvent(new Event("blur"));
 
-    // if (!this.demoVisible) {
-    linkElement?.classList.remove("show"); // Link is hidden whenever not focused unless the demoVisible is true (aka we're showing it for reference sites)
-    //}
+    linkElement?.classList.remove("show"); // Link is hidden whenever not focused
   }
 
   private _handleClick() {

--- a/packages/nys-textarea/src/nys-textarea.mdx
+++ b/packages/nys-textarea/src/nys-textarea.mdx
@@ -92,9 +92,10 @@ The `nys-textarea` component includes the following accessibility-focused featur
 
 The `nys-textarea` component emits the following events:
 
-1. **`input`** – Fired when the input text changes.
-2. **`focus`** – Fired when the input gains focus.
-3. **`blur`** – Fired when the input loses focus.
+1. **`nys-input`** – Fired when the input text changes.
+2. **`nys-focus`** – Fired when the input gains focus.
+3. **`nys-blur`** – Fired when the input loses focus.
+4. **`nys-select`** – Fired when the user selects text within the textarea.
 
 You can listen to these events using JavaScript:
 
@@ -103,18 +104,23 @@ You can listen to these events using JavaScript:
 // Select the textarea component
 const textarea = document.querySelector('nys-textarea');
 
-// Listen for the 'input' event
-textarea.addEventListener('input', (event) => {
-  console.log('Text input changed:', event.target.value);
+// Listen for the 'nys-input' event
+textarea.addEventListener('nys-input', (event) => {
+  console.log('Text input changed:', event.detail.value);
 });
 
-// Listen for the 'focus' event
-textarea.addEventListener('focus', () => {
+// Listen for the 'nys-focus' event
+textarea.addEventListener('nys-focus', () => {
   console.log('Text input is focused');
 });
 
-// Listen for the 'blur' event
-textarea.addEventListener('blur', () => {
+// Listen for the 'nys-blur' event
+textarea.addEventListener('nys-blur', () => {
   console.log('Text input is blurred');
+});
+
+// Listen for the 'nys-select' event
+textarea.addEventListener('nys-select', (event) => {
+  console.log('Text selected:', event.detail.value);
 });
 ```

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -197,7 +197,7 @@ export class NysTextarea extends LitElement {
     }
 
     this.dispatchEvent(
-      new CustomEvent("input", {
+      new CustomEvent("nys-input", {
         detail: { value: this.value },
         bubbles: true,
         composed: true,
@@ -207,7 +207,7 @@ export class NysTextarea extends LitElement {
 
   // Handle focus event
   private _handleFocus() {
-    this.dispatchEvent(new Event("focus"));
+    this.dispatchEvent(new Event("nys-focus"));
   }
 
   // Handle blur event
@@ -217,19 +217,14 @@ export class NysTextarea extends LitElement {
     }
 
     this._validate();
-    this.dispatchEvent(new Event("blur"));
-  }
-
-  // Handle change event to bubble up selected value
-  private _handleChange() {
-    this.dispatchEvent(new Event("change"));
+    this.dispatchEvent(new Event("nys-blur"));
   }
 
   private _handleSelect(e: Event) {
     const select = e.target as HTMLSelectElement;
     this.value = select.value;
     this.dispatchEvent(
-      new CustomEvent("select", {
+      new CustomEvent("nys-select", {
         detail: { value: this.value },
         bubbles: true,
         composed: true,
@@ -280,7 +275,6 @@ export class NysTextarea extends LitElement {
           @input=${this._handleInput}
           @focus="${this._handleFocus}"
           @blur="${this._handleBlur}"
-          @change="${this._handleChange}"
           @select="${this._handleSelect}"
           @selectionchange="${this._handleSelectionChange}"
         >

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -103,9 +103,9 @@ The `nys-textinput` component includes the following accessibility-focused featu
 
 The `nys-textinput` component emits the following events:
 
-1. **`nys-checkValidity`** – Fired when the input text changes.
-2. **`focus`** – Fired when the input gains focus.
-3. **`blur`** – Fired when the input loses focus.
+1. **`nys-input`** – Fired when the input text changes.
+2. **`nys-focus`** – Fired when the input gains focus.
+3. **`nys-blur`** – Fired when the input loses focus.
 
 You can listen to these events using JavaScript:
 
@@ -114,18 +114,18 @@ You can listen to these events using JavaScript:
 // Select the textinput component
 const textinput = document.querySelector('nys-textinput');
 
-// Listen for the 'input' event
-textinput.addEventListener('input', (event) => {
+// Listen for the 'nys-input' event
+textinput.addEventListener('nys-input', (event) => {
   console.log('Text input changed:', event.target.value);
 });
 
-// Listen for the 'focus' event
-textinput.addEventListener('focus', () => {
+// Listen for the 'nys-focus' event
+textinput.addEventListener('nys-focus', () => {
   console.log('Text input is focused');
 });
 
-// Listen for the 'blur' event
-textinput.addEventListener('blur', () => {
+// Listen for the 'nys-blur' event
+textinput.addEventListener('nys-blur', () => {
   console.log('Text input is blurred');
 });
 ```

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -116,7 +116,7 @@ const textinput = document.querySelector('nys-textinput');
 
 // Listen for the 'nys-input' event
 textinput.addEventListener('nys-input', (event) => {
-  console.log('Text input changed:', event.target.value);
+  console.log('Text input changed:', event.detail.value);
 });
 
 // Listen for the 'nys-focus' event

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -244,7 +244,7 @@ export class NysTextinput extends LitElement {
     }
 
     this.dispatchEvent(
-      new CustomEvent("input", {
+      new CustomEvent("nys-input", {
         detail: { value: this.value },
         bubbles: true,
         composed: true,
@@ -254,7 +254,7 @@ export class NysTextinput extends LitElement {
 
   // Handle focus event
   private _handleFocus() {
-    this.dispatchEvent(new Event("focus"));
+    this.dispatchEvent(new Event("nys-focus"));
   }
 
   // Handle blur event
@@ -264,12 +264,7 @@ export class NysTextinput extends LitElement {
     }
     this._validate();
 
-    this.dispatchEvent(new Event("blur"));
-  }
-
-  // Handle change event
-  private _handleChange() {
-    this.dispatchEvent(new Event("change"));
+    this.dispatchEvent(new Event("nys-blur"));
   }
 
   private _validateButtonSlot(slotName: string) {
@@ -369,7 +364,6 @@ export class NysTextinput extends LitElement {
               @input=${this._handleInput}
               @focus="${this._handleFocus}"
               @blur="${this._handleBlur}"
-              @change="${this._handleChange}"
             />
             ${this.type === "password"
               ? html` <nys-button

--- a/packages/nys-toggle/src/nys-toggle.mdx
+++ b/packages/nys-toggle/src/nys-toggle.mdx
@@ -121,7 +121,7 @@ You can listen to these events using JavaScript:
 
   // Listen for the 'nys-change' event
   toggle.addEventListener('nys-change', (event) => {
-    console.log('Checkbox changed:', event.target.checked);
+    console.log('Checkbox changed:', event.detail.checked);
   });
 
   // Listen for the 'nys-focus' event

--- a/packages/nys-toggle/src/nys-toggle.mdx
+++ b/packages/nys-toggle/src/nys-toggle.mdx
@@ -75,42 +75,6 @@ To remove icons from the toggle switch, use the `NoIcons` boolean property.
 ## Form Prop
 The form attribute associates the `nys-toggle` component with a specific `<form>` element, regardless of its location on the page. This ensures that the toggle's state is included in the form submission, whether it is inside the `<form>` element or outside it.
 
-## Events
-The `<nys-toggle>` component emits three custom Javascript events:
-
-1. **`change`** – Fired when the toggle state changes (checked/unchecked).
-2. **`focus`** – Fired when the toggle gains focus.
-3. **`blur`** – Fired when the toggle loses focus.
-4. **`keydown`** – Fired when a key is pressed while the toggle is focused.
-
-You can listen to these events using JavaScript:
-
-```js
-
-  // Select the toggle component
-  const toggle = document.querySelector('nys-toggle');
-
-  // Listen for the 'change' event
-  toggle.addEventListener('change', (event) => {
-    console.log('Checkbox changed:', event.target.checked);
-  });
-
-  // Listen for the 'focus' event
-  toggle.addEventListener('focus', () => {
-    console.log('Checkbox is focused');
-  });
-
-  // Listen for the 'blur' event
-  toggle.addEventListener('blur', () => {
-    console.log('Checkbox lost focus');
-  });
-
-  // Listen for the 'keydown' event
-  toggle.addEventListener('keydown', (event) => {
-    console.log('Key pressed:', event.key);
-  });
-```
-
 ## Accessibility
 
 The `nys-toggle` component includes the following accessibility-focused features:
@@ -140,3 +104,33 @@ Include a label property to provide accessible text for screen readers.
     </tr>
     </tbody>
 </table>
+
+## Events
+The `<nys-toggle>` component emits the following events:
+
+1. **`nys-change`** – Fired when the toggle state changes (checked/unchecked).
+2. **`nys-focus`** – Fired when the toggle gains focus.
+3. **`nys-blur`** – Fired when the toggle loses focus.
+
+You can listen to these events using JavaScript:
+
+```js
+
+  // Select the toggle component
+  const toggle = document.querySelector('nys-toggle');
+
+  // Listen for the 'nys-change' event
+  toggle.addEventListener('nys-change', (event) => {
+    console.log('Checkbox changed:', event.target.checked);
+  });
+
+  // Listen for the 'nys-focus' event
+  toggle.addEventListener('nys-focus', () => {
+    console.log('Checkbox is focused');
+  });
+
+  // Listen for the 'nys-blur' event
+  toggle.addEventListener('nys-blur', () => {
+    console.log('Checkbox lost focus');
+  });
+```

--- a/packages/nys-toggle/src/nys-toggle.ts
+++ b/packages/nys-toggle/src/nys-toggle.ts
@@ -64,27 +64,31 @@ export class NysToggle extends LitElement {
     }
   }
 
-  /********************** Functions **********************/
-  // Handle focus event
-  private _handleFocus() {
-    this.dispatchEvent(new Event("focus"));
-  }
-
-  // Handle blur event
-  private _handleBlur() {
-    this.dispatchEvent(new Event("blur"));
-  }
-
-  private _handleChange(e: Event) {
-    const { checked } = e.target as HTMLInputElement;
-    this.checked = checked;
+  /********************** Event Handlers **********************/
+  private _emitChangeEvent() {
     this.dispatchEvent(
-      new CustomEvent("change", {
+      new CustomEvent("nys-change", {
         detail: { checked: this.checked },
         bubbles: true,
         composed: true,
       }),
     );
+  }
+
+  // Handle focus event
+  private _handleFocus() {
+    this.dispatchEvent(new Event("nys-focus"));
+  }
+
+  // Handle blur event
+  private _handleBlur() {
+    this.dispatchEvent(new Event("nys-blur"));
+  }
+
+  private _handleChange(e: Event) {
+    const { checked } = e.target as HTMLInputElement;
+    this.checked = checked;
+    this._emitChangeEvent();
   }
 
   private _handleKeyDown(event: KeyboardEvent) {
@@ -97,13 +101,7 @@ export class NysToggle extends LitElement {
       /* Dispatch a custom event for the toggle action:
        * allows bubbling up so if developers wish to use the toggle state info.
        */
-      this.dispatchEvent(
-        new CustomEvent("change", {
-          detail: { checked: this.checked },
-          bubbles: true,
-          composed: true,
-        }),
-      );
+      this._emitChangeEvent();
     }
   }
 

--- a/templates/mdx.template.hbs
+++ b/templates/mdx.template.hbs
@@ -60,6 +60,24 @@ The `nys-{{componentName}}` component includes the following accessibility-focus
 - TODO: Add accessibility features
 - TODO: Add accessibility features
 
+## Slots
+<table>
+    <thead>
+    <tr>
+        <th>Slot name</th>
+        <th>Description</th>
+        <th>Default value</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>`description`</td>
+        <td>Description text for either `nys-component` or `nys-component`</td>
+        <td>none</td>
+    </tr>
+    </tbody>
+</table>
+
 ## Events
 
 The `nys-{{componentName}}` component emits the following events:


### PR DESCRIPTION
# Summary

Fix storybook events documentation, code revision for dispatch events switch to have prefix `nys-` and fix issue with checkbox keydown validation.

## Breaking change
This is **not** a breaking change.  

## Related issues

- PR Closes #623 
- PR Closes #617 

## Major changes
- **Modified components**: mainly `nys-checkbox` validation bug + event update on most components
- **Documentation updates**: Storybook's event section

## Testing and review

Tested on [React Demo](https://github.com/ITS-HCD/nysds-react-demo) repo.