### PR TITLE
Fix: icon prop update

### DIFF
--- a/packages/nys-icon/src/nys-icon.mdx
+++ b/packages/nys-icon/src/nys-icon.mdx
@@ -105,12 +105,12 @@ The **`nys-icon`** component is a reusable web component for use in New York Sta
 The name property is the **ONLY** required attribute for the icon component. The
 current icon prop is `name="publish"` but you can change it to any of the listed icons like "edit-square".
 
-Note: Leaving the 'label' blank will set aria-hidden for screen readers.
+Note: Leaving the 'ariaLabel' blank will set aria-hidden for screen readers.
 
 <Canvas of={NysIconStories.NameProp} />
 
-### Labels
-Include a label property to provide accessible text for screen readers.
+### Aria Label
+Include a `ariaLabel` property to provide accessible text for screen readers.
 <Canvas of={NysIconStories.Labels} />
 
 
@@ -181,7 +181,7 @@ Available values are `horizontal`, `vertical`, and `both`.
       ### <nys-icon name="check_circle" color="--var(nys-color-success)" /> Do
       - Use icons to enhance user interfaces with clear, recognizable icons.
       - Use appropriate icons align with the purpose and context of the UI elements they accompany.
-      - Provide an accessible label using the label attribute to ensure screen readers can interpret the icon's purpose (if warranted).
+      - Provide an accessible label using the `ariaLabel` attribute to ensure screen readers can interpret the icon's purpose (if warranted).
       - Customize icon sizes and colors to match the design system.
     </div>
   </div>
@@ -199,5 +199,5 @@ Available values are `horizontal`, `vertical`, and `both`.
 
 The `nys-icon` component includes the following accessibility-focused features:
 
-- **ARIA Hidden by Default:** If no label is provided, the icon is hidden from screen readers by setting `aria-hidden="true"`.
-- **Customizable ARIA Label:** If a label is provided, the component automatically adds an `aria-label` attribute, making the icon accessible to screen readers.
+- **ARIA Hidden by Default:** If no `ariaLabel` is provided, the icon is hidden from screen readers by setting `aria-hidden="true"`.
+- **Customizable ARIA Label:** If a `ariaLabel` is provided, the component automatically adds an `aria-label` attribute, making the icon accessible to screen readers.

