### PR TITLE
Fix select story, properly loads nys-icon

### DIFF
--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-select";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysSelectArgs {


### PR DESCRIPTION
Select story uses nys-icon and needed to have that added as an import so the carat shows up