### PR TITLE
Fix: Button - height overflow when text longer than parent container

### DIFF
--- a/packages/nys-button/src/nys-button.styles.ts
+++ b/packages/nys-button/src/nys-button.styles.ts
@@ -328,7 +328,7 @@ export default css`
 
   .nys-button {
     width: var(--_nys-button-width);
-    height: var(--_nys-button-height);
+    min-height: var(--_nys-button-height);
     /* set every corner individually */
     border-top-left-radius: var(--_nys-button-radius-left);
     border-bottom-left-radius: var(--_nys-button-radius-left);


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/a33a38ab-b690-41ea-93c4-17ee97974c21)

after:
![image](https://github.com/user-attachments/assets/602cb05b-fa6e-4b8c-a52c-2de352390a46)

the button width is determined by the text inside but if the text is wider than the parent container holding the button the text will wrap, but the height of the button will not accommodate that. By changing the button height to min-height the button can grow in height in these edge cases.