### PR TITLE
re-configure imports, cut file size to 380KB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,6 +1103,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1111,6 +1124,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
+      "integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1442,9 +1468,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz",
-      "integrity": "sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
+      "integrity": "sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==",
       "cpu": [
         "arm"
       ],
@@ -1456,9 +1482,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.0.tgz",
-      "integrity": "sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.1.tgz",
+      "integrity": "sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==",
       "cpu": [
         "arm64"
       ],
@@ -1470,9 +1496,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.0.tgz",
-      "integrity": "sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.1.tgz",
+      "integrity": "sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==",
       "cpu": [
         "arm64"
       ],
@@ -1484,9 +1510,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.0.tgz",
-      "integrity": "sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.1.tgz",
+      "integrity": "sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==",
       "cpu": [
         "x64"
       ],
@@ -1498,9 +1524,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.0.tgz",
-      "integrity": "sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.1.tgz",
+      "integrity": "sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==",
       "cpu": [
         "arm64"
       ],
@@ -1512,9 +1538,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.0.tgz",
-      "integrity": "sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.1.tgz",
+      "integrity": "sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==",
       "cpu": [
         "x64"
       ],
@@ -1526,9 +1552,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.0.tgz",
-      "integrity": "sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.1.tgz",
+      "integrity": "sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==",
       "cpu": [
         "arm"
       ],
@@ -1540,9 +1566,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.0.tgz",
-      "integrity": "sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.1.tgz",
+      "integrity": "sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==",
       "cpu": [
         "arm"
       ],
@@ -1554,9 +1580,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.0.tgz",
-      "integrity": "sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.1.tgz",
+      "integrity": "sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==",
       "cpu": [
         "arm64"
       ],
@@ -1568,9 +1594,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.0.tgz",
-      "integrity": "sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.1.tgz",
+      "integrity": "sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==",
       "cpu": [
         "arm64"
       ],
@@ -1582,9 +1608,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.0.tgz",
-      "integrity": "sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.1.tgz",
+      "integrity": "sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==",
       "cpu": [
         "loong64"
       ],
@@ -1596,9 +1622,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.0.tgz",
-      "integrity": "sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.1.tgz",
+      "integrity": "sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==",
       "cpu": [
         "ppc64"
       ],
@@ -1610,9 +1636,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.0.tgz",
-      "integrity": "sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.1.tgz",
+      "integrity": "sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==",
       "cpu": [
         "riscv64"
       ],
@@ -1624,9 +1650,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.0.tgz",
-      "integrity": "sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.1.tgz",
+      "integrity": "sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==",
       "cpu": [
         "riscv64"
       ],
@@ -1638,9 +1664,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.0.tgz",
-      "integrity": "sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.1.tgz",
+      "integrity": "sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==",
       "cpu": [
         "s390x"
       ],
@@ -1652,9 +1678,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
-      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz",
+      "integrity": "sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==",
       "cpu": [
         "x64"
       ],
@@ -1666,9 +1692,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.0.tgz",
-      "integrity": "sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.1.tgz",
+      "integrity": "sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==",
       "cpu": [
         "x64"
       ],
@@ -1680,9 +1706,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.0.tgz",
-      "integrity": "sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.1.tgz",
+      "integrity": "sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==",
       "cpu": [
         "arm64"
       ],
@@ -1694,9 +1720,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.0.tgz",
-      "integrity": "sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.1.tgz",
+      "integrity": "sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==",
       "cpu": [
         "ia32"
       ],
@@ -1708,9 +1734,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.0.tgz",
-      "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.1.tgz",
+      "integrity": "sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==",
       "cpu": [
         "x64"
       ],
