### PR TITLE
Enhancement/badge code connect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+FIGMA_ACCESS_TOKEN=your-token-here

--- a/figma.config.json
+++ b/figma.config.json
@@ -17,7 +17,7 @@
       "<FIGMA_ALERT>": "https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu?node-id=3981-8845",
       "<FIGMA_AVATAR>": "https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu?node-id=3981-9063",
       "<FIGMA_BACKTOTOP>": "https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu?node-id=4303-1514",
-      "<FIGMA_BADGE>": "https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu?node-id=5409-1651",
+      "<FIGMA_BADGE>": "https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu?node-id=8579-28809",
       "<FIGMA_BUTTON>": "https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu?node-id=3981-8292",
       "<FIGMA_CHECKBOX>": "https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu?node-id=4102-9216",
       "<FIGMA_CHECKBOXGROUP>": "https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu?node-id=4102-9601",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@web/test-runner": "^0.19.0",
         "@web/test-runner-commands": "^0.9.0",
         "@web/test-runner-playwright": "^0.11.0",
+        "dotenv-cli": "^10.0.0",
         "eslint": "^9.10.0",
         "eslint-plugin-lit": "^1.15.0",
         "eslint-plugin-prettier": "^5.2.1",
@@ -1263,6 +1264,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@nysds/nys-accordion": {
+      "resolved": "packages/nys-accordion",
+      "link": true
     },
     "node_modules/@nysds/nys-alert": {
       "resolved": "packages/nys-alert",
@@ -4645,6 +4650,51 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
       "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-10.0.0.tgz",
+      "integrity": "sha512-lnOnttzfrzkRx2echxJHQRB6vOAMSCzzZg79IxpC00tU42wZPuZkQxNNrrwVAxaQZIIh001l4PxVlCrBxngBzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^11.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "engines": {
         "node": ">=12"
       },
@@ -13574,6 +13624,23 @@
         "zod": "^3.18.0"
       }
     },
+    "packages/nys-accordion": {
+      "name": "@nysds/nys-accordion",
+      "version": "1.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "@nysds/nys-icon": "^1.6.0"
+      },
+      "devDependencies": {
+        "@nysds/nys-icon": "^1.6.0",
+        "lit": "^3.2.1",
+        "typescript": "^5.7.2",
+        "vite": "^6.3.4"
+      },
+      "peerDependencies": {
+        "lit": "^3.2.1"
+      }
+    },
     "packages/nys-alert": {
       "name": "@nysds/nys-alert",
       "version": "1.6.0",
@@ -13634,6 +13701,7 @@
         "@nysds/nys-icon": "^1.6.0"
       },
       "devDependencies": {
+        "@nysds/nys-icon": "^1.6.0",
         "lit": "^3.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.3.4"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "storybook:cibuild": "storybook build",
     "clean:node": "rm -rf node_modules && rm -rf packages/*/node_modules",
     "clean:dist": "rm -rf dist && rm -rf packages/*/dist",
-    "clean:all": "npm run clean:dist && npm run clean:node"
+    "clean:all": "npm run clean:dist && npm run clean:node",
+    "code-connect": "dotenv -- npx figma connect publish"
+
   },
   "repository": {
     "type": "git",
@@ -72,6 +74,7 @@
     "@web/test-runner": "^0.19.0",
     "@web/test-runner-commands": "^0.9.0",
     "@web/test-runner-playwright": "^0.11.0",
+    "dotenv-cli": "^10.0.0",
     "eslint": "^9.10.0",
     "eslint-plugin-lit": "^1.15.0",
     "eslint-plugin-prettier": "^5.2.1",

--- a/packages/nys-accordion/src/nys-accordion.mdx
+++ b/packages/nys-accordion/src/nys-accordion.mdx
@@ -16,7 +16,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>
@@ -107,7 +107,7 @@ accordion.addEventListener("nys-accordionitem-toggle", () => {
 	console.log("Accordion toggled");
 	console.log("Accordion details:", event.detail);
 });
-``` 
+```
 
 ## Dependencies
 

--- a/packages/nys-alert/src/nys-alert.mdx
+++ b/packages/nys-alert/src/nys-alert.mdx
@@ -16,7 +16,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-avatar/src/nys-avatar.mdx
+++ b/packages/nys-avatar/src/nys-avatar.mdx
@@ -16,7 +16,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-backtotop/src/nys-backtotop.mdx
+++ b/packages/nys-backtotop/src/nys-backtotop.mdx
@@ -15,7 +15,7 @@ It provides a button that allows users to quickly return to the top of a page, e
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-badge/src/nys-badge.figma.ts
+++ b/packages/nys-badge/src/nys-badge.figma.ts
@@ -10,12 +10,12 @@ figma.connect("<FIGMA_BADGE>", {
     }),
     size: figma.enum("Size", {
       sm: "sm",
-      md: "sm",
+      md: "md",
     }),
-    prefixIcon: figma.boolean("Prefix Icon"),
-    suffixIcon: figma.boolean("Suffix Icon"),
-    prefix: figma.string("Prefix"),
-    label: figma.string("Label"),
+    prefixIcon: figma.string("Prefix Icon"),
+    suffixIcon: figma.string("Suffix Icon"),
+    prefix: figma.string("Prefix Label"),
+    label: figma.string("Prefix Label"),
   },
   example: (props) => html`
     <nys-badge

--- a/packages/nys-badge/src/nys-badge.figma.ts
+++ b/packages/nys-badge/src/nys-badge.figma.ts
@@ -18,12 +18,13 @@ figma.connect("<FIGMA_BADGE>", {
     label: figma.string("Prefix Label"),
   },
   example: (props) => html`
