### PR TITLE
Fix: tooltip rendering

### DIFF
--- a/packages/nys-icon/src/nys-icon.figma.ts
+++ b/packages/nys-icon/src/nys-icon.figma.ts
@@ -2,7 +2,7 @@ import figma, { html } from "@figma/code-connect/html";
 
 figma.connect("<FIGMA_ICON>", {
   props: {
-    size: figma.enum("size", {
+    size: figma.enum("Size", {
       "12": "12",
       "24": "24",
       "32": "32",

--- a/packages/nys-tooltip/src/nys-tooltip.ts
+++ b/packages/nys-tooltip/src/nys-tooltip.ts
@@ -71,9 +71,14 @@ export class NysTooltip extends LitElement {
   }
 
   firstUpdated() {
-    const firstEl = this._firstAssignedEl;
-    if (firstEl) {
-      this._applyFocusBehavior(firstEl);
+    const slot = this.shadowRoot?.querySelector("slot");
+    if (slot) {
+      slot.addEventListener("slotchange", () => {
+        const firstEl = this._firstAssignedEl;
+        if (firstEl) {
+          this._applyFocusBehavior(firstEl);
+        }
+      });
     }
   }
 


### PR DESCRIPTION

# Summary
Attempted fix at a problem with the reference site.

Problem with reference site not having focusable for `nys-tooltip`. I suspect this is due to client-side rendering for Storybook and React (which is why it works) versus 11.ty(how HTML is static and render first)

## Breaking change
This is **not** a breaking change. 