### PR TITLE
add font family so it isnt monospace

### DIFF
--- a/packages/nys-textarea/src/nys-textarea.styles.ts
+++ b/packages/nys-textarea/src/nys-textarea.styles.ts
@@ -96,6 +96,7 @@ export default css`
   .nys-textarea__textarea {
     color: var(--_nys-textarea-color);
     font-size: var(--_nys-textarea-size-ui-md);
+    font-family: var(--_nys-textarea-family-ui);
     border-radius: var(--_nys-textarea-radius);
     border: solid var(--_nys-textarea-color-border)
       var(--_nys-textarea-width-border);


### PR DESCRIPTION
it was monospace, not its not

### before: 
<img width="454" height="152" alt="image" src="https://github.com/user-attachments/assets/82682f86-1fd5-4b20-af85-bf0816d70fdd" />

### after:
<img width="312" height="150" alt="image" src="https://github.com/user-attachments/assets/e0523fe3-89a8-4985-82c4-717bf197836f" />
