### PR TITLE
Fix: VO label for dismiss button in alert 

### DIFF
--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -212,7 +212,7 @@ export class NysAlert extends LitElement {
                   icon="close"
                   size="sm"
                   ?inverted=${this.type === "emergency"}
-                  ariaLabel="close button"
+                  ariaLabel="${this.heading}, alert, Close"
                   .onClick=${() => this._closeAlert()}
                 ></nys-button>`
               : ""}


### PR DESCRIPTION

# Summary
A11y password

## Breaking change

This is **not** a breaking change.  

## Related issues
Part of #765 🎟️