@@ -2122,9 +2148,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2746,6 +2772,46 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/dev-server-rollup/node_modules/rollup": {
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
+      "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.44.1",
+        "@rollup/rollup-android-arm64": "4.44.1",
+        "@rollup/rollup-darwin-arm64": "4.44.1",
+        "@rollup/rollup-darwin-x64": "4.44.1",
+        "@rollup/rollup-freebsd-arm64": "4.44.1",
+        "@rollup/rollup-freebsd-x64": "4.44.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.44.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.44.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.44.1",
+        "@rollup/rollup-linux-arm64-musl": "4.44.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.44.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.44.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.44.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.44.1",
+        "@rollup/rollup-linux-x64-gnu": "4.44.1",
+        "@rollup/rollup-linux-x64-musl": "4.44.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.44.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.44.1",
+        "@rollup/rollup-win32-x64-msvc": "4.44.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/@web/parse5-utils": {
@@ -3468,6 +3534,15 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -11593,42 +11668,20 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.0.tgz",
-      "integrity": "sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.7"
-      },
+      "optional": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.40.0",
-        "@rollup/rollup-android-arm64": "4.40.0",
-        "@rollup/rollup-darwin-arm64": "4.40.0",
-        "@rollup/rollup-darwin-x64": "4.40.0",
-        "@rollup/rollup-freebsd-arm64": "4.40.0",
-        "@rollup/rollup-freebsd-x64": "4.40.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.40.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.40.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.40.0",
-        "@rollup/rollup-linux-arm64-musl": "4.40.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.40.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.40.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.40.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.40.0",
-        "@rollup/rollup-linux-x64-gnu": "4.40.0",
-        "@rollup/rollup-linux-x64-musl": "4.40.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.40.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.40.0",
-        "@rollup/rollup-win32-x64-msvc": "4.40.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -12041,6 +12094,31 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12505,6 +12583,36 @@
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.43.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/text-decoder": {
       "version": "1.2.3",
@@ -13056,6 +13164,46 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
+      "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.44.1",
+        "@rollup/rollup-android-arm64": "4.44.1",
+        "@rollup/rollup-darwin-arm64": "4.44.1",
+        "@rollup/rollup-darwin-x64": "4.44.1",
+        "@rollup/rollup-freebsd-arm64": "4.44.1",
+        "@rollup/rollup-freebsd-x64": "4.44.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.44.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.44.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.44.1",
+        "@rollup/rollup-linux-arm64-musl": "4.44.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.44.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.44.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.44.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.44.1",
+        "@rollup/rollup-linux-x64-gnu": "4.44.1",
+        "@rollup/rollup-linux-x64-musl": "4.44.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.44.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.44.1",
+        "@rollup/rollup-win32-x64-msvc": "4.44.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/packages/nys-alert/src/nys-alert.stories.ts
+++ b/packages/nys-alert/src/nys-alert.stories.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-alert";
 import "@nysds/nys-button";