--- a/packages/nys-icon/src/nys-icon.stories.ts
+++ b/packages/nys-icon/src/nys-icon.stories.ts
@@ -5,19 +5,18 @@ import "./nys-icon";
 // Define the structure of the args used in the stories
 interface NysIconArgs {
   name: string;
-  label?: string;
+  ariaLabel?: string;
   color?: string;
   rotate?: string;
   flip?: string;
   size?: string;
-  ariaDescription?: string;
 }
 
 const meta: Meta<NysIconArgs> = {
   title: "Components/Icon",
   component: "nys-icon",
   argTypes: {
-    label: { control: "text" },
+    ariaLabel: { control: "text" },
     name: { control: "text" },
     color: { control: "text" },
     rotate: { control: "text" },
@@ -46,7 +45,6 @@ const meta: Meta<NysIconArgs> = {
         "64",
       ],
     },
-    ariaDescription: { control: "text" },
   },
   parameters: {
     docs: {
@@ -71,13 +69,12 @@ export const Basic: Story = {
   },
   render: (args) =>
     html` <nys-icon
-      .label=${args.label}
+      .ariaLabel=${args.ariaLabel}
       .name=${args.name}
       color=${args.color}
       rotate=${args.rotate}
       flip=${args.flip}
       size=${args.size}
-      .ariaDescription=${args.ariaDescription}
     >
     </nys-icon>`,
   parameters: {
@@ -102,13 +99,12 @@ export const NameProp: Story = {
   },
   render: (args) =>
     html` <nys-icon
-      .label=${args.label}
+      .ariaLabel=${args.ariaLabel}
       .name=${args.name}
       color=${args.color}
       rotate=${args.rotate}
       flip=${args.flip}
       size=${args.size}
-      .ariaDescription=${args.ariaDescription}
     >
     </nys-icon>`,
   parameters: {
@@ -127,18 +123,17 @@ export const NameProp: Story = {
 // Story: Labels
 export const Labels: Story = {
   args: {
-    label: "edit_square icon",
+    ariaLabel: "edit_square icon",
     name: "edit_square",
   },
   render: (args) => html`
     <nys-icon
-      .label=${args.label}
+      .ariaLabel=${args.ariaLabel}
       .name=${args.name}
       color=${args.color}
       rotate=${args.rotate}
       flip=${args.flip}
       size=${args.size}
-      .ariaDescription=${args.ariaDescription}
     >
     </nys-icon>
   `,
@@ -147,7 +142,7 @@ export const Labels: Story = {
       source: {
         code: `
   <nys-icon
-  label="edit_square icon"
+  ariaLabel="edit_square icon"
   name="edit_square"
   ></nys-icon>
         `,
@@ -160,7 +155,7 @@ export const Labels: Story = {
 // Story: InheritSize
 export const InheritSize: Story = {
   args: {
-    label: "search icon",
+    ariaLabel: "search icon",
     name: "search",
   },
   render: (args) => html`
@@ -172,13 +167,12 @@ export const InheritSize: Story = {
         Font size not found on the parent element. Defaulting to the root font
         size of 16px
         <nys-icon
-          .label=${args.label}
+          .ariaLabel=${args.ariaLabel}
           .name=${args.name}
           color=${args.color}
           rotate=${args.rotate}
           flip=${args.flip}
           size=${args.size}
-          .ariaDescription=${args.ariaDescription}
         ></nys-icon>
       </p>
     </div>
@@ -189,13 +183,12 @@ export const InheritSize: Story = {
       <p>
         The nearest parent container's font-size is set to 1.5rem
         <nys-icon
-          .label=${args.label}
+          .ariaLabel=${args.ariaLabel}
           .name=${args.name}
           color=${args.color}
           rotate=${args.rotate}
           flip=${args.flip}
           size=${args.size}
-          .ariaDescription=${args.ariaDescription}
         ></nys-icon>
       </p>
     </div>
@@ -206,13 +199,12 @@ export const InheritSize: Story = {
       <p>
         The nearest parent container's font-size is set to 2rem
         <nys-icon
-          .label=${args.label}
+          .ariaLabel=${args.ariaLabel}
           .name=${args.name}
           color=${args.color}
           rotate=${args.rotate}
           flip=${args.flip}
           size=${args.size}
-          .ariaDescription=${args.ariaDescription}
         ></nys-icon>
       </p>
     </div>
@@ -223,13 +215,13 @@ export const InheritSize: Story = {
         code: `
 <div class="parent-container" style="display:flex; align-items: center; border: 2px solid black; border-bottom:none; padding: 5px 20px;">
   <p> The nearest parent container's font-size is not set <nys-icon
-    <nys-icon label="search icon" name="search"></nys-icon>
+    <nys-icon ariaLabel="search icon" name="search"></nys-icon>
   </p>
 </div>
 <div class="parent-container" style="font-size: 1.5rem; display:flex; align-items: center; border: 2px solid black; border-bottom:none; padding: 5px 20px;">
   <p> The nearest parent container's font-size is set to 1.5rem
     <nys-icon
-      label="search icon"
+      ariaLabel="search icon"
       name="search"
     ></nys-icon>
   </p>
@@ -237,7 +229,7 @@ export const InheritSize: Story = {
 <div class="parent-container" style="font-size: 2rem; display:flex; align-items: center; border: 2px solid black; border-bottom:none; padding: 5px 20px;">
   <p> The nearest parent container's font-size is set to 2rem <nys-icon
     <nys-icon
-      label="search icon"
+      ariaLabel="search icon"
       name="search"
     ></nys-icon>
   </p>
@@ -251,7 +243,7 @@ export const InheritSize: Story = {
 // Story: CustomSize (ex: xl)
 export const CustomSize: Story = {
   args: {
-    label: "search icon",
+    ariaLabel: "search icon",
     name: "search",
     size: "3xl",
   },
@@ -285,13 +277,12 @@ export const CustomSize: Story = {
       <p>
         The font-size of the parent container is dynamically controlled.
         <nys-icon
-          .label=${args.label}
+          .ariaLabel=${args.ariaLabel}
           .name=${args.name}
           color=${args.color}
           rotate=${args.rotate}
           flip=${args.flip}
           size=${args.size}
-          .ariaDescription=${args.ariaDescription}
         >
         </nys-icon>
       </p>
@@ -304,7 +295,7 @@ export const CustomSize: Story = {
   <div class="parent-container" style="font-size: var(--parent-font-size, 16px);  display:flex; align-items: center; border: 2px solid black; padding: 5px 20px;">
     <p> The font-size of the parent container is dynamically controlled.
       <nys-icon
-      label="search icon"
+      ariaLabel="search icon"
       name="search"
       size="3xl"
       ></nys-icon>
@@ -319,7 +310,7 @@ export const CustomSize: Story = {
 // Story: Color with inheritance
 export const ColorInheritance: Story = {
   args: {
-    label: "upload_file icon",
+    ariaLabel: "upload_file icon",
     name: "upload_file",
     size: "2xl",
   },
@@ -331,13 +322,12 @@ export const ColorInheritance: Story = {
       <p style="display:flex; align-items: center;">
         The color of the nearest parent container is set to DarkBlue.&nbsp;
         <nys-icon
-          .label=${args.label}
+          .ariaLabel=${args.ariaLabel}
           .name=${args.name}
           color=${args.color}
           rotate=${args.rotate}
           flip=${args.flip}
           size=${args.size}
-          .ariaDescription=${args.ariaDescription}
         >
         </nys-icon>
       </p>
@@ -351,7 +341,7 @@ export const ColorInheritance: Story = {
     <p style="display:flex; align-items: center;">
       The color of the nearest parent container is set to DarkBlue.
       <nys-icon
-        label="upload_file icon"
+        ariaLabel="upload_file icon"
         name="upload_file"
         size="2xl"
       ></nys-icon>
@@ -366,7 +356,7 @@ export const ColorInheritance: Story = {
 // Story: Color change using custom css variable
 export const ColorChange: Story = {
   args: {
-    label: "upload_file icon",
+    ariaLabel: "upload_file icon",
     name: "upload_file",
     color: "#db117d",
     size: "2xl",
@@ -379,13 +369,12 @@ export const ColorChange: Story = {
       <p style="display:flex; align-items: center;">
         The color of the nearest parent container is set to DarkBlue.&nbsp;
         <nys-icon
-          .label=${args.label}
+          .ariaLabel=${args.ariaLabel}
           .name=${args.name}
           color=${args.color}
           rotate=${args.rotate}
           flip=${args.flip}
           size=${args.size}
-          .ariaDescription=${args.ariaDescription}
         >
         </nys-icon>
       </p>
@@ -399,7 +388,7 @@ export const ColorChange: Story = {
     <p style="display:flex; align-items: center;">
       The color of the nearest parent container is set to DarkBlue.
       <nys-icon
-        label="upload_file icon"
+        ariaLabel="upload_file icon"
         name="upload_file"
         color="#db117d"
         size="2xl"
@@ -415,20 +404,19 @@ export const ColorChange: Story = {
 // Story: Rotate filter
 export const Rotate: Story = {
   args: {
-    label: "warning icon",
+    ariaLabel: "warning icon",
     name: "warning",
     rotate: "20",
     size: "2xl",
   },
   render: (args) => html`
     <nys-icon
-      .label=${args.label}
+      .ariaLabel=${args.ariaLabel}
       .name=${args.name}
       color=${args.color}
       rotate=${args.rotate}
       flip=${args.flip}
       size=${args.size}
-      .ariaDescription=${args.ariaDescription}
     ></nys-icon>
   `,
   parameters: {
@@ -436,7 +424,7 @@ export const Rotate: Story = {
       source: {
         code: `
   <nys-icon
-  label="warning icon"
+  ariaLabel="warning icon"
   name="warning"
   rotate="20"
   size="2xl"
@@ -450,20 +438,19 @@ export const Rotate: Story = {
 // Story: Flip prop
 export const Flip: Story = {
   args: {
-    label: "arrow_back icon",
+    ariaLabel: "arrow_back icon",
     name: "arrow_back",
     size: "2xl",
     flip: "horizontal",
   },
   render: (args) => html`
     <nys-icon
-      .label=${args.label}
+      .ariaLabel=${args.ariaLabel}
       .name=${args.name}
       color=${args.color}
       rotate=${args.rotate}
       flip=${args.flip}
       size=${args.size}
-      .ariaDescription=${args.ariaDescription}
     ></nys-icon>
   `,
   parameters: {
@@ -471,7 +458,7 @@ export const Flip: Story = {
       source: {
         code: `
   <nys-icon
-  label="arrow_back icon"
+  ariaLabel="arrow_back icon"
   name="arrow_back"
   flip="horizontal"
   size="2xl"

--- a/packages/nys-icon/src/nys-icon.test.ts
+++ b/packages/nys-icon/src/nys-icon.test.ts
@@ -84,9 +84,9 @@ describe("nys-icon", () => {
     expect(svg).to.be.null;
   });
 
-  it("sets accessibility attributes when 'label' is provided", async () => {
+  it("sets accessibility attributes when 'ariaLabel' is provided", async () => {
     const el = await fixture<NysIcon>(
-      html`<nys-icon label="download icon" name="download"></nys-icon>`,
+      html`<nys-icon ariaLabel="download icon" name="download"></nys-icon>`,
     );
     const svg = el.shadowRoot?.querySelector("svg");
 
@@ -94,7 +94,7 @@ describe("nys-icon", () => {
     expect(svg?.getAttribute("aria-label")).to.equal("download icon");
   });
 
-  it("hides from screen readers when 'label' is not provided", async () => {
+  it("hides from screen readers when 'ariaLabel' is not provided", async () => {
     const el = await fixture<NysIcon>(html`<nys-icon name="check"></nys-icon>`);
     const svg = el.shadowRoot?.querySelector("svg");
 

--- a/packages/nys-icon/src/nys-icon.ts
+++ b/packages/nys-icon/src/nys-icon.ts
@@ -5,8 +5,7 @@ import styles from "./nys-icon.styles";
 
 export class NysIcon extends LitElement {
   @property({ type: String, reflect: true }) name = "";
-  @property({ type: String }) label = "";
-  @property({ type: String }) ariaDescription = "";
+  @property({ type: String }) ariaLabel = "";
   @property({ type: String }) rotate = "0";
   @property({ type: String }) flip = "";
   @property({ type: String }) color = "";
@@ -67,15 +66,12 @@ export class NysIcon extends LitElement {
 
     // Add accessibility attributes directly to the <svg>
     svgElement.setAttribute("role", "img");
-    if (this.label) {
-      svgElement.setAttribute("aria-label", this.label);
+    if (this.ariaLabel) {
+      svgElement.setAttribute("aria-label", this.ariaLabel);
       svgElement.removeAttribute("aria-hidden");
     } else {
       svgElement.setAttribute("aria-hidden", "true");
       svgElement.removeAttribute("aria-label");
-    }
-    if (this.ariaDescription) {
-      svgElement.setAttribute("aria-description", this.ariaDescription);
     }
 
     // Add styles


### PR DESCRIPTION
# Summary

Renaming `label` to `ariaLabel` and removing `ariaDescription` prop on `nys-icon`

<!--
A good summary is written in the past tense and includes:
- What was changed
- Why it was changed
- The benefit from the update
-->

## Breaking change
This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to the JavaScript API of a component
  - Changes to the HTML/markup required for a component
  - Major design changes or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes #735 🎟️