### PR TITLE
Enhancement: `nys-avatar`

### DIFF
--- a/packages/nys-avatar/src/nys-avatar.figma.ts
+++ b/packages/nys-avatar/src/nys-avatar.figma.ts
@@ -3,12 +3,14 @@ import figma, { html } from "@figma/code-connect/html";
 figma.connect("<FIGMA_AVATAR>", {
   props: {
     initials: figma.string("Initials"),
-    ariaLabel: figma.string("Aria Label"),
+    interactive: figma.boolean("Interactive"),
+    disabled: figma.boolean("Disabled"),
   },
   example: (props) => html`
     <nys-avatar
       initials="${props.initials}"
-      ariaLabel="${props.ariaLabel}"
+      interactive="${props.interactive}"
+      disabled="${props.disabled}"
     ></nys-avatar>
   `,
 });

--- a/packages/nys-avatar/src/nys-avatar.mdx
+++ b/packages/nys-avatar/src/nys-avatar.mdx
@@ -43,13 +43,21 @@ If an image is unavailable, you can set the `initials` attribute to display a pe
 When no image or initials are set, an icon will be shown. The default avatar shows an icon called "account_circle", but you can customize this with any other name found in `nys-icon` using the `icon` prop or customize directly within `nys-avatar` with the icon slot.
 <Canvas of={NysAvatarStories.AvatarIcon} />
 
+### Interactive
+Enable the `interactive` prop to apply interactive styling states and keyboard focus.
+<Canvas of={NysAvatarStories.AvatarInteractive} />
+
+### Disabled
+Use the `disabled` prop to prevent interaction and remove focusability.
+<Canvas of={NysAvatarStories.AvatarDisabled} />
+
 ### Shapes
 Avatars can be shaped using the shape attribute.
 <Canvas of={NysAvatarStories.AvatarShapes} />
 
 ### Background Color
 The background color of the Avatar can be customized using the color attribute. This attribute accepts any valid color value, including <a href="https://designsystem.ny.gov/foundations/design-tokens/" target="_blank" rel="noopener noreferrer">design tokens</a>, such as: `color="var(--nys-color-theme)"` \
-**Note:** When an image is provided, it will overlay and fully cover the background color.
+**Note:** When an image is provided, it will overlay and fully cover the background color. The inner foreground (icon or initials) automatically switches to #000 or #fff for contrast.
 <Canvas of={NysAvatarStories.AvatarBgColor} />
 
 ## Usage

--- a/packages/nys-avatar/src/nys-avatar.mdx
+++ b/packages/nys-avatar/src/nys-avatar.mdx
@@ -40,7 +40,7 @@ If an image is unavailable, you can set the `initials` attribute to display a pe
 <Canvas of={NysAvatarStories.AvatarInitials} />
 
 ### Custom Icons
-When no image or initials are set, an icon will be shown. The default avatar shows an icon called "account_circle", but you can customize this with any other name found in `nys-icon` using the `icon` prop or customize directly within `nys-avatar` with the icon slot.
+When no image or initials are set, an icon will be shown. The default avatar shows an icon called "account_circle", but you can customize this with any other name found in `<nys-icon>` using the `icon` prop or customize directly within `nys-avatar` with the icon slot.
 <Canvas of={NysAvatarStories.AvatarIcon} />
 
 ### Interactive
@@ -50,10 +50,6 @@ Enable the `interactive` prop to apply interactive styling states and keyboard f
 ### Disabled
 Use the `disabled` prop to prevent interaction and remove focusability.
 <Canvas of={NysAvatarStories.AvatarDisabled} />
-
-### Shapes
-Avatars can be shaped using the shape attribute.
-<Canvas of={NysAvatarStories.AvatarShapes} />
 
 ### Background Color
 The background color of the Avatar can be customized using the color attribute. This attribute accepts any valid color value, including <a href="https://designsystem.ny.gov/foundations/design-tokens/" target="_blank" rel="noopener noreferrer">design tokens</a>, such as: `color="var(--nys-color-theme)"` \
@@ -75,7 +71,7 @@ The background color of the Avatar can be customized using the color attribute. 
       <div className="usage-card usage-card--do">
          ### <nys-icon name="check_circle" color="var(--nys-color-success)" /> Do
          - Use for clear, simple user or entity representation.
