### PR TITLE
Fix: tooltip storybook

### DIFF
--- a/packages/nys-tooltip/src/nys-tooltip.stories.ts
+++ b/packages/nys-tooltip/src/nys-tooltip.stories.ts
@@ -64,7 +64,7 @@ export const Basic: Story = {
       source: {
         code: `
 <nys-tooltip
-  label="I am a tooltip."
+  text="I am a tooltip."
 >
   <nys-button id="button1" name="button1" label="Hover Me"></nys-button>
 </nys-tooltip>`,
@@ -103,8 +103,7 @@ export const Focusable: Story = {
 <div style="display: flex; gap: 5px">
   <p>Hover over the icon</p>
   <nys-tooltip
-    label="I am a tooltip."
-    position="right"
+    text="I am a tooltip."
     focusable
   >
     <nys-icon name="info" size="3xl"></nys-icon>
@@ -147,7 +146,7 @@ export const Position: Story = {
 <div style="display: flex; gap: 5px">
   <p>Hover over the icon</p>
   <nys-tooltip
-    label="I am a tooltip."
+    text="I am a tooltip."
     position="right"
     focusable
   >
@@ -192,7 +191,7 @@ export const Inverted: Story = {
 <div style="color: #fff; display: flex; gap: 5px">
   <p>Hover over the icon</p>
   <nys-tooltip
-    label="I am a tooltip."
+    text="I am a tooltip."
     inverted
     focusable
   >


### PR DESCRIPTION

# Summary

Fix the storybook incorrect `label` to `text`

<!--
A good summary is written in the past tense and includes:
- What was changed
- Why it was changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  