+    <!-- For custom icons treat the property as a string. i.e: prefixIcon="check" -->
     <nys-badge
       label="${props.label}"
       intent="${props.intent}"
       size="${props.size}"
-      ?${props.prefixIcon}
-      ?${props.suffixIcon}
+      prefixIcon="${props.prefixIcon}"
+      suffixIcon="${props.suffixIcon}"
       prefixLabel="${props.prefixLabel}"
     ></nys-badge>
   `,

--- a/packages/nys-badge/src/nys-badge.figma.ts
+++ b/packages/nys-badge/src/nys-badge.figma.ts
@@ -14,7 +14,7 @@ figma.connect("<FIGMA_BADGE>", {
     }),
     prefixIcon: figma.string("Prefix Icon"),
     suffixIcon: figma.string("Suffix Icon"),
-    prefix: figma.string("Prefix Label"),
+    prefixLabel: figma.string("Prefix Label"),
     label: figma.string("Prefix Label"),
   },
   example: (props) => html`
@@ -22,9 +22,9 @@ figma.connect("<FIGMA_BADGE>", {
       label="${props.label}"
       intent="${props.intent}"
       size="${props.size}"
-      ?prefixIcon="${props.prefixIcon}"
-      ?suffixIcon="${props.suffixIcon}"
-      prefix="${props.prefix}"
+      ?${props.prefixIcon}
+      ?${props.suffixIcon}
+      prefixLabel="${props.prefixLabel}"
     ></nys-badge>
   `,
 });

--- a/packages/nys-badge/src/nys-badge.mdx
+++ b/packages/nys-badge/src/nys-badge.mdx
@@ -14,7 +14,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>
@@ -44,9 +44,9 @@ Badge is available in two sizes: medium and small. The size can be specified usi
 **Note:** Do not mix sizes within a group of badges.
 <Canvas of={NysBadgeStories.Size} />
 
-### Prefix
-Badge can include a prefix, which is a short text that appears before the main label. The prefix can be specified using the `prefix` attribute.
-<Canvas of={NysBadgeStories.Prefix} />
+### Prefix Label
+Badge can include a prefix label, which is a short text that appears before the main label. The prefix label can be specified using the `prefixLabel` attribute.
+<Canvas of={NysBadgeStories.PrefixLabel} />
 
 ## Usage
 

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -66,7 +66,7 @@ export const Basic: Story = {
       .label=${args.label}
       .size=${args.size}
       .intent=${args.intent}
-      .prefix=${args.prefix}
+      .prefixLabel=${args.prefix}
       .prefixIcon=${args.prefixIcon}
       .suffixIcon=${args.suffixIcon}
     ></nys-badge>
@@ -83,7 +83,7 @@ export const Basic: Story = {
 
 export const Intent: Story = {
   render: () => html`
-    <div className="nys-grid-row nys-grid-gap-1">
+    <div class="nys-grid-row nys-grid-gap-1">
       <nys-badge label="Neutral" prefixIcon></nys-badge>
       <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
       <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
@@ -95,7 +95,7 @@ export const Intent: Story = {
       source: {
         type: "auto",
         code: `
-<div className="nys-grid-row nys-grid-gap-1">
+<div class="nys-grid-row nys-grid-gap-1">
   <nys-badge label="Neutral" prefixIcon></nys-badge>
   <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
   <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
@@ -109,7 +109,7 @@ export const Intent: Story = {
 
 export const Icons: Story = {
   render: () => html`
-    <div className="nys-grid-row nys-grid-gap-1">
+    <div class="nys-grid-row nys-grid-gap-1">
       <nys-badge label="Default neutral" prefixIcon></nys-badge>
       <nys-badge label="Default neutral" suffixIcon></nys-badge>
       <nys-badge label="Custom neutral" prefixIcon="check"></nys-badge>
@@ -121,7 +121,7 @@ export const Icons: Story = {
       source: {
         type: "auto",
         code: `
-<div className="nys-grid-row nys-grid-gap-1">
+<div class="nys-grid-row nys-grid-gap-1">
   <nys-badge label="Default neutral" prefixIcon></nys-badge>
   <nys-badge label="Default neutral" suffixIcon></nys-badge>
   <nys-badge label="Custom neutral" prefixIcon="check"></nys-badge>
@@ -135,7 +135,7 @@ export const Icons: Story = {
 
 export const Size: Story = {
   render: () => html`
-    <div className="nys-grid-row nys-grid-gap-1">
+    <div class="nys-grid-row nys-grid-gap-1">
       <nys-badge label="Medium"></nys-badge>
       <nys-badge label="Small" size="sm"></nys-badge>
     </div>
@@ -145,7 +145,7 @@ export const Size: Story = {
       source: {
         type: "auto",
         code: `
-<div className="nys-grid-row nys-grid-gap-1">
+<div class="nys-grid-row nys-grid-gap-1">
   <nys-badge label="Medium"></nys-badge>
   <nys-badge label="Small" size="sm"></nys-badge>
 </div>
@@ -155,13 +155,13 @@ export const Size: Story = {
   },
 };
 
-export const Prefix: Story = {
+export const PrefixLabel: Story = {
   render: () => html`
-    <div className="nys-grid-row nys-grid-gap-1">
+    <div class="nys-grid-row nys-grid-gap-1">
       <nys-badge label="Stable" prefixIcon="code"></nys-badge>
       <nys-badge
         prefixIcon
-        prefix="WCAG 2.2"
+        prefixLabel="WCAG 2.2"
         label="AA"
         intent="success"
       ></nys-badge>
@@ -172,9 +172,9 @@ export const Prefix: Story = {
       source: {
         type: "auto",
         code: `
-<div className="nys-grid-row nys-grid-gap-1">
+<div class="nys-grid-row nys-grid-gap-1">
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
-  <nys-badge prefix="WCAG 2.2" label="AA" intent="success" prefixIcon></nys-badge>
+  <nys-badge prefixLabel="WCAG 2.2" label="AA" intent="success" prefixIcon></nys-badge>
 </div>
 `,
       },

--- a/packages/nys-badge/src/nys-badge.test.ts
+++ b/packages/nys-badge/src/nys-badge.test.ts
@@ -32,7 +32,7 @@ describe("nys-badge", () => {
     expect(el.prefixIcon).to.equal("check");
   });
 
-  it("renders the prefix", async () => {
+  it("renders the prefixLabel", async () => {
     const el = await fixture<NysBadge>(
       html`<nys-badge prefixLabel="prefix" label="label"></nys-badge>`,
     );

--- a/packages/nys-badge/src/nys-badge.test.ts
+++ b/packages/nys-badge/src/nys-badge.test.ts
@@ -5,7 +5,7 @@ import { NysBadge } from "./nys-badge.js";
 // Below are placeholder examples of test cases for a web component. Add your own tests as needed.
 describe("nys-badge", () => {
   it("renders the component", async () => {
-    const el = await fixture(html`<nys-badge></nys-badge>`);
+    const el = await fixture<NysBadge>(html`<nys-badge></nys-badge>`);
     expect(el).to.exist;
   });
 
@@ -33,14 +33,16 @@ describe("nys-badge", () => {
   });
 
   it("renders the prefix", async () => {
-    const el = await fixture(
-      html`<nys-badge prefix="prefix" label="label"></nys-badge>`,
+    const el = await fixture<NysBadge>(
+      html`<nys-badge prefixLabel="prefix" label="label"></nys-badge>`,
     );
-    expect(el.prefix).to.equal("prefix");
+    expect(el.prefixLabel).to.equal("prefix");
   });
 
   it("passes the a11y audit", async () => {
-    const el = await fixture(html`<nys-badge label="My Label"></nys-badge>`);
+    const el = await fixture<NysBadge>(
+      html`<nys-badge label="My Label"></nys-badge>`,
+    );
     await expect(el).shadowDom.to.be.accessible();
   });
 

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -38,7 +38,7 @@ export class NysBadge extends LitElement {
       ? (value as (typeof NysBadge.VALID_INTENT)[number])
       : "neutral";
   }
-  @property({ type: String }) prefix = "";
+  @property({ type: String }) prefixLabel = "";
   @property({ type: String }) label = "";
 
   // Icons (string or boolean)
@@ -116,8 +116,8 @@ export class NysBadge extends LitElement {
         ${prefixIconName
           ? html`<nys-icon size="16" name=${prefixIconName}></nys-icon>`
           : ""}
-        ${this.prefix
-          ? html`<div class="nys-badge__prefix">${this.prefix}</div>`
+        ${this.prefixLabel
+          ? html`<div class="nys-badge__prefix">${this.prefixLabel}</div>`
           : ""}
         <div class="nys-badge__label">${this.label}</div>
         ${suffixIconName

--- a/packages/nys-button/src/nys-button.mdx
+++ b/packages/nys-button/src/nys-button.mdx
@@ -22,7 +22,7 @@ When using the `<nys-button>`, use the `onClick` prop (in lit.dev it's `.onClick
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-checkbox/src/nys-checkbox.mdx
+++ b/packages/nys-checkbox/src/nys-checkbox.mdx
@@ -16,7 +16,7 @@ The **`nys-checkbox`** component is a reusable web component for use in New York
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-errormessage/src/nys-errormessage.mdx
+++ b/packages/nys-errormessage/src/nys-errormessage.mdx
@@ -21,7 +21,7 @@ The **`nys-errormessage`** is a reusable web component for use in New York State
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-fileinput/src/nys-fileinput.mdx
+++ b/packages/nys-fileinput/src/nys-fileinput.mdx
@@ -16,7 +16,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-globalfooter/src/nys-globalfooter.mdx
+++ b/packages/nys-globalfooter/src/nys-globalfooter.mdx
@@ -14,7 +14,7 @@ The **`nys-globalfooter`** component is a reusable web component for use in New 
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-globalheader/src/nys-globalheader.mdx
+++ b/packages/nys-globalheader/src/nys-globalheader.mdx
@@ -14,7 +14,7 @@ The **`nys-globalheader`** component is a reusable web component for use in New 
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-icon/src/nys-icon.mdx
+++ b/packages/nys-icon/src/nys-icon.mdx
@@ -14,7 +14,7 @@ The **`nys-icon`** component is a reusable web component for use in New York Sta
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-label/src/nys-label.mdx
+++ b/packages/nys-label/src/nys-label.mdx
@@ -21,7 +21,7 @@ The **`nys-label`** is a reusable web component for use in New York State digita
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -18,7 +18,7 @@ The **`nys-radiobutton`** component is a reusable web component for use in New Y
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-select/src/nys-select.mdx
+++ b/packages/nys-select/src/nys-select.mdx
@@ -14,7 +14,7 @@ The **`nys-select`** is a reusable web component for use in New York State digit
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-skipnav/src/nys-skipnav.mdx
+++ b/packages/nys-skipnav/src/nys-skipnav.mdx
@@ -16,7 +16,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-textarea/src/nys-textarea.mdx
+++ b/packages/nys-textarea/src/nys-textarea.mdx
@@ -14,7 +14,7 @@ The **`nys-textarea`** is a reusable web component for use in New York State dig
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -15,7 +15,7 @@ The **`nys-textinput`** is a reusable web component for use in New York State di
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-toggle/src/nys-toggle.mdx
+++ b/packages/nys-toggle/src/nys-toggle.mdx
@@ -15,7 +15,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-tooltip/src/nys-tooltip.mdx
+++ b/packages/nys-tooltip/src/nys-tooltip.mdx
@@ -17,7 +17,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-unavfooter/src/nys-unavfooter.mdx
+++ b/packages/nys-unavfooter/src/nys-unavfooter.mdx
@@ -14,7 +14,7 @@ The **`nys-unavfooter`** component is a reusable web component for use in New Yo
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/packages/nys-unavheader/src/nys-unavheader.mdx
+++ b/packages/nys-unavheader/src/nys-unavheader.mdx
@@ -17,7 +17,7 @@ Technology Standard ](https://its.ny.gov/system/files/documents/2025/02/nys-s16-
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>

--- a/templates/mdx.template.hbs
+++ b/templates/mdx.template.hbs
@@ -16,7 +16,7 @@ If an id is not passed, a unique id will be generated.
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>
   <nys-badge
     prefixIcon
-    prefix="WCAG 2.2"
+    prefixLabel="WCAG 2.2"
     label="AA"
     intent="success"
   ></nys-badge>


### PR DESCRIPTION
- rename `prefix` prop to `prefixLabel`
  - THIS IS A BREAKING CHANGE
- published code connect
- added a `.env.example` to store the figma access token (copy file to `.env` and replace token with yours) 
  - added `dotenv-cli` package to read from the new `.env` file
 - added `npm run code-connect` to make life easier
 
closes #823 