### PR TITLE
Fix: Active link on `nys-globalheader` for sub links

### DIFF
--- a/packages/nys-globalheader/src/nys-globalheader.ts
+++ b/packages/nys-globalheader/src/nys-globalheader.ts
@@ -49,6 +49,8 @@ export class NysGlobalHeader extends LitElement {
       container.innerHTML = "";
       containerMobile.innerHTML = "";
 
+      const currentUrl = this._normalizePath(window.location.pathname);
+
       // Clone and append slotted elements into the shadow DOM container
       assignedNodes.forEach((node) => {
         if (node.nodeType === Node.ELEMENT_NODE) {
@@ -64,11 +66,13 @@ export class NysGlobalHeader extends LitElement {
           });
 
           // Highlight active link
-          const currentUrl = this._normalizePath(window.location.pathname);
           cleanNode.querySelectorAll("a").forEach((a) => {
             const hrefAttr = a.getAttribute("href");
             const linkPath = this._normalizePath(hrefAttr);
-            if (linkPath === currentUrl) {
+
+            if (!linkPath) return;
+
+            if (currentUrl?.startsWith(linkPath)) {
               const li = a.closest("li");
               if (li) li.classList.add("active");
             }
@@ -76,7 +80,10 @@ export class NysGlobalHeader extends LitElement {
           cleanNodeMobile.querySelectorAll("a").forEach((a) => {
             const hrefAttr = a.getAttribute("href");
             const linkPath = this._normalizePath(hrefAttr);
-            if (linkPath === currentUrl) {
+
+            if (!linkPath) return;
+
+            if (currentUrl?.startsWith(linkPath)) {
               const li = a.closest("li");
               if (li) li.classList.add("active");
             }


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

`nys-globalheader` should keep an active state for sub-page links like:
foundations -> foundations/accessibility -> foundations/accessibility/digital-experiences/
<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change


This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes #838 🎟️
