### PR TITLE
Fix active link for home routes'

### DIFF
--- a/packages/nys-globalheader/src/nys-globalheader.ts
+++ b/packages/nys-globalheader/src/nys-globalheader.ts
@@ -72,9 +72,17 @@ export class NysGlobalHeader extends LitElement {
 
             if (!linkPath) return;
 
-            if (currentUrl?.startsWith(linkPath)) {
-              const li = a.closest("li");
-              if (li) li.classList.add("active");
+            if (linkPath === "/") {
+              // Only match if it's exactly the homepage
+              if (currentUrl === "/") {
+                const li = a.closest("li");
+                if (li) li.classList.add("active");
+              }
+            } else {
+              if (currentUrl?.startsWith(linkPath)) {
+                const li = a.closest("li");
+                if (li) li.classList.add("active");
+              }
             }
           });
           cleanNodeMobile.querySelectorAll("a").forEach((a) => {
@@ -83,9 +91,17 @@ export class NysGlobalHeader extends LitElement {
 
             if (!linkPath) return;
 
-            if (currentUrl?.startsWith(linkPath)) {
-              const li = a.closest("li");
-              if (li) li.classList.add("active");
+            if (linkPath === "/") {
+              // Only match if it's exactly the homepage
+              if (currentUrl === "/") {
+                const li = a.closest("li");
+                if (li) li.classList.add("active");
+              }
+            } else {
+              if (currentUrl?.startsWith(linkPath)) {
+                const li = a.closest("li");
+                if (li) li.classList.add("active");
+              }
             }
           });
 


### PR DESCRIPTION

# Summary

Fix issue with `nys-globalheader` active route highlighting.
Previously, the root path (`/`) was always highlighted because the active route check used `startsWith()`

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change


This is **not** a breaking change.  


## Related issues

Closes #853 🎟️

<!--
Every pull request should resolve an open issue.
If no issue exists, please create one so we can track the changes at:
https://github.com/its-hcd/nysds/issues/new/choose
-->

## Testing
Tested in React Demo