-         - Use appropriate shapes, sizes, and images to fit the overall page design.
+         - Use appropriate images, initials, and icons to fit the overall page design.
          - Use `<nys-icon>` as a slot when you need further customizations that the `icon` prop can't provide.
       </div>
    </div>

--- a/packages/nys-avatar/src/nys-avatar.stories.ts
+++ b/packages/nys-avatar/src/nys-avatar.stories.ts
@@ -32,7 +32,7 @@ const meta: Meta<NysAvatarArgs> = {
     color: {
       control: "text",
       type: "string",
-      defaultValue: { summary: "#555" },
+      defaultValue: { summary: "#eff6fb" },
     },
     lazy: { control: "boolean", type: "boolean" },
     interactive: { control: "boolean", type: "boolean" },

--- a/packages/nys-avatar/src/nys-avatar.stories.ts
+++ b/packages/nys-avatar/src/nys-avatar.stories.ts
@@ -13,6 +13,8 @@ interface NysAvatarArgs {
   shape?: string;
   color?: string;
   lazy?: boolean;
+  interactive?: boolean;
+  disabled?: boolean;
 }
 
 const meta: Meta<NysAvatarArgs> = {
@@ -39,6 +41,8 @@ const meta: Meta<NysAvatarArgs> = {
       defaultValue: { summary: "#555" },
     },
     lazy: { control: "boolean", type: "boolean" },
+    interactive: { control: "boolean", type: "boolean" },
+    disabled: { control: "boolean", type: "boolean" },
   },
   parameters: {
     docs: {
@@ -70,6 +74,8 @@ export const Basic: Story = {
       .image=${args.image}
       .shape=${args.shape}
       .lazy=${args.lazy}
+      .interactive=${args.interactive}
+      .disabled=${args.disabled}
       .color=${args.color}
     >
     </nys-avatar>`,
@@ -100,6 +106,8 @@ export const AvatarImage: Story = {
         .icon=${args.icon}
         image="https://images.unsplash.com/photo-1513360371669-4adf3dd7dff8?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
         .shape=${args.shape}
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
       >
       </nys-avatar>
       <nys-avatar
@@ -109,6 +117,8 @@ export const AvatarImage: Story = {
         image="https://images.unsplash.com/photo-1523318840068-3e8c0f998509?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
         .shape=${args.shape}
         ?lazy
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
       >
       </nys-avatar>
     </div>`,
@@ -147,6 +157,8 @@ export const AvatarInitials: Story = {
       .image=${args.image}
       .shape=${args.shape}
       .lazy=${args.lazy}
+      .interactive=${args.interactive}
+      .disabled=${args.disabled}
       .color=${args.color}
     >
     </nys-avatar>
@@ -180,6 +192,8 @@ export const AvatarIcon: Story = {
         .image=${args.image}
         .shape=${args.shape}
         .lazy=${args.lazy}
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
         .color=${args.color}
       >
       </nys-avatar>
@@ -189,6 +203,8 @@ export const AvatarIcon: Story = {
         .image=${args.image}
         .shape=${args.shape}
         .lazy=${args.lazy}
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
         color="#f2efee"
       >
         <nys-icon
@@ -224,10 +240,10 @@ export const AvatarIcon: Story = {
   },
 };
 
-// Story: Shapes
-export const AvatarShapes: Story = {
+// Story: Interactive
+export const AvatarInteractive: Story = {
   args: {
-    ariaLabel: "User avatar",
+    interactive: true,
     icon: "account_circle",
   },
   render: (args) =>
@@ -237,8 +253,63 @@ export const AvatarShapes: Story = {
         .initials=${args.initials}
         .icon=${args.icon}
         .image=${args.image}
-        shape="square"
+        .shape=${args.shape}
         .lazy=${args.lazy}
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
+        .color=${args.color}
+      >
+      </nys-avatar>
+      <nys-avatar
+        ariaLabel="NY"
+        initials="NY"
+        .shape=${args.shape}
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
+        .color=${args.color}
+      >
+      </nys-avatar>
+    </div>`,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<div style="display:flex; gap:5px;">
+<nys-avatar
+  ariaLabel="User avatar"
+  icon="account_circle"
+  interactive
+></nys-avatar>
+<nys-avatar
+  ariaLabel="New York Initial"
+  initials="NY"
+  interactive
+></nys-avatar>
+</div>
+    `.trim(),
+      },
+    },
+  },
+};
+
+// Story: Shapes
+export const AvatarShapes: Story = {
+  args: {
+    ariaLabel: "User avatar",
+    icon: "account_circle",
+    shape: "square",
+  },
+  render: (args) =>
+    html` <div style="display:flex; gap:5px;">
+      <nys-avatar
+        .ariaLabel=${args.ariaLabel}
+        .initials=${args.initials}
+        .icon=${args.icon}
+        .image=${args.image}
+        .shape=${args.shape}
+        .lazy=${args.lazy}
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
         .color=${args.color}
       >
       </nys-avatar>
@@ -249,6 +320,8 @@ export const AvatarShapes: Story = {
         .image=${args.image}
         shape="rounded"
         .lazy=${args.lazy}
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
         .color=${args.color}
       >
       </nys-avatar>
@@ -259,6 +332,8 @@ export const AvatarShapes: Story = {
         .image=${args.image}
         shape="circle"
         .lazy=${args.lazy}
+        .interactive=${args.interactive}
+        .disabled=${args.disabled}
         .color=${args.color}
       >
       </nys-avatar>
@@ -290,6 +365,40 @@ export const AvatarShapes: Story = {
   },
 };
 
+// Story: AvatarDisabled
+export const AvatarDisabled: Story = {
+  args: {
+    ariaLabel: "User avatar",
+    disabled: true,
+  },
+  render: (args) => html`
+    <nys-avatar
+      .ariaLabel=${args.ariaLabel}
+      .initials=${args.initials}
+      .icon=${args.icon}
+      .image=${args.image}
+      .shape=${args.shape}
+      .lazy=${args.lazy}
+      .interactive=${args.interactive}
+      .disabled=${args.disabled}
+      .color=${args.color}
+    >
+    </nys-avatar>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+ <nys-avatar
+	ariaLabel="User avatar"
+	disabled
+ ></nys-avatar>
+	  `.trim(),
+      },
+    },
+  },
+};
+
 // Story: AvatarBgColor
 export const AvatarBgColor: Story = {
   args: {
@@ -304,6 +413,8 @@ export const AvatarBgColor: Story = {
       .image=${args.image}
       .shape=${args.shape}
       .lazy=${args.lazy}
+      .interactive=${args.interactive}
+      .disabled=${args.disabled}
       .color=${args.color}
     >
     </nys-avatar>

--- a/packages/nys-avatar/src/nys-avatar.stories.ts
+++ b/packages/nys-avatar/src/nys-avatar.stories.ts
@@ -10,7 +10,6 @@ interface NysAvatarArgs {
   initials?: string;
   icon?: string;
   image?: string;
-  shape?: string;
   color?: string;
   lazy?: boolean;
   interactive?: boolean;
@@ -30,11 +29,6 @@ const meta: Meta<NysAvatarArgs> = {
       defaultValue: { summary: "account_circle" },
     },
     image: { control: "text", type: "string" },
-    shape: {
-      control: "select",
-      options: ["square", "rounded", "circle"],
-      type: "string",
-    },
     color: {
       control: "text",
       type: "string",
@@ -72,7 +66,6 @@ export const Basic: Story = {
       .initials=${args.initials}
       .icon=${args.icon}
       .image=${args.image}
-      .shape=${args.shape}
       .lazy=${args.lazy}
       .interactive=${args.interactive}
       .disabled=${args.disabled}
@@ -105,7 +98,6 @@ export const AvatarImage: Story = {
         .initials=${args.initials}
         .icon=${args.icon}
         image="https://images.unsplash.com/photo-1513360371669-4adf3dd7dff8?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-        .shape=${args.shape}
         .interactive=${args.interactive}
         .disabled=${args.disabled}
       >
@@ -115,7 +107,6 @@ export const AvatarImage: Story = {
         .initials=${args.initials}
         .icon=${args.icon}
         image="https://images.unsplash.com/photo-1523318840068-3e8c0f998509?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-        .shape=${args.shape}
         ?lazy
         .interactive=${args.interactive}
         .disabled=${args.disabled}
@@ -155,7 +146,6 @@ export const AvatarInitials: Story = {
       .initials=${args.initials}
       .icon=${args.icon}
       .image=${args.image}
-      .shape=${args.shape}
       .lazy=${args.lazy}
       .interactive=${args.interactive}
       .disabled=${args.disabled}
@@ -190,7 +180,6 @@ export const AvatarIcon: Story = {
         .initials=${args.initials}
         .icon=${args.icon}
         .image=${args.image}
-        .shape=${args.shape}
         .lazy=${args.lazy}
         .interactive=${args.interactive}
         .disabled=${args.disabled}
@@ -201,7 +190,6 @@ export const AvatarIcon: Story = {
         .ariaLabel=${args.ariaLabel}
         .initials=${args.initials}
         .image=${args.image}
-        .shape=${args.shape}
         .lazy=${args.lazy}
         .interactive=${args.interactive}
         .disabled=${args.disabled}
@@ -253,7 +241,6 @@ export const AvatarInteractive: Story = {
         .initials=${args.initials}
         .icon=${args.icon}
         .image=${args.image}
-        .shape=${args.shape}
         .lazy=${args.lazy}
         .interactive=${args.interactive}
         .disabled=${args.disabled}
@@ -263,7 +250,6 @@ export const AvatarInteractive: Story = {
       <nys-avatar
         ariaLabel="NY"
         initials="NY"
-        .shape=${args.shape}
         .interactive=${args.interactive}
         .disabled=${args.disabled}
         .color=${args.color}
@@ -292,79 +278,6 @@ export const AvatarInteractive: Story = {
   },
 };
 
-// Story: Shapes
-export const AvatarShapes: Story = {
-  args: {
-    ariaLabel: "User avatar",
-    icon: "account_circle",
-    shape: "square",
-  },
-  render: (args) =>
-    html` <div style="display:flex; gap:5px;">
-      <nys-avatar
-        .ariaLabel=${args.ariaLabel}
-        .initials=${args.initials}
-        .icon=${args.icon}
-        .image=${args.image}
-        .shape=${args.shape}
-        .lazy=${args.lazy}
-        .interactive=${args.interactive}
-        .disabled=${args.disabled}
-        .color=${args.color}
-      >
-      </nys-avatar>
-      <nys-avatar
-        .ariaLabel=${args.ariaLabel}
-        .initials=${args.initials}
-        .icon=${args.icon}
-        .image=${args.image}
-        shape="rounded"
-        .lazy=${args.lazy}
-        .interactive=${args.interactive}
-        .disabled=${args.disabled}
-        .color=${args.color}
-      >
-      </nys-avatar>
-      <nys-avatar
-        .ariaLabel=${args.ariaLabel}
-        .initials=${args.initials}
-        .icon=${args.icon}
-        .image=${args.image}
-        shape="circle"
-        .lazy=${args.lazy}
-        .interactive=${args.interactive}
-        .disabled=${args.disabled}
-        .color=${args.color}
-      >
-      </nys-avatar>
-    </div>`,
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<div style="display:flex; gap:5px;">
-<nys-avatar
-  ariaLabel="User avatar"
-  icon="account_circle"
-  shape="square"
-></nys-avatar>
-<nys-avatar
-  ariaLabel="User avatar"
-  icon="account_circle"
-  shape="rounded"
-></nys-avatar>
-<nys-avatar
-  ariaLabel="User avatar"
-  icon="account_circle"
-  shape="circle"
-></nys-avatar>
-</div>
-    `.trim(),
-      },
-    },
-  },
-};
-
 // Story: AvatarDisabled
 export const AvatarDisabled: Story = {
   args: {
@@ -377,7 +290,6 @@ export const AvatarDisabled: Story = {
       .initials=${args.initials}
       .icon=${args.icon}
       .image=${args.image}
-      .shape=${args.shape}
       .lazy=${args.lazy}
       .interactive=${args.interactive}
       .disabled=${args.disabled}
@@ -411,7 +323,6 @@ export const AvatarBgColor: Story = {
       .initials=${args.initials}
       .icon=${args.icon}
       .image=${args.image}
-      .shape=${args.shape}
       .lazy=${args.lazy}
       .interactive=${args.interactive}
       .disabled=${args.disabled}

--- a/packages/nys-avatar/src/nys-avatar.styles.ts
+++ b/packages/nys-avatar/src/nys-avatar.styles.ts
@@ -9,6 +9,9 @@ export default css`
     --_nys-avatar-size: var(--nys-font-size-6xl, 36px);
     --_nys-avatar-color: var(--nys-color-theme, #154973);
     --_nys-avatar-background: var(--nys-color-theme-weaker, #46a4e7ff);
+    --_nys-avatar-color-focus: var(--nys-color-focus, #004dd1);
+    --_nys-avatar-width-focus: var(--nys-border-width-md, 2px);
+    --_nys-avatar-outline-offset: var(--nys-space-2px, 2px);
   }
 
   .nys-avatar {
@@ -28,6 +31,7 @@ export default css`
     color: var(--_nys-avatar-color);
     background-color: var(--_nys-avatar-background);
     border: var(--_nys-avatar-border-size) solid var(--_nys-avatar-border-color);
+    outline-offset: var(--_nys-avatar-outline-offset);
     transition: all 0.15s ease-in-out;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -59,17 +63,8 @@ export default css`
     cursor: not-allowed;
   }
 
-  /* Shape */
-  :host([shape="square"]) {
-    --_nys-avatar-shape: var(--nys-radius-xs, var(--nys-space-1px, 1px));
-  }
-
-  :host([shape="rounded"]) {
-    --_nys-avatar-shape: var(--nys-radius-md, var(--nys-space-50, 4px));
-  }
-
-  :host([shape="circle"]) {
-    --_nys-avatar-shape: var(--nys-radius-round, 1776px);
+  :host([disabled]) .nys-avatar__component:focus-within {
+    outline: solid var(--_nys-avatar-width-focus) var(--_nys-avatar-color-focus);
   }
 
   div[part="nys-avatar__icon"] {

--- a/packages/nys-avatar/src/nys-avatar.styles.ts
+++ b/packages/nys-avatar/src/nys-avatar.styles.ts
@@ -6,11 +6,11 @@ export default css`
     --_nys-avatar-shape: var(--nys-radius-round, 1776px);
     --_nys-avatar-border-color: var(--nys-color-ink-reverse, #fff);
     --_nys-avatar-border-size: var(--nys-border-width-sm, 1px);
-    --_nys-avatar-size: var(--nys-font-size-6xl, 36px);
+    --_nys-avatar-width: var(--nys-font-size-6xl, 36px);
     --_nys-avatar-color: var(--nys-color-theme, #154973);
-    --_nys-avatar-background: var(--nys-color-theme-weaker, #eff6fb);
-    --_nys-avatar-color-focus: var(--nys-color-focus, #004dd1);
-    --_nys-avatar-width-focus: var(--nys-border-width-md, 2px);
+    --_nys-avatar-background-color: var(--nys-color-theme-weaker, #eff6fb);
+    --_nys-avatar-outline-color: var(--nys-color-focus, #004dd1);
+    --_nys-avatar-outline-width: var(--nys-border-width-md, 2px);
     --_nys-avatar-outline-offset: var(--nys-space-2px, 2px);
   }
 
@@ -23,13 +23,13 @@ export default css`
     justify-content: center;
     align-items: center;
     border-radius: var(--_nys-avatar-shape);
-    width: var(--_nys-avatar-size);
-    height: var(--_nys-avatar-size);
-    font-size: var(--_nys-avatar-size);
+    width: var(--_nys-avatar-width);
+    height: var(--_nys-avatar-width);
+    font-size: var(--_nys-avatar-width);
     overflow: hidden;
     box-sizing: border-box;
     color: var(--_nys-avatar-color);
-    background-color: var(--_nys-avatar-background);
+    background-color: var(--_nys-avatar-background-color);
     border: var(--_nys-avatar-border-size) solid var(--_nys-avatar-border-color);
     outline-offset: var(--_nys-avatar-outline-offset);
     transition: all 0.15s ease-in-out;
@@ -50,21 +50,21 @@ export default css`
   }
 
   :host([interactive]) .nys-avatar__component:hover {
-    --_nys-avatar-background: var(--nys-color-theme-mid, #457aa5);
+    --_nys-avatar-background-color: var(--nys-color-theme-mid, #457aa5);
   }
 
   :host([interactive]) .nys-avatar__component:active {
-    --_nys-avatar-background: var(--nys-color-theme-strong, #0e324f);
+    --_nys-avatar-background-color: var(--nys-color-theme-strong, #0e324f);
   }
 
   :host([disabled]) .nys-avatar__component {
     --_nys-avatar-color: var(--nys-color-text-disabled, #bec0c1);
-    --_nys-avatar-background: var(--nys-color-neutral-10, #f6f6f6);
+    --_nys-avatar-background-color: var(--nys-color-neutral-10, #f6f6f6);
     cursor: not-allowed;
   }
 
   :host([disabled]) .nys-avatar__component:focus-within {
-    outline: solid var(--_nys-avatar-width-focus) var(--_nys-avatar-color-focus);
+    outline: solid var(--_nys-avatar-outline-width) var(--_nys-avatar-outline-color);
   }
 
   div[part="nys-avatar__icon"] {
@@ -80,7 +80,7 @@ export default css`
     justify-content: center;
     width: 100%;
     height: 100%;
-    font-size: calc(var(--_nys-avatar-size) * 0.5);
+    font-size: calc(var(--_nys-avatar-width) * 0.5);
     font-weight: bold;
     text-transform: uppercase;
   }

--- a/packages/nys-avatar/src/nys-avatar.styles.ts
+++ b/packages/nys-avatar/src/nys-avatar.styles.ts
@@ -4,8 +4,11 @@ export default css`
   :host {
     /* Global Avatar Styles */
     --_nys-avatar-shape: var(--nys-radius-round, 1776px);
-    --_nys-avatar-border: var(--nys-font-size-6xl, 36px);
+    --_nys-avatar-border-color: var(--nys-color-ink-reverse, #fff);
+    --_nys-avatar-border-size: var(--nys-border-width-sm, 1px);
     --_nys-avatar-size: var(--nys-font-size-6xl, 36px);
+    --_nys-avatar-color: var(--nys-color-theme, #154973);
+    --_nys-avatar-background: var(--nys-color-theme-weaker, #46a4e7ff);
   }
 
   .nys-avatar {
@@ -22,7 +25,38 @@ export default css`
     font-size: var(--_nys-avatar-size);
     overflow: hidden;
     box-sizing: border-box;
-    color: white;
+    color: var(--_nys-avatar-color);
+    background-color: var(--_nys-avatar-background);
+    border: var(--_nys-avatar-border-size) solid var(--_nys-avatar-border-color);
+    transition: all 0.15s ease-in-out;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+  }
+
+  /* Hover/Active states/Disabled */
+  :host([interactive]) .nys-avatar__component:hover,
+  :host([interactive]) .nys-avatar__component:active {
+    --_nys-avatar-color: var(
+      --nys-color-text-reverse,
+      --nys-color-ink-reverse,
+      #fff
+    );
+    cursor: pointer;
+  }
+
+  :host([interactive]) .nys-avatar__component:hover {
+    --_nys-avatar-background: var(--nys-color-theme-mid, #457aa5);
+  }
+
+  :host([interactive]) .nys-avatar__component:active {
+    --_nys-avatar-background: var(--nys-color-theme-strong, #0e324f);
+  }
+
+  :host([disabled]) .nys-avatar__component {
+    --_nys-avatar-color: var(--nys-color-text-disabled, #bec0c1);
+    --_nys-avatar-background: var(--nys-color-neutral-10, #f6f6f6);
+    cursor: not-allowed;
   }
 
   /* Shape */

--- a/packages/nys-avatar/src/nys-avatar.styles.ts
+++ b/packages/nys-avatar/src/nys-avatar.styles.ts
@@ -64,7 +64,8 @@ export default css`
   }
 
   :host([disabled]) .nys-avatar__component:focus-within {
-    outline: solid var(--_nys-avatar-outline-width) var(--_nys-avatar-outline-color);
+    outline: solid var(--_nys-avatar-outline-width)
+      var(--_nys-avatar-outline-color);
   }
 
   div[part="nys-avatar__icon"] {

--- a/packages/nys-avatar/src/nys-avatar.styles.ts
+++ b/packages/nys-avatar/src/nys-avatar.styles.ts
@@ -8,7 +8,7 @@ export default css`
     --_nys-avatar-border-size: var(--nys-border-width-sm, 1px);
     --_nys-avatar-size: var(--nys-font-size-6xl, 36px);
     --_nys-avatar-color: var(--nys-color-theme, #154973);
-    --_nys-avatar-background: var(--nys-color-theme-weaker, #46a4e7ff);
+    --_nys-avatar-background: var(--nys-color-theme-weaker, #eff6fb);
     --_nys-avatar-color-focus: var(--nys-color-focus, #004dd1);
     --_nys-avatar-width-focus: var(--nys-border-width-md, 2px);
     --_nys-avatar-outline-offset: var(--nys-space-2px, 2px);

--- a/packages/nys-avatar/src/nys-avatar.test.ts
+++ b/packages/nys-avatar/src/nys-avatar.test.ts
@@ -3,15 +3,17 @@ import { NysAvatar } from "./nys-avatar";
 import "../dist/nys-avatar.js";
 
 describe("nys-avatar", () => {
-  it("should have default color as #555", async () => {
+  it("should have default color as #eff6fb", async () => {
     const el = await fixture<NysAvatar>(html`<nys-avatar></nys-avatar>`);
 
     const avatarContainer = el?.shadowRoot?.querySelector(
       ".nys-avatar__component",
     );
-    expect(avatarContainer?.getAttribute("style")).to.include(
-      "background-color: #555",
-    );
+    const bgColor =
+      avatarContainer && getComputedStyle(avatarContainer).backgroundColor;
+
+    // Check against the expected RGB value of #EFF6FB
+    expect(bgColor).to.equal("rgb(239, 246, 251)");
   });
 
   it("should have icon as default", async () => {

--- a/packages/nys-avatar/src/nys-avatar.test.ts
+++ b/packages/nys-avatar/src/nys-avatar.test.ts
@@ -3,11 +3,6 @@ import { NysAvatar } from "./nys-avatar";
 import "../dist/nys-avatar.js";
 
 describe("nys-avatar", () => {
-  it("should have default shape as circle", async () => {
-    const el = await fixture<NysAvatar>(html`<nys-avatar></nys-avatar>`);
-    expect(el?.shape).to.equal("circle");
-  });
-
   it("should have default color as #555", async () => {
     const el = await fixture<NysAvatar>(html`<nys-avatar></nys-avatar>`);
 

--- a/packages/nys-avatar/src/nys-avatar.ts
+++ b/packages/nys-avatar/src/nys-avatar.ts
@@ -143,7 +143,6 @@ export class NysAvatar extends LitElement {
                         name=${this.icon?.length > 0
                           ? this.icon
                           : "account_circle"}
-                        size="xl"
                       ></nys-icon>
                     </div>`}
           </div>

--- a/packages/nys-avatar/src/nys-avatar.ts
+++ b/packages/nys-avatar/src/nys-avatar.ts
@@ -18,29 +18,6 @@ export class NysAvatar extends LitElement {
   @property({ type: Boolean, reflect: true }) interactive = false;
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) lazy = false;
-  private static readonly VALID_SHAPES = [
-    "square",
-    "rounded",
-    "circle",
-  ] as const;
-
-  // Private property to store the internal `shape` value, restricted to the valid types. Default is "circle".
-  private _shape: (typeof NysAvatar.VALID_SHAPES)[number] = "circle";
-
-  // Getter for the `shape` property.
-  @property({ reflect: true })
-  get shape(): (typeof NysAvatar.VALID_SHAPES)[number] {
-    return this._shape;
-  }
-  // Setter for the `shape` property.
-  set shape(value: string) {
-    this._shape = NysAvatar.VALID_SHAPES.includes(
-      value as (typeof NysAvatar.VALID_SHAPES)[number],
-    )
-      ? (value as (typeof NysAvatar.VALID_SHAPES)[number])
-      : "circle";
-    this.requestUpdate("shape");
-  }
   @state() private _slotHasContent = true;
 
   /******************** Functions ********************/

--- a/packages/nys-avatar/src/nys-avatar.ts
+++ b/packages/nys-avatar/src/nys-avatar.ts
@@ -102,7 +102,7 @@ export class NysAvatar extends LitElement {
             part="nys-avatar"
             class="nys-avatar__component"
             style=${this.color
-              ? `--_nys-avatar-background: ${this.color}; color: ${this.getContrastForeground()}`
+              ? `--_nys-avatar-background-color: ${this.color}; color: ${this.getContrastForeground()}`
               : ""}
             role=${ifDefined(
               this.interactive ? "button" : this.image ? undefined : "img",


### PR DESCRIPTION
# Summary

New updates to `nys-avatar`:
- new base color
- removed `shape` prop
- new logic that changes the inner foreground initial/icon color based on the `color` prop
- Add `disabled` prop
- Add `interactive` prop

## Breaking change
:warning: This is **100%** a breaking change upstream! :warning:
@esteinborn Please announce the removal of the `shape` property, as design dictates that the avatar should have only a "circle" shape. This is a **breaking change to EVERYONE** using this component!

## Related issues

Closes #346 🎟️

## Screenshot
<img width="82" height="50" alt="Screenshot 2025-08-28 at 6 16 20 PM" src="https://github.com/user-attachments/assets/7a658669-490f-423c-944a-d800ebccd2e7" />