+import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysAlertArgs {

--- a/packages/nys-alert/src/nys-alert.test.ts
+++ b/packages/nys-alert/src/nys-alert.test.ts
@@ -1,6 +1,8 @@
 import { expect, html, fixture } from "@open-wc/testing";
 import { NysAlert } from "./nys-alert";
 import "../dist/nys-alert.js";
+import "@nysds/nys-button";
+import "@nysds/nys-icon";
 
 describe("nys-alert", () => {
   it("should have default type as base", async () => {

--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -3,7 +3,6 @@ import { property, state } from "lit/decorators.js";
 import styles from "./nys-alert.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-
 let alertIdCounter = 0; // Counter for generating unique IDs
 
 export class NysAlert extends LitElement {

--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -2,8 +2,7 @@ import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import styles from "./nys-alert.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
-import "@nysds/nys-icon";
-import "@nysds/nys-button";
+
 
 let alertIdCounter = 0; // Counter for generating unique IDs
 

--- a/packages/nys-avatar/src/nys-avatar.ts
+++ b/packages/nys-avatar/src/nys-avatar.ts
@@ -1,6 +1,5 @@
 import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
-import "@nysds/nys-icon";
 import styles from "./nys-avatar.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
 

--- a/packages/nys-backtotop/src/nys-backtotop.stories.ts
+++ b/packages/nys-backtotop/src/nys-backtotop.stories.ts
@@ -5,6 +5,7 @@ import "@nysds/nys-unavheader";
 import "@nysds/nys-globalheader";
 import "@nysds/nys-unavfooter";
 import "@nysds/nys-button";
+import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysBacktotopArgs {

--- a/packages/nys-backtotop/src/nys-backtotop.ts
+++ b/packages/nys-backtotop/src/nys-backtotop.ts
@@ -1,7 +1,6 @@
 import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import styles from "./nys-backtotop.styles";
-import "@nysds/nys-button";
 
 export class NysBacktotop extends LitElement {
   @property({ type: String }) position = "right";

--- a/packages/nys-button/src/nys-button.stories.ts
+++ b/packages/nys-button/src/nys-button.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-button";
+import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysButtonArgs {

--- a/packages/nys-button/src/nys-button.test.ts
+++ b/packages/nys-button/src/nys-button.test.ts
@@ -1,6 +1,7 @@
 import { expect, html, fixture, oneEvent } from "@open-wc/testing";
 import { NysButton } from "./nys-button";
 import "../dist/nys-button.js";
+import "@nysds/nys-icon";
 
 describe("nys-button", () => {
   it("should have default type as button", async () => {
@@ -114,6 +115,18 @@ describe("nys-button", () => {
     );
     expect(prefixIcon).to.exist;
     expect(suffixIcon).to.exist;
+  });
+
+  it(" should allow for the button to be slotted in", async () => {
+    const el = await fixture<NysButton>(
+      html`<nys-button suffixIcon="slotted" size="sm">
+        <nys-icon slot="suffix-icon" size="2xl" name="visibility"></nys-icon>
+      </nys-button>`,
+    );
+    const prefixIcon = el.querySelector("nys-icon[name='visibility']");
+
+    expect(el.prefixIcon).to.exist;
+    expect(prefixIcon).to.exist;
   });
 
   it("should dispatch focus and blur events", async () => {

--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -1,7 +1,6 @@
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import styles from "./nys-button.styles";
-import "@nysds/nys-icon";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 let buttonIdCounter = 0; // Counter for generating unique IDs

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -1,6 +1,9 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-checkbox";
+import "@nysds/nys-label";
+import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysCheckboxArgs {

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -2,7 +2,6 @@ import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import styles from "./nys-checkbox.styles";
-import "@nysds/nys-icon";
 import "./nys-checkboxgroup";
 
 let checkboxIdCounter = 0; // Counter for generating unique IDs

--- a/packages/nys-errormessage/src/nys-errormessage.test.ts
+++ b/packages/nys-errormessage/src/nys-errormessage.test.ts
@@ -1,4 +1,20 @@
-/*** Accessibility tests ***/
-/*
- * Ensure that the <errormessage> is readable for screen readers.
- */
+import { expect, html, fixture } from "@open-wc/testing";
+import "../dist/nys-errormessage.js";
+import { NysErrorMessage } from "./nys-errormessage.js";
+
+// Below are placeholder examples of test cases for a web component. Add your own tests as needed.
+describe("nys-errormessage", () => {
+  it("renders the component", async () => {
+    const el = await fixture<NysErrorMessage>(
+      html`<nys-errormessage></nys-errormessage>`,
+    );
+    expect(el).to.exist;
+  });
+
+  it("passes the a11y audit", async () => {
+    const el = await fixture(
+      html`<nys-errormessage label="My Label"></nys-errormessage>`,
+    );
+    await expect(el).shadowDom.to.be.accessible();
+  });
+});

--- a/packages/nys-errormessage/src/nys-errormessage.ts
+++ b/packages/nys-errormessage/src/nys-errormessage.ts
@@ -1,7 +1,6 @@
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import styles from "./nys-errormessage.styles";
-import "@nysds/nys-icon";
 
 export class NysErrorMessage extends LitElement {
   @property({ type: Boolean }) showError = false;

--- a/packages/nys-globalheader/src/nys-globalheader.stories.ts
+++ b/packages/nys-globalheader/src/nys-globalheader.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-globalheader";
+import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysGlobalHeaderArgs {

--- a/packages/nys-globalheader/src/nys-globalheader.ts
+++ b/packages/nys-globalheader/src/nys-globalheader.ts
@@ -1,7 +1,6 @@
 import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import styles from "./nys-globalheader.styles";
-import "@nysds/nys-icon";
 
 export class NysGlobalHeader extends LitElement {
   static styles = styles;

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -1,7 +1,8 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-radiobutton";
-
+import "@nysds/nys-label";
+import "@nysds/nys-errormessage";
 // Define the structure of the args used in the stories
 interface NysRadiobuttonArgs {
   //radiobutton

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -2,7 +2,6 @@ import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import styles from "./nys-radiobutton.styles";
 
-
 let radiogroupIdCounter = 0; // Counter for generating unique IDs
 
 export class NysRadiogroup extends LitElement {

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -1,8 +1,7 @@
 import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import styles from "./nys-radiobutton.styles";
-import "@nysds/nys-label";
-import "@nysds/nys-errormessage";
+
 
 let radiogroupIdCounter = 0; // Counter for generating unique IDs
 

--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -1,6 +1,8 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-select";
+import "@nysds/nys-label";
+import "@nysds/nys-errormessage";
 
 // Define the structure of the args used in the stories
 interface NysSelectArgs {

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -3,7 +3,6 @@ import { property } from "lit/decorators.js";
 import styles from "./nys-select.styles";
 import { NysOption } from "./nys-option";
 
-
 let selectIdCounter = 0; // Counter for generating unique IDs
 
 export class NysSelect extends LitElement {

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -2,9 +2,7 @@ import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import styles from "./nys-select.styles";
 import { NysOption } from "./nys-option";
-import "@nysds/nys-icon";
-import "@nysds/nys-label";
-import "@nysds/nys-errormessage";
+
 
 let selectIdCounter = 0; // Counter for generating unique IDs
 

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -1,6 +1,8 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-textarea";
+import "@nysds/nys-label";
+import "@nysds/nys-errormessage";
 
 // Define the structure of the args used in the stories
 interface NysTextareaArgs {

--- a/packages/nys-textarea/src/nys-textarea.test.ts
+++ b/packages/nys-textarea/src/nys-textarea.test.ts
@@ -1,6 +1,8 @@
 import { expect, html, fixture } from "@open-wc/testing";
 import { NysTextarea } from "./nys-textarea";
 import "../dist/nys-textarea.js";
+import "@nysds/nys-label";
+import "@nysds/nys-errormessage";
 
 describe("nys-textarea", () => {
   it("renders the component with default attributes", async () => {

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -3,7 +3,6 @@ import { property } from "lit/decorators.js";
 import styles from "./nys-textarea.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-
 let textareaIdCounter = 0; // Counter for generating unique IDs
 
 export class NysTextarea extends LitElement {

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -2,9 +2,7 @@ import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import styles from "./nys-textarea.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
-import "@nysds/nys-icon";
-import "@nysds/nys-label";
-import "@nysds/nys-errormessage";
+
 
 let textareaIdCounter = 0; // Counter for generating unique IDs
 

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -1,6 +1,8 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-textinput";
+import "@nysds/nys-label";
+import "@nysds/nys-errormessage";
 
 // Define the structure of the args used in the stories
 interface NysTextinputArgs {

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -3,6 +3,8 @@ import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-textinput";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-button";
+import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysTextinputArgs {

--- a/packages/nys-textinput/src/nys-textinput.test.ts
+++ b/packages/nys-textinput/src/nys-textinput.test.ts
@@ -1,7 +1,10 @@
 import { expect, html, fixture } from "@open-wc/testing";
 import { NysTextinput } from "./nys-textinput";
 import "../dist/nys-textinput.js";
-
+import "@nysds/nys-label";
+import "@nysds/nys-errormessage";
+import "@nysds/nys-button";
+import "@nysds/nys-icon";
 /**
  * Test Tips (Official WTR Doc): Defaults, interactivity, customization, and accessibility, form a great baseline for testing most web UI.
  * When testing web UI it is important to think of your test inputs as a future visitor interacting with your web component or a future developer building with your web component.

--- a/packages/nys-textinput/src/nys-textinput.test.ts
+++ b/packages/nys-textinput/src/nys-textinput.test.ts
@@ -94,6 +94,58 @@ describe("nys-textinput", () => {
     );
   });
 
+  it("falls back to type text if invalid type is provided", async () => {
+    const el = await fixture<NysTextinput>(
+      html`<nys-textinput type="invalid"></nys-textinput>`,
+    );
+    expect(el.type).to.equal("text");
+    const input = el.shadowRoot?.querySelector("input");
+    expect(input?.type).to.equal("text");
+  });
+
+  it("falls back to width full if invalid width is set", async () => {
+    const el = await fixture<NysTextinput>(
+      html`<nys-textinput width="invalid"></nys-textinput>`,
+    );
+    await el.updateComplete;
+    expect(el.width).to.equal("full");
+  });
+
+  it("runs native checkValidity", async () => {
+    const el = await fixture<NysTextinput>(
+      html`<nys-textinput></nys-textinput>`,
+    );
+    expect(el.checkValidity()).to.be.true;
+  });
+
+  it("validates startButton slot and removes extra non-nys-button nodes", async () => {
+    const el = await fixture<NysTextinput>(html`
+      <nys-textinput>
+        <div slot="startButton">invalid</div>
+        <nys-button slot="startButton" label="MyBtn"></nys-button>
+        <div slot="startButton">also invalid</div>
+      </nys-textinput>
+    `);
+
+    const slot = el.shadowRoot?.querySelector('slot[name="startButton"]');
+    slot?.dispatchEvent(new Event("slotchange"));
+    await el.updateComplete;
+
+    const container = el.shadowRoot?.querySelector(
+      ".nys-textinput__buttoncontainer",
+    );
+    expect(container?.classList.contains("has-start-button")).to.be.true;
+  });
+
+  it("sets custom validity message and showError flag", async () => {
+    const el = await fixture<NysTextinput>(
+      html`<nys-textinput></nys-textinput>`,
+    );
+    (el as any)._setValidityMessage("Something is wrong");
+    expect(el.showError).to.be.true;
+    expect(el.errorMessage).to.include("Something is wrong");
+  });
+
   it("passes the a11y audit", async () => {
     const el = await fixture(
       html`<nys-textinput label="First Name"></nys-textinput>`,

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -3,7 +3,6 @@ import { property, state } from "lit/decorators.js";
 import styles from "./nys-textinput.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-
 let textinputIdCounter = 0; // Counter for generating unique IDs
 
 export class NysTextinput extends LitElement {

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -2,10 +2,7 @@ import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import styles from "./nys-textinput.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
-import "@nysds/nys-icon";
-import "@nysds/nys-label";
-import "@nysds/nys-errormessage";
-import "@nysds/nys-button";
+
 
 let textinputIdCounter = 0; // Counter for generating unique IDs
 

--- a/packages/nys-toggle/src/nys-toggle.stories.ts
+++ b/packages/nys-toggle/src/nys-toggle.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-toggle";
+import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysToggleArgs {

--- a/packages/nys-toggle/src/nys-toggle.ts
+++ b/packages/nys-toggle/src/nys-toggle.ts
@@ -1,7 +1,6 @@
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import "@nysds/nys-icon";
 import styles from "./nys-toggle.styles";
 
 let toggleIdCounter = 0; // Counter for generating unique IDs

--- a/packages/nys-unavheader/src/nys-unavheader.stories.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.stories.ts
@@ -1,6 +1,9 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-unavheader";
+import "@nysds/nys-button";
+import "@nysds/nys-icon";
+import "@nysds/nys-textinput";
 
 // Define the structure of the args used in the stories
 interface NysUnavHeaderArgs {

--- a/packages/nys-unavheader/src/nys-unavheader.test.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.test.ts
@@ -1,12 +1,59 @@
-/*** Accessibility tests ***/
-/*
- * Ensure that the <unav-footer> logo is readable for screen readers:
- * - Verify that the logo is properly read by screen readers when the <unav-footer> is focused.
- */
+import { expect, html, fixture } from "@open-wc/testing";
+import { NysUnavHeader } from "./nys-unavheader";
+import "../dist/nys-unavheader.js";
 
-/*
- * Ensure links are focusable and keyboard accessibility.
- */
+describe("nys-unavheader", () => {
+  it("should render with NYS logo link", async () => {
+    const el = await fixture<NysUnavHeader>(
+      html`<nys-unavheader></nys-unavheader>`,
+    );
+    const logoLink = el.shadowRoot?.getElementById(
+      "nys-unavheader__logolink",
+    ) as HTMLAnchorElement;
+    expect(logoLink).to.exist;
+    expect(logoLink?.getAttribute("href")).to.equal("https://www.ny.gov");
+    expect(logoLink?.getAttribute("aria-label")).to.equal(
+      "logo of New York State",
+    );
+  });
+});
 
-/* ACCESSIBILITY INSIGHT TOOL (Feedback) */
-// "Ensure button has discernible text"
+it("toggles trustbar visibility when clicking the top trustbar", async () => {
+  const el = await fixture<NysUnavHeader>(
+    html`<nys-unavheader></nys-unavheader>`,
+  );
+  const trustbarToggle = el.shadowRoot?.querySelector(
+    ".nys-unavheader__toptrustbar",
+  )!;
+  expect(el.trustbarVisible).to.be.false;
+
+  trustbarToggle.dispatchEvent(new MouseEvent("click"));
+  expect(el.trustbarVisible).to.be.true;
+
+  trustbarToggle.dispatchEvent(new MouseEvent("click"));
+  expect(el.trustbarVisible).to.be.false;
+});
+
+it("toggles language list when 'nys-click' event dispatched on translate button", async () => {
+  const el = await fixture<NysUnavHeader>(
+    html`<nys-unavheader></nys-unavheader>`,
+  );
+  el.languageVisible = true;
+  await el.updateComplete;
+  const langList = el.shadowRoot?.querySelector(
+    ".nys-unavheader__languagelist",
+  );
+  expect(langList).to.exist;
+  expect(langList?.classList.contains("show")).to.be.true;
+  expect(langList?.classList.contains("hide")).to.be.false;
+
+  el.languageVisible = false;
+  await el.updateComplete;
+  expect(langList?.classList.contains("hide")).to.be.true;
+  expect(langList?.classList.contains("show")).to.be.false;
+});
+
+it("passes the a11y audit", async () => {
+  const el = await fixture(html`<nys-unavheader></nys-unavheader>`);
+  await expect(el).shadowDom.to.be.accessible();
+});

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -2,9 +2,7 @@ import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import styles from "./nys-unavheader.styles";
 import nysLogo from "./nys-unav.logo";
-import "@nysds/nys-icon";
-import "@nysds/nys-textinput";
-import "@nysds/nys-button";
+
 
 export class NysUnavHeader extends LitElement {
   @property({ type: Boolean }) trustbarVisible = false;

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -185,7 +185,7 @@ export class NysUnavHeader extends LitElement {
           <div class="nys-unavheader__maincontent">
             <div class="nys-unavheader__left">
               <a
-                href="https://ny.gov"
+                href="https://www.ny.gov"
                 id="nys-unavheader__logolink"
                 aria-label="logo of New York State"
               >

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -3,7 +3,6 @@ import { property } from "lit/decorators.js";
 import styles from "./nys-unavheader.styles";
 import nysLogo from "./nys-unav.logo";
 
-
 export class NysUnavHeader extends LitElement {
   @property({ type: Boolean }) trustbarVisible = false;
   @property({ type: Boolean }) searchDropdownVisible = false;


### PR DESCRIPTION
I do not believe we need to @import all the dependencies between modules. This should be handled by the peerdeps in each components package.json file. 

I have tested this in Storybook, vanilla, and React demos without issue.