### PR TITLE
NYSDS - Button: fix keyboard click functionality

### DIFF
--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -165,9 +165,20 @@ export class NysButton extends LitElement {
       e.key === " " ||
       e.key === "Enter"
     ) {
+      if (this.disabled) return;
+
       e.preventDefault();
-      if (!this.disabled) {
-        this._manageFormAction(e);
+
+      if (this.href) {
+        // Click the internal <a> so native navigation happens
+        const linkEl = this.renderRoot.querySelector(
+          "a.nys-button",
+        ) as HTMLAnchorElement;
+        if (linkEl) {
+          linkEl.click();
+        }
+      } else {
+        this.click(); // Normal button mode
       }
     }
   }
@@ -197,6 +208,9 @@ export class NysButton extends LitElement {
                 @click=${this._handleClick}
                 @focus="${this._handleFocus}"
                 @blur="${this._handleBlur}"
+                @keydown="${this._handleKeydown}"
+                role="button"
+                tabindex="${this.disabled ? -1 : 0}"
               >
                 ${this.prefixIcon && this.variant !== "text"
                   ? html`<slot name="prefix-icon">


### PR DESCRIPTION
fixes bug reported by @plasticmind:
---
Page: https://designsystem.ny.gov/getting-started/developers/

Where/what:

Attempting to use the keyboard to "copy code" by pressing enter on a code block did not copy code or show the success message. Clicking with mouse does.
Expected:

Behavior with the keyboard should match the functionality of the mouse.
Notes:

UA: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36
---
Tested using `npm link` on the ref site and both keyboard and mouse click work on `onclick` and on `href` buttons.
Tested in firefox and chrome. Issues in safari still
