### PR TITLE
Feature: tooltip prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13825,6 +13825,10 @@
       "name": "@nysds/nys-label",
       "version": "1.8.0",
       "license": "MIT",
+      "dependencies": {
+        "@nysds/nys-icon": "^1.8.0",
+        "@nysds/nys-tooltip": "^1.8.0"
+      },
       "devDependencies": {
         "lit": "^3.2.1",
         "typescript": "^5.7.2",

--- a/packages/nys-checkbox/src/nys-checkbox.mdx
+++ b/packages/nys-checkbox/src/nys-checkbox.mdx
@@ -29,34 +29,34 @@ The **`nys-checkbox`** component is a reusable web component for use in New York
 
 <Controls />
 
-### Variants
-#### Checkbox Grouping
+## Options
+### Checkbox Grouping
 ⚠️ Important: While optional, you may find wrapping checkboxes with **`nys-checkboxgroup`** helpful for multiple selections with the same checkbox name. This ensures they function as a single form control visually & in validation.
 - When using **`nys-checkboxgroup`**, you can add `errorMessage` and `required` at the group level instead of on individual `nys-checkbox`.
 - For grouping to work correctly, all `nys-checkbox` elements within the same **`nys-checkboxgroup`** must have the same name attribute. This allows the form to recognize them as a related set of options.
 <Canvas of={NysCheckboxStories.Grouping} />
 
-#### Disabled
+### Disabled
 <Canvas of={NysCheckboxStories.Disabled} />
 #### Size
 Set the `size` prop of the **`nys-checkboxgroup`** to have all **`nys-checkbox`** be the same size. Our current sizes are:
 - `sm`: Set to 24px in width and height
 - `md`: The default size. Set to 32px in width and height.
 <Canvas of={NysCheckboxStories.Size} />
-#### Tile
+### Tile
 The `tile` prop will change the styling of the checkbox to a tile. This is useful when you want a larger clickable area for the user.\
 - The `tile` prop can be applied to the `nys-checkboxgroup` or the `nys-checkbox` component. If applied to the `nys-checkboxgroup`, all checkboxes will be displayed as tiles. If applied to the `nys-checkbox`, only that checkbox will be displayed as a tile.
 - Do not use the `tile` prop on a checkbox if it is inside a `nys-checkboxgroup`. All checkboxes in a group should be the same size and style.
 <Canvas of={NysCheckboxStories.Tile} />
-#### Required
+### Required
 <Canvas of={NysCheckboxStories.Required} />
-#### Optional
+### Optional
 Adding the `optional` prop will add an optional flag to the input.
 <Canvas of={NysCheckboxStories.Optional} />
-#### Error Message
+### Error Message
 The error message will appear **ONLY** when the `showError` attribute is set to `true`. Setting `errorMessage` will not display the error message by default.
 <Canvas of={NysCheckboxStories.ErrorMessage} />
-#### Slots
+### Slots
 When the description requires more complexity than a simple `string` value,  add your HTML content directly within the component as slot content, rather than setting a `description` prop. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`
 <Canvas of={NysCheckboxStories.Slot} />
 

--- a/packages/nys-checkbox/src/nys-checkbox.mdx
+++ b/packages/nys-checkbox/src/nys-checkbox.mdx
@@ -59,10 +59,6 @@ The error message will appear **ONLY** when the `showError` attribute is set to 
 ### Slots
 When the description requires more complexity than a simple `string` value,  add your HTML content directly within the component as slot content, rather than setting a `description` prop. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`
 <Canvas of={NysCheckboxStories.Slot} />
-### Tooltip
-Pass in the `tooltip` prop to display a tooltip as a hint for users. \
-**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
-<Canvas of={NysCheckboxStories.Tooltip} />
 
 ## Usage
 

--- a/packages/nys-checkbox/src/nys-checkbox.mdx
+++ b/packages/nys-checkbox/src/nys-checkbox.mdx
@@ -59,6 +59,10 @@ The error message will appear **ONLY** when the `showError` attribute is set to 
 ### Slots
 When the description requires more complexity than a simple `string` value,  add your HTML content directly within the component as slot content, rather than setting a `description` prop. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`
 <Canvas of={NysCheckboxStories.Slot} />
+### Tooltip
+Pass in the `tooltip` prop to display a tooltip as a hint for users. \
+**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
+<Canvas of={NysCheckboxStories.Tooltip} />
 
 ## Usage
 

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -23,6 +23,7 @@ interface NysCheckboxArgs {
   errorMessage: string;
   form: string;
   tooltip: string;
+  tooltipInverted: boolean;
 }
 
 const meta: Meta<NysCheckboxArgs> = {
@@ -44,6 +45,7 @@ const meta: Meta<NysCheckboxArgs> = {
     errorMessage: { control: "text" },
     form: { control: "text" },
     tooltip: { control: "text" },
+    tooltipInverted: { control: "boolean" },
   },
   parameters: {
     docs: {
@@ -69,6 +71,7 @@ export const Basic: Story = {
     name: "landmarks",
     value: "adirondacks",
     tooltip: "",
+    tooltipInverted: false,
     showError: false,
     errorMessage: "",
     tile: false,
@@ -84,6 +87,7 @@ export const Basic: Story = {
       .errorMessage=${args.errorMessage}
       .form=${args.form}
       .tooltip=${args.tooltip}
+      .tooltipInverted=${args.tooltipInverted}
     >
       <nys-checkbox
         .checked=${args.checked}

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -826,13 +826,32 @@ export const Tooltip: Story = {
     docs: {
       source: {
         code: `
-<nys-checkbox
-  disabled
-  label="Register for Early Voting"
-  description="This option is currently unavailable."
-  name="earlyVoting"
-  value="early-voting"
-></nys-checkbox>
+<nys-checkboxgroup
+  label="Select NYS Services"
+  description="Choose the services you want to access online."
+  tooltip="Select services to access their online applications."
+>
+  <nys-checkbox
+    name="services"
+    value="driver_license_renewal"
+    label="Driver License Renewal"
+  ></nys-checkbox>
+  <nys-checkbox
+    name="services"
+    value="vehicle_registration"
+    label="Vehicle Registration"
+  ></nys-checkbox>
+  <nys-checkbox
+    name="services"
+    value="tax_assistance"
+    label="State Tax Assistance"
+  ></nys-checkbox>
+  <nys-checkbox
+    name="services"
+    value="none"
+    label="None of the above"
+  ></nys-checkbox>
+</nys-checkboxgroup>
         `.trim(),
       },
     },

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -1,8 +1,6 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-checkbox";
-import "@nysds/nys-icon";
-import "@nysds/nys-tooltip";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
 
@@ -22,8 +20,6 @@ interface NysCheckboxArgs {
   showError: boolean;
   errorMessage: string;
   form: string;
-  tooltip: string;
-  tooltipInverted: boolean;
 }
 
 const meta: Meta<NysCheckboxArgs> = {
@@ -44,8 +40,6 @@ const meta: Meta<NysCheckboxArgs> = {
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
     form: { control: "text" },
-    tooltip: { control: "text" },
-    tooltipInverted: { control: "boolean" },
   },
   parameters: {
     docs: {
@@ -70,8 +64,6 @@ export const Basic: Story = {
     description: "",
     name: "landmarks",
     value: "adirondacks",
-    tooltip: "",
-    tooltipInverted: false,
     showError: false,
     errorMessage: "",
     tile: false,
@@ -86,8 +78,6 @@ export const Basic: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
-      .tooltipInverted=${args.tooltipInverted}
     >
       <nys-checkbox
         .checked=${args.checked}
@@ -178,7 +168,6 @@ export const Grouping: Story = {
         .showError=${args.showError}
         .errorMessage=${args.errorMessage}
         .form=${args.form}
-        .tooltip=${args.tooltip}
         .required=${args.required}
         .optional=${args.optional}
       >
@@ -305,7 +294,6 @@ export const Disabled: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     ></nys-checkbox>
     <nys-checkbox
       checked
@@ -319,7 +307,6 @@ export const Disabled: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     ></nys-checkbox>
   `,
   parameters: {
@@ -365,7 +352,6 @@ export const Size: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     >
       <nys-checkbox
         .checked=${args.checked}
@@ -455,7 +441,6 @@ export const Tile: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     >
       <nys-checkbox
         .checked=${args.checked}
@@ -555,7 +540,6 @@ export const Required: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     ></nys-checkbox>
   `,
   parameters: {
@@ -604,7 +588,6 @@ export const ErrorMessage: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .tile=${args.tile}
     ></nys-checkbox>
   `,
@@ -654,7 +637,6 @@ export const Slot: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     >
       <p slot="description">
         ${args.description}<a href="https://www.ny.gov/" target="__blank"
@@ -705,7 +687,6 @@ export const Optional: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .required=${args.required}
       .optional=${args.optional}
     >
@@ -776,87 +757,6 @@ export const Optional: Story = {
         `,
 
         type: "auto",
-      },
-    },
-  },
-};
-
-// Story: Tooltip
-export const Tooltip: Story = {
-  args: {
-    label: "Select NYS Services",
-    description: "Choose the services you want to access online.",
-    tooltip: "Select services to access their online applications.",
-  },
-  render: (args) => html`
-    <div style="display: flex; gap: 8px;">
-      <nys-checkboxgroup
-        style="flex: 1;"
-        label=${args.label}
-        description=${args.description}
-        size=${args.size}
-        .tile=${args.tile}
-        .showError=${args.showError}
-        .errorMessage=${args.errorMessage}
-        .form=${args.form}
-        .tooltip=${args.tooltip}
-        .required=${args.required}
-        .optional=${args.optional}
-      >
-        <nys-checkbox
-          name="services"
-          value="driver_license_renewal"
-          label="Driver License Renewal"
-        ></nys-checkbox>
-        <nys-checkbox
-          name="services"
-          value="vehicle_registration"
-          label="Vehicle Registration"
-        ></nys-checkbox>
-        <nys-checkbox
-          name="services"
-          value="tax_assistance"
-          label="State Tax Assistance"
-        ></nys-checkbox>
-        <nys-checkbox
-          name="services"
-          value="none"
-          label="None of the above"
-        ></nys-checkbox>
-      </nys-checkboxgroup>
-    </div>
-  `,
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-checkboxgroup
-  label="Select NYS Services"
-  description="Choose the services you want to access online."
-  tooltip="Select services to access their online applications."
->
-  <nys-checkbox
-    name="services"
-    value="driver_license_renewal"
-    label="Driver License Renewal"
-  ></nys-checkbox>
-  <nys-checkbox
-    name="services"
-    value="vehicle_registration"
-    label="Vehicle Registration"
-  ></nys-checkbox>
-  <nys-checkbox
-    name="services"
-    value="tax_assistance"
-    label="State Tax Assistance"
-  ></nys-checkbox>
-  <nys-checkbox
-    name="services"
-    value="none"
-    label="None of the above"
-  ></nys-checkbox>
-</nys-checkboxgroup>
-        `.trim(),
       },
     },
   },

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -1,9 +1,10 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-checkbox";
+import "@nysds/nys-icon";
+import "@nysds/nys-tooltip";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
-import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysCheckboxArgs {
@@ -20,6 +21,8 @@ interface NysCheckboxArgs {
   optional: boolean;
   showError: boolean;
   errorMessage: string;
+  form: string;
+  tooltip: string;
 }
 
 const meta: Meta<NysCheckboxArgs> = {
@@ -39,6 +42,8 @@ const meta: Meta<NysCheckboxArgs> = {
     value: { control: "text" },
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
+    form: { control: "text" },
+    tooltip: { control: "text" },
   },
   parameters: {
     docs: {
@@ -63,6 +68,7 @@ export const Basic: Story = {
     description: "",
     name: "landmarks",
     value: "adirondacks",
+    tooltip: "",
     showError: false,
     errorMessage: "",
     tile: false,
@@ -76,6 +82,8 @@ export const Basic: Story = {
       .tile=${args.tile}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     >
       <nys-checkbox
         .checked=${args.checked}
@@ -165,6 +173,8 @@ export const Grouping: Story = {
         .tile=${args.tile}
         .showError=${args.showError}
         .errorMessage=${args.errorMessage}
+        .form=${args.form}
+        .tooltip=${args.tooltip}
         .required=${args.required}
         .optional=${args.optional}
       >
@@ -290,6 +300,8 @@ export const Disabled: Story = {
       .value=${args.value}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     ></nys-checkbox>
     <nys-checkbox
       checked
@@ -302,6 +314,8 @@ export const Disabled: Story = {
       .value=${args.value}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     ></nys-checkbox>
   `,
   parameters: {
@@ -346,6 +360,8 @@ export const Size: Story = {
       .tile=${args.tile}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     >
       <nys-checkbox
         .checked=${args.checked}
@@ -434,6 +450,8 @@ export const Tile: Story = {
       .tile=${args.tile}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     >
       <nys-checkbox
         .checked=${args.checked}
@@ -532,6 +550,8 @@ export const Required: Story = {
       .value=${args.value}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     ></nys-checkbox>
   `,
   parameters: {
@@ -579,6 +599,8 @@ export const ErrorMessage: Story = {
       .value=${args.value}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
       .tile=${args.tile}
     ></nys-checkbox>
   `,
@@ -627,6 +649,8 @@ export const Slot: Story = {
       .value=${args.value}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     >
       <p slot="description">
         ${args.description}<a href="https://www.ny.gov/" target="__blank"
@@ -676,6 +700,8 @@ export const Optional: Story = {
       .tile=${args.tile}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
       .required=${args.required}
       .optional=${args.optional}
     >
@@ -746,6 +772,68 @@ export const Optional: Story = {
         `,
 
         type: "auto",
+      },
+    },
+  },
+};
+
+// Story: Tooltip
+export const Tooltip: Story = {
+  args: {
+    label: "Select NYS Services",
+    description: "Choose the services you want to access online.",
+    tooltip: "Select services to access their online applications.",
+  },
+  render: (args) => html`
+    <div style="display: flex; gap: 8px;">
+      <nys-checkboxgroup
+        style="flex: 1;"
+        label=${args.label}
+        description=${args.description}
+        size=${args.size}
+        .tile=${args.tile}
+        .showError=${args.showError}
+        .errorMessage=${args.errorMessage}
+        .form=${args.form}
+        .tooltip=${args.tooltip}
+        .required=${args.required}
+        .optional=${args.optional}
+      >
+        <nys-checkbox
+          name="services"
+          value="driver_license_renewal"
+          label="Driver License Renewal"
+        ></nys-checkbox>
+        <nys-checkbox
+          name="services"
+          value="vehicle_registration"
+          label="Vehicle Registration"
+        ></nys-checkbox>
+        <nys-checkbox
+          name="services"
+          value="tax_assistance"
+          label="State Tax Assistance"
+        ></nys-checkbox>
+        <nys-checkbox
+          name="services"
+          value="none"
+          label="None of the above"
+        ></nys-checkbox>
+      </nys-checkboxgroup>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-checkbox
+  disabled
+  label="Register for Early Voting"
+  description="This option is currently unavailable."
+  name="earlyVoting"
+  value="early-voting"
+></nys-checkbox>
+        `.trim(),
       },
     },
   },

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -16,7 +16,7 @@ export class NysCheckboxgroup extends LitElement {
   @property({ type: Boolean, reflect: true }) tile = false;
   @property({ type: String, reflect: true }) form = "";
   @property({ type: String }) tooltip = "";
-    @property({ type: Boolean, reflect: true }) tooltipInverted = false;
+  @property({ type: Boolean, reflect: true }) tooltipInverted = false;
   @state() private _slottedDescriptionText = "";
   private static readonly VALID_SIZES = ["sm", "md"] as const;
   private _size: (typeof NysCheckboxgroup.VALID_SIZES)[number] = "md";

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -16,6 +16,7 @@ export class NysCheckboxgroup extends LitElement {
   @property({ type: Boolean, reflect: true }) tile = false;
   @property({ type: String, reflect: true }) form = "";
   @property({ type: String }) tooltip = "";
+    @property({ type: Boolean, reflect: true }) tooltipInverted = false;
   @state() private _slottedDescriptionText = "";
   private static readonly VALID_SIZES = ["sm", "md"] as const;
   private _size: (typeof NysCheckboxgroup.VALID_SIZES)[number] = "md";
@@ -280,6 +281,7 @@ export class NysCheckboxgroup extends LitElement {
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
           tooltip=${this.tooltip}
+          ?tooltipInverted=${this.tooltipInverted}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -15,6 +15,7 @@ export class NysCheckboxgroup extends LitElement {
   @property({ type: String }) description = "";
   @property({ type: Boolean, reflect: true }) tile = false;
   @property({ type: String, reflect: true }) form = "";
+  @property({ type: String }) tooltip = "";
   @state() private _slottedDescriptionText = "";
   private static readonly VALID_SIZES = ["sm", "md"] as const;
   private _size: (typeof NysCheckboxgroup.VALID_SIZES)[number] = "md";
@@ -278,6 +279,7 @@ export class NysCheckboxgroup extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
+          tooltip=${this.tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -15,8 +15,7 @@ export class NysCheckboxgroup extends LitElement {
   @property({ type: String }) description = "";
   @property({ type: Boolean, reflect: true }) tile = false;
   @property({ type: String, reflect: true }) form = "";
-  @property({ type: String }) tooltip = "";
-  @property({ type: Boolean, reflect: true }) tooltipInverted = false;
+  @property({ type: String }) _tooltip = "";
   @state() private _slottedDescriptionText = "";
   private static readonly VALID_SIZES = ["sm", "md"] as const;
   private _size: (typeof NysCheckboxgroup.VALID_SIZES)[number] = "md";
@@ -280,8 +279,7 @@ export class NysCheckboxgroup extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
-          tooltip=${this.tooltip}
-          ?tooltipInverted=${this.tooltipInverted}
+          tooltip=${this._tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-fileinput/src/nys-fileinput.mdx
+++ b/packages/nys-fileinput/src/nys-fileinput.mdx
@@ -59,6 +59,11 @@ Set `disabled` to prevent interaction with the file input. Useful when the input
 You can supply a description via our `description` prop for plain text or by embedding HTML within our component via our slot for higher customization.
 <Canvas of={NysFileinputStories.DescriptionSlot} />
 
+### Tooltip
+Pass in the `tooltip` prop to display a tooltip as a hint for users. \
+**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
+<Canvas of={NysFileinputStories.Tooltip} />
+
 ## Usage
 
 ### When to use this component

--- a/packages/nys-fileinput/src/nys-fileinput.mdx
+++ b/packages/nys-fileinput/src/nys-fileinput.mdx
@@ -59,11 +59,6 @@ Set `disabled` to prevent interaction with the file input. Useful when the input
 You can supply a description via our `description` prop for plain text or by embedding HTML within our component via our slot for higher customization.
 <Canvas of={NysFileinputStories.DescriptionSlot} />
 
-### Tooltip
-Pass in the `tooltip` prop to display a tooltip as a hint for users. \
-**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
-<Canvas of={NysFileinputStories.Tooltip} />
-
 ## Usage
 
 ### When to use this component

--- a/packages/nys-fileinput/src/nys-fileinput.stories.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.stories.ts
@@ -2,7 +2,6 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-fileinput";
 import "@nysds/nys-icon";
-import "@nysds/nys-tooltip";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
 import "@nysds/nys-button";
@@ -23,7 +22,6 @@ interface NysFileinputArgs {
   showError?: boolean;
   dropzone?: boolean;
   form?: string;
-  tooltip?: string;
 }
 
 const meta: Meta<NysFileinputArgs> = {
@@ -48,7 +46,6 @@ const meta: Meta<NysFileinputArgs> = {
     showError: { control: "boolean" },
     dropzone: { control: "boolean" },
     form: { control: "text" },
-    tooltip: { control: "text" },
   },
   parameters: {
     docs: {
@@ -77,7 +74,6 @@ export const Basic: Story = {
     errorMessage: "",
     showError: false,
     dropzone: false,
-    tooltip: "",
   },
   render: (args) => html`
     <nys-fileinput
@@ -95,7 +91,6 @@ export const Basic: Story = {
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -138,7 +133,6 @@ export const Dropzone: Story = {
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -181,7 +175,6 @@ export const Width: Story = {
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -224,7 +217,6 @@ export const Multiple: Story = {
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -270,7 +262,6 @@ export const Disabled: Story = {
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -314,7 +305,6 @@ export const DescriptionSlot: Story = {
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     >
       <span slot="description">
         Learn more at
@@ -337,46 +327,6 @@ export const DescriptionSlot: Story = {
     <a href="https://www.ny.gov" target="_blank" rel="noopener">ny.gov</a>
   </span>
 </nys-fileinput>`,
-        type: "auto",
-      },
-    },
-  },
-};
-
-export const Tooltip: Story = {
-  args: {
-    label: "Upload a file",
-    description: "Accepted file types: .jpg, .png, .pdf",
-    tooltip: "Maximum file size is 10MB",
-  },
-  render: (args) => html`
-    <nys-fileinput
-      .id=${args.id}
-      .name=${args.name}
-      .label=${args.label}
-      .description=${args.description}
-      .width=${args.width}
-      ?multiple=${args.multiple}
-      .accept=${args.accept}
-      ?required=${args.required}
-      ?optional=${args.optional}
-      ?disabled=${args.disabled}
-      .errorMessage=${args.errorMessage}
-      ?showError=${args.showError}
-      ?dropzone=${args.dropzone}
-      .form=${args.form}
-      .tooltip=${args.tooltip}
-    ></nys-fileinput>
-  `,
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-fileinput
-  label="Upload a file"
-  description="Accepted file types: .jpg, .png, .pdf"
-  tooltip="Maximum file size is 10MB">
-></nys-fileinput>`,
         type: "auto",
       },
     },

--- a/packages/nys-fileinput/src/nys-fileinput.stories.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.stories.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-fileinput";
 import "@nysds/nys-icon";
+import "@nysds/nys-tooltip";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
 import "@nysds/nys-button";
@@ -21,6 +22,8 @@ interface NysFileinputArgs {
   errorMessage?: string;
   showError?: boolean;
   dropzone?: boolean;
+  form?: string;
+  tooltip?: string;
 }
 
 const meta: Meta<NysFileinputArgs> = {
@@ -44,6 +47,8 @@ const meta: Meta<NysFileinputArgs> = {
     errorMessage: { control: "text" },
     showError: { control: "boolean" },
     dropzone: { control: "boolean" },
+    form: { control: "text" },
+    tooltip: { control: "text" },
   },
   parameters: {
     docs: {
@@ -72,6 +77,7 @@ export const Basic: Story = {
     errorMessage: "",
     showError: false,
     dropzone: false,
+    tooltip: "",
   },
   render: (args) => html`
     <nys-fileinput
@@ -88,6 +94,8 @@ export const Basic: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -129,6 +137,8 @@ export const Dropzone: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -170,6 +180,8 @@ export const Width: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -211,6 +223,8 @@ export const Multiple: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -255,6 +269,8 @@ export const Disabled: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     ></nys-fileinput>
   `,
   parameters: {
@@ -287,7 +303,18 @@ export const DescriptionSlot: Story = {
       .id=${args.id}
       .name=${args.name}
       .label=${args.label}
+      .description=${args.description}
       .width=${args.width}
+      ?multiple=${args.multiple}
+      .accept=${args.accept}
+      ?required=${args.required}
+      ?optional=${args.optional}
+      ?disabled=${args.disabled}
+      .errorMessage=${args.errorMessage}
+      ?showError=${args.showError}
+      ?dropzone=${args.dropzone}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     >
       <span slot="description">
         Learn more at
@@ -310,6 +337,46 @@ export const DescriptionSlot: Story = {
     <a href="https://www.ny.gov" target="_blank" rel="noopener">ny.gov</a>
   </span>
 </nys-fileinput>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Tooltip: Story = {
+  args: {
+    label: "Upload a file",
+    description: "Accepted file types: .jpg, .png, .pdf",
+    tooltip: "Maximum file size is 10MB",
+  },
+  render: (args) => html`
+    <nys-fileinput
+      .id=${args.id}
+      .name=${args.name}
+      .label=${args.label}
+      .description=${args.description}
+      .width=${args.width}
+      ?multiple=${args.multiple}
+      .accept=${args.accept}
+      ?required=${args.required}
+      ?optional=${args.optional}
+      ?disabled=${args.disabled}
+      .errorMessage=${args.errorMessage}
+      ?showError=${args.showError}
+      ?dropzone=${args.dropzone}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
+    ></nys-fileinput>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-fileinput
+  label="Upload a file"
+  description="Accepted file types: .jpg, .png, .pdf"
+  tooltip="Maximum file size is 10MB">
+></nys-fileinput>`,
         type: "auto",
       },
     },

--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -20,7 +20,8 @@ export class NysFileinput extends LitElement {
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: Boolean }) multiple = false;
-  @property({ type: String }) form = "";
+  @property({ type: String, reflect: true }) form = "";
+  @property({ type: String }) tooltip = "";
   @property({ type: String }) accept = ""; // e.g. "image/*,.pdf"
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) required = false;
@@ -434,6 +435,7 @@ export class NysFileinput extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : this.optional ? "optional" : ""}
+        tooltip=${this.tooltip}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -435,7 +435,7 @@ export class NysFileinput extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : this.optional ? "optional" : ""}
-        tooltip=${this._tooltip}
+        _tooltip=${this._tooltip}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -21,7 +21,7 @@ export class NysFileinput extends LitElement {
   @property({ type: String }) description = "";
   @property({ type: Boolean }) multiple = false;
   @property({ type: String, reflect: true }) form = "";
-  @property({ type: String }) tooltip = "";
+  @property({ type: String }) _tooltip = "";
   @property({ type: String }) accept = ""; // e.g. "image/*,.pdf"
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) required = false;
@@ -435,7 +435,7 @@ export class NysFileinput extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : this.optional ? "optional" : ""}
-        tooltip=${this.tooltip}
+        tooltip=${this._tooltip}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-label/package.json
+++ b/packages/nys-label/package.json
@@ -24,6 +24,10 @@
   "peerDependencies": {
     "lit": "^3.2.1"
   },
+  "dependencies": {
+    "@nysds/nys-icon": "^1.8.0",
+    "@nysds/nys-tooltip": "^1.8.0"
+  },
   "devDependencies": {
     "lit": "^3.2.1",
     "typescript": "^5.7.2",

--- a/packages/nys-label/src/nys-label.mdx
+++ b/packages/nys-label/src/nys-label.mdx
@@ -42,6 +42,8 @@ The **`nys-label`** is a reusable web component for use in New York State digita
 <Canvas of={NysLabelStories.Required} />
 #### Optional
 <Canvas of={NysLabelStories.Optional} />
+#### Tooltip
+<Canvas of={NysLabelStories.Tooltip} />
 
 ## Use cases
 

--- a/packages/nys-label/src/nys-label.stories.ts
+++ b/packages/nys-label/src/nys-label.stories.ts
@@ -1,12 +1,15 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-label";
+import '@nysds/nys-icon';
+import '@nysds/nys-tooltip';
 
 // Define the structure of the args used in the stories
 interface NysLabelArgs {
   label: string;
   description: string;
   flag: string | null;
+  tooltip?: string;
 }
 
 const meta: Meta<NysLabelArgs> = {
@@ -22,6 +25,7 @@ const meta: Meta<NysLabelArgs> = {
       options: [null, "required", "optional"],
       defaultValue: { summary: `null` },
     },
+    tooltip: { control: { type: "text" } },
   },
   parameters: {
     docs: {
@@ -40,6 +44,7 @@ export const Basic: Story = {
   args: {
     label: "This is a basic nys-label",
     description: "",
+    tooltip: "",
     flag: null,
   },
   render: (args) =>
@@ -47,6 +52,7 @@ export const Basic: Story = {
       label=${args.label}
       description=${args.description}
       flag=${args.flag}
+      tooltip=${args.tooltip}
     ></nys-label>`,
   parameters: {
     docs: {
@@ -69,6 +75,7 @@ export const Description: Story = {
       label=${args.label}
       description=${args.description}
       flag=${args.flag}
+      tooltip=${args.tooltip}
     ></nys-label>`,
   parameters: {
     docs: {
@@ -91,7 +98,11 @@ export const DescriptionSlot: Story = {
     flag: null,
   },
   render: (args) =>
-    html`<nys-label label=${args.label} flag=${args.flag}>
+    html`<nys-label
+      label=${args.label}
+      flag=${args.flag}
+      tooltip=${args.tooltip}
+    >
       <label slot="description"
         >${args.description}
         <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a"
@@ -123,6 +134,7 @@ export const Required: Story = {
       label=${args.label}
       description=${args.description}
       flag=${args.flag}
+      tooltip=${args.tooltip}
     ></nys-label>`,
   parameters: {
     docs: {
@@ -149,6 +161,7 @@ export const Optional: Story = {
       label=${args.label}
       description=${args.description}
       flag=${args.flag}
+      tooltip=${args.tooltip}
     ></nys-label>`,
   parameters: {
     docs: {
@@ -157,6 +170,33 @@ export const Optional: Story = {
   <nys-label 
       label="This form is optional"
       flag="optional"
+  ></nys-label>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Tooltip: Story = {
+  args: {
+    label: "This label has a tooltip",
+    description: "",
+    tooltip: "Helpful tooltip text",
+  },
+  render: (args) =>
+    html`<nys-label
+      label=${args.label}
+      description=${args.description}
+      flag=${args.flag}
+      tooltip=${args.tooltip}
+    ></nys-label>`,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  <nys-label 
+      label="This label has a tooltip"
+      tooltip="Helpful tooltip text"
   ></nys-label>`,
         type: "auto",
       },

--- a/packages/nys-label/src/nys-label.stories.ts
+++ b/packages/nys-label/src/nys-label.stories.ts
@@ -1,8 +1,8 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-label";
-import '@nysds/nys-icon';
-import '@nysds/nys-tooltip';
+import "@nysds/nys-icon";
+import "@nysds/nys-tooltip";
 
 // Define the structure of the args used in the stories
 interface NysLabelArgs {

--- a/packages/nys-label/src/nys-label.styles.ts
+++ b/packages/nys-label/src/nys-label.styles.ts
@@ -33,7 +33,7 @@ export default css`
     --nys-optional-font-color: var(--nys-color-text-weak, #4a4d4f);
 
     /* Spacing */
-    --_nys-label-gap: var(--nys-space-2px, 2px);
+    --_nys-label-gap: var(--nys-space-4px, 4px);
   }
 
   .nys-label {
@@ -46,12 +46,9 @@ export default css`
     letter-spacing: var(--_nys-label-letter-spacing);
   }
 
-  .nys-label__labelwrapper {
+  .nys-label__label {
     display: flex;
     gap: var(--_nys-label-gap);
-  }
-
-  .nys-label__label {
     text-align: left;
     font-weight: var(--_nys-label-font-weight);
     color: var(--_nys-label-color);
@@ -72,5 +69,14 @@ export default css`
   .nys-label__optional {
     font-weight: var(--nys-optional-font-weight);
     color: var(--nys-optional-font-color);
+  }
+
+  .nys-label__tooltip-wrapper {
+    display: flex;
+    gap: 5px;
+  }
+
+  .nys-label__tooltip-icon {
+    margin-top: -2px;
   }
 `;

--- a/packages/nys-label/src/nys-label.ts
+++ b/packages/nys-label/src/nys-label.ts
@@ -7,8 +7,15 @@ export class NysLabel extends LitElement {
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: String }) flag = "";
-  @property({ type: String }) tooltip = "";
   @property({ type: Boolean, reflect: true }) tooltipInverted = false;
+  @property({ type: String })
+  get tooltip() {
+    return this._tooltip;
+  }
+  set tooltip(value: string) {
+    this._tooltip = value;
+  }
+  private _tooltip: string = "";
 
   static styles = styles;
 
@@ -25,9 +32,9 @@ export class NysLabel extends LitElement {
               ? html`<div class="nys-label__optional">(Optional)</div>`
               : ""}</label
           >
-          ${this.tooltip
+          ${this._tooltip
             ? html`<nys-tooltip
-                text="${this.tooltip}"
+                text="${this._tooltip}"
                 position="top"
                 focusable
                 ?inverted=${this.tooltipInverted}

--- a/packages/nys-label/src/nys-label.ts
+++ b/packages/nys-label/src/nys-label.ts
@@ -7,22 +7,32 @@ export class NysLabel extends LitElement {
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: String }) flag = "";
+  @property({ type: String }) tooltip = "";
 
   static styles = styles;
 
   render() {
     return html`
       <div class="nys-label">
-        <label for=${this.id} class="nys-label__label"
-          >${this.label}
-          ${this.flag === "required"
-            ? html`<label class="nys-label__required">*</label>`
+        <div class="nys-label__tooltip-wrapper">
+          <label for=${this.for} class="nys-label__label"
+            >${this.label}
+            ${this.flag === "required"
+              ? html`<div class="nys-label__required">*</div>`
+              : ""}
+            ${this.flag === "optional"
+              ? html`<div class="nys-label__optional">(Optional)</div>`
+              : ""}</label
+          >
+          ${this.tooltip
+            ? html`<nys-tooltip text="${this.tooltip}" position="top" focusable>
+                <div class="nys-label__tooltip-icon">
+                  <nys-icon name="info" size="3xl"></nys-icon>
+                </div>
+              </nys-tooltip>`
             : ""}
-          ${this.flag === "optional"
-            ? html`<label class="nys-label__optional">(Optional)</label>`
-            : ""}</label
-        >
-        <label for=${this.id} class="nys-label__description">
+        </div>
+        <label for=${this.for} class="nys-label__description">
           <slot name="description">${this.description}</slot>
         </label>
       </div>

--- a/packages/nys-label/src/nys-label.ts
+++ b/packages/nys-label/src/nys-label.ts
@@ -30,7 +30,7 @@ export class NysLabel extends LitElement {
                 text="${this.tooltip}"
                 position="top"
                 focusable
-                inverted=${this.tooltipInverted}
+                ?inverted=${this.tooltipInverted}
               >
                 <div class="nys-label__tooltip-icon">
                   <nys-icon name="info" size="3xl"></nys-icon>

--- a/packages/nys-label/src/nys-label.ts
+++ b/packages/nys-label/src/nys-label.ts
@@ -8,6 +8,7 @@ export class NysLabel extends LitElement {
   @property({ type: String }) description = "";
   @property({ type: String }) flag = "";
   @property({ type: String }) tooltip = "";
+  @property({ type: Boolean, reflect: true }) tooltipInverted = false;
 
   static styles = styles;
 
@@ -25,7 +26,12 @@ export class NysLabel extends LitElement {
               : ""}</label
           >
           ${this.tooltip
-            ? html`<nys-tooltip text="${this.tooltip}" position="top" focusable>
+            ? html`<nys-tooltip
+                text="${this.tooltip}"
+                position="top"
+                focusable
+                inverted=${this.tooltipInverted}
+              >
                 <div class="nys-label__tooltip-icon">
                   <nys-icon name="info" size="3xl"></nys-icon>
                 </div>

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -31,31 +31,31 @@ The **`nys-radiobutton`** component is a reusable web component for use in New Y
 
 <Controls />
 
-### Variants
+## Options
 ⚠️ Important: Wrap radio buttons with `nys-radiogroup` to ensure they function as a single form control.
 
-#### Partial Editable Options
+### Partial Editable Options
 <Canvas of={NysRadiobuttonStories.PartialEditableOptions} />
-#### Disabled Options
+### Disabled Options
 <Canvas of={NysRadiobuttonStories.DisabledOptions} />
-#### Required
+### Required
 <Canvas of={NysRadiobuttonStories.Required} />
-#### Optional
+### Optional
 Adding the `optional` prop will add an optional flag to the input.
 <Canvas of={NysRadiobuttonStories.Optional} />
-#### Size
+### Size
 Set the `size` prop of the **`nys-radiogroup`** to have all **`nys-radiobutton`** be the same size. Our current sizes are:
 - `sm`: Set to 24px in width and height
 - `md`: The default size. Set to 32px in width and height.
 <Canvas of={NysRadiobuttonStories.Size} />
-#### Tile
+### Tile
 The `tile` prop will change the styling of the radio button to a tile. This is useful when you want a larger clickable area for the user.\
 Note: The `tile` prop is applied  to the `nys-radiogroup` component, not the `nys-radiobutton`. All `nys-radiobutton` in the `nys-radiogroup` will be set to tile.
 <Canvas of={NysRadiobuttonStories.Tile} />
-#### Error Message
+### Error Message
 Note: in order to display an error message, you must pass in `showError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysRadiobuttonStories.ErrorMessage} />
-#### Slots
+### Slots
 When the description requires more complexity than a simple `string` value, use the `slot="description"` to hold the text. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`\
 Note: Both `nys-radiobutton` and `nys-radiogroup` support the description slot.
 <Canvas of={NysRadiobuttonStories.Slot} />

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -59,10 +59,6 @@ Note: in order to display an error message, you must pass in `showError` to the 
 When the description requires more complexity than a simple `string` value, use the `slot="description"` to hold the text. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`\
 Note: Both `nys-radiobutton` and `nys-radiogroup` support the description slot.
 <Canvas of={NysRadiobuttonStories.Slot} />
-### Tooltip
-Pass in the `tooltip` prop to display a tooltip as a hint for users. \
-**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
-<Canvas of={NysRadiobuttonStories.Tooltip} />
 
 ## Usage
 

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -59,6 +59,10 @@ Note: in order to display an error message, you must pass in `showError` to the 
 When the description requires more complexity than a simple `string` value, use the `slot="description"` to hold the text. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`\
 Note: Both `nys-radiobutton` and `nys-radiogroup` support the description slot.
 <Canvas of={NysRadiobuttonStories.Slot} />
+### Tooltip
+Pass in the `tooltip` prop to display a tooltip as a hint for users. \
+**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
+<Canvas of={NysRadiobuttonStories.Tooltip} />
 
 ## Usage
 

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -3,8 +3,6 @@ import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-radiobutton";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
-import "@nysds/nys-icon";
-import "@nysds/nys-tooltip";
 
 // Define the structure of the args used in the stories
 interface NysRadiobuttonArgs {
@@ -19,7 +17,6 @@ interface NysRadiobuttonArgs {
   disabled: boolean;
   value: string;
   form: string;
-  tooltip: string;
   required: boolean;
   optional: boolean;
   showError: boolean;
@@ -40,7 +37,7 @@ const meta: Meta<NysRadiobuttonArgs> = {
     disabled: { control: "boolean" },
     value: { control: "text" },
     form: { control: "text" },
-    tooltip: { control: "text" },
+
     required: { control: "boolean" },
     optional: { control: "boolean" },
     showError: { control: "boolean" },
@@ -66,7 +63,6 @@ export const Basic: Story = {
     label: "Albany",
     description: "Upstate New York",
     value: "albany",
-    tooltip: "",
     tile: false,
     checked: false,
     disabled: false,
@@ -85,7 +81,6 @@ export const Basic: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     >
       <nys-radiobutton
         .id=${args.id}
@@ -307,7 +302,6 @@ export const Required: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -378,7 +372,6 @@ export const Size: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -455,7 +448,6 @@ export const Tile: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
     >
       <nys-radiobutton
         .name=${args.name}
@@ -525,7 +517,6 @@ export const ErrorMessage: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -671,7 +662,6 @@ export const Optional: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -718,83 +708,6 @@ export const Optional: Story = {
 </nys-radiogroup>
 `.trim(),
 
-        type: "auto",
-      },
-    },
-  },
-};
-
-export const Tooltip: Story = {
-  args: {
-    name: "service",
-    label: "Driver License Renewal",
-    value: "driver_license_renewal",
-    description: "Renew your NYS driver license online",
-    tooltip:
-      "Make sure you have your current license and proof of residency ready.",
-    tile: false,
-    checked: false,
-    disabled: false,
-    required: false,
-    optional: false,
-    showError: false,
-  },
-  render: (args) => html`
-    <nys-radiogroup
-      label="Choose an NYS service"
-      description="Select the service you want to complete online."
-      size=${args.size}
-      .tile=${args.tile}
-      .showError=${args.showError}
-      .errorMessage=${args.errorMessage}
-      .required=${args.required}
-      .optional=${args.optional}
-      .form=${args.form}
-      .tooltip=${args.tooltip}
-    >
-      <nys-radiobutton
-        .id=${args.id}
-        .name=${args.name}
-        label=${args.label}
-        description=${args.description}
-        .checked=${args.checked}
-        .disabled=${args.disabled}
-        .value=${args.value}
-      ></nys-radiobutton>
-      <nys-radiobutton
-        .id=${args.id}
-        .name=${args.name}
-        label="Vehicle Registration"
-        description="Renew or register your vehicle in NYS"
-        .checked=${false}
-        .disabled=${args.disabled}
-        .value="vehicle_registration"
-      ></nys-radiobutton>
-    </nys-radiogroup>
-  `,
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-radiogroup 
-  label="Choose an NYS service"
-  description="Select the service you want to complete online."
-  tooltip="Select the service you want to access online."
->
-  <nys-radiobutton
-    name="service"
-    label="Driver License Renewal"
-    description="Renew your NYS driver license online"
-    value="driver_license_renewal"
-  ></nys-radiobutton>
-  <nys-radiobutton
-    name="service"
-    label="Vehicle Registration"
-    description="Renew or register your vehicle in NYS"
-    value="vehicle_registration"
-  ></nys-radiobutton>
-</nys-radiogroup>
-`.trim(),
         type: "auto",
       },
     },

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -780,7 +780,6 @@ export const Tooltip: Story = {
   label="Choose an NYS service"
   description="Select the service you want to complete online."
   tooltip="Select the service you want to access online."
-  size="md"
 >
   <nys-radiobutton
     name="service"

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -3,6 +3,9 @@ import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-radiobutton";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
+import "@nysds/nys-tooltip";
+
 // Define the structure of the args used in the stories
 interface NysRadiobuttonArgs {
   //radiobutton
@@ -16,6 +19,7 @@ interface NysRadiobuttonArgs {
   disabled: boolean;
   value: string;
   form: string;
+  tooltip: string;
   required: boolean;
   optional: boolean;
   showError: boolean;
@@ -36,6 +40,7 @@ const meta: Meta<NysRadiobuttonArgs> = {
     disabled: { control: "boolean" },
     value: { control: "text" },
     form: { control: "text" },
+    tooltip: { control: "text" },
     required: { control: "boolean" },
     optional: { control: "boolean" },
     showError: { control: "boolean" },
@@ -61,6 +66,7 @@ export const Basic: Story = {
     label: "Albany",
     description: "Upstate New York",
     value: "albany",
+    tooltip: "",
     tile: false,
     checked: false,
     disabled: false,
@@ -78,6 +84,8 @@ export const Basic: Story = {
       .errorMessage=${args.errorMessage}
       .required=${args.required}
       .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     >
       <nys-radiobutton
         .id=${args.id}
@@ -298,6 +306,8 @@ export const Required: Story = {
       .tile=${args.tile}
       .required=${args.required}
       .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -367,6 +377,8 @@ export const Size: Story = {
       .tile=${args.tile}
       .required=${args.required}
       .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -442,6 +454,8 @@ export const Tile: Story = {
       .errorMessage=${args.errorMessage}
       .required=${args.required}
       .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
     >
       <nys-radiobutton
         .name=${args.name}
@@ -510,6 +524,8 @@ export const ErrorMessage: Story = {
       .tile=${args.tile}
       .required=${args.required}
       .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -654,6 +670,8 @@ export const Optional: Story = {
       .tile=${args.tile}
       .required=${args.required}
       .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
     >
@@ -700,6 +718,84 @@ export const Optional: Story = {
 </nys-radiogroup>
 `.trim(),
 
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Tooltip: Story = {
+  args: {
+    name: "service",
+    label: "Driver License Renewal",
+    value: "driver_license_renewal",
+    description: "Renew your NYS driver license online",
+    tooltip:
+      "Make sure you have your current license and proof of residency ready.",
+    tile: false,
+    checked: false,
+    disabled: false,
+    required: false,
+    optional: false,
+    showError: false,
+  },
+  render: (args) => html`
+    <nys-radiogroup
+      label="Choose an NYS service"
+      description="Select the service you want to complete online."
+      size=${args.size}
+      .tile=${args.tile}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+      .required=${args.required}
+      .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
+    >
+      <nys-radiobutton
+        .id=${args.id}
+        .name=${args.name}
+        label=${args.label}
+        description=${args.description}
+        .checked=${args.checked}
+        .disabled=${args.disabled}
+        .value=${args.value}
+      ></nys-radiobutton>
+      <nys-radiobutton
+        .id=${args.id}
+        .name=${args.name}
+        label="Vehicle Registration"
+        description="Renew or register your vehicle in NYS"
+        .checked=${false}
+        .disabled=${args.disabled}
+        .value="vehicle_registration"
+      ></nys-radiobutton>
+    </nys-radiogroup>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-radiogroup 
+  label="Choose an NYS service"
+  description="Select the service you want to complete online."
+  tooltip="Select the service you want to access online."
+  size="md"
+>
+  <nys-radiobutton
+    name="service"
+    label="Driver License Renewal"
+    description="Renew your NYS driver license online"
+    value="driver_license_renewal"
+  ></nys-radiobutton>
+  <nys-radiobutton
+    name="service"
+    label="Vehicle Registration"
+    description="Renew or register your vehicle in NYS"
+    value="vehicle_registration"
+  ></nys-radiobutton>
+</nys-radiogroup>
+`.trim(),
         type: "auto",
       },
     },

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -360,7 +360,7 @@ export class NysRadiogroup extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : this.optional ? "optional" : ""}
-        tooltip=${this._tooltip}
+        _tooltip=${this._tooltip}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -15,6 +15,7 @@ export class NysRadiogroup extends LitElement {
   @property({ type: String }) description = "";
   @property({ type: Boolean, reflect: true }) tile = false;
   @property({ type: String, reflect: true }) form = "";
+  @property({ type: String }) tooltip = "";
 
   @state() private selectedValue: string | null = null;
   @state() private _slottedDescriptionText = "";
@@ -353,6 +354,7 @@ export class NysRadiogroup extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : this.optional ? "optional" : ""}
+        tooltip=${this.tooltip}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -15,7 +15,7 @@ export class NysRadiogroup extends LitElement {
   @property({ type: String }) description = "";
   @property({ type: Boolean, reflect: true }) tile = false;
   @property({ type: String, reflect: true }) form = "";
-  @property({ type: String }) tooltip = "";
+  @property({ type: String }) _tooltip = "";
 
   @state() private selectedValue: string | null = null;
   @state() private _slottedDescriptionText = "";
@@ -354,7 +354,7 @@ export class NysRadiogroup extends LitElement {
         label=${this.label}
         description=${this.description}
         flag=${this.required ? "required" : this.optional ? "optional" : ""}
-        tooltip=${this.tooltip}
+        tooltip=${this._tooltip}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-select/src/nys-select.mdx
+++ b/packages/nys-select/src/nys-select.mdx
@@ -52,8 +52,12 @@ You can supply a description via our `description` prop for plain text or by emb
 
 #### Error Message
 In order to display an error message, you must pass in `showError` to the component. Setting `errorMessage` does not display the message by default.
-
 <Canvas of={NysSelectStories.ErrorMessage} />
+
+#### Tooltip
+Pass in the `tooltip` prop to display a tooltip as a hint for users. \
+**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
+<Canvas of={NysSelectStories.Tooltip} />
 
 ## Usage
 

--- a/packages/nys-select/src/nys-select.mdx
+++ b/packages/nys-select/src/nys-select.mdx
@@ -54,11 +54,6 @@ You can supply a description via our `description` prop for plain text or by emb
 In order to display an error message, you must pass in `showError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysSelectStories.ErrorMessage} />
 
-### Tooltip
-Pass in the `tooltip` prop to display a tooltip as a hint for users. \
-**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
-<Canvas of={NysSelectStories.Tooltip} />
-
 ## Usage
 
 ### When to use this component

--- a/packages/nys-select/src/nys-select.mdx
+++ b/packages/nys-select/src/nys-select.mdx
@@ -27,34 +27,34 @@ The **`nys-select`** is a reusable web component for use in New York State digit
 
 <Controls />
 
-### Variants
+## Options
 The `nys-option` can have the label set as either the label property or the inner text of the component. The rendered code will show the label as a property if set as inner text.
 <Canvas of={NysSelectStories.OptionsLabelSlot} />
-#### Disabled
+### Disabled
 <Canvas of={NysSelectStories.Disabled} />
-#### Required
+### Required
 <Canvas of={NysSelectStories.Required} />
-#### Optional
+### Optional
 Adding the `optional` prop will add an optional flag to the input.
 <Canvas of={NysSelectStories.Optional} />
-#### Width
+### Width
 The following width options are available:
 - `sm` (Small): 88px, ideal for compact layouts.
 - `md` (Medium): 200px, ideal for balanced designs.
 - `lg` (Large): 384px, suitable for displaying longer content.
 - `full` (Full Width): default size. Expands to fill the available space.
 <Canvas of={NysSelectStories.Width} />
-#### Description Slot
+### Description Slot
 You can supply a description via our `description` prop for plain text or by embedding HTML within our component via our slot for higher customization.
 
 <div style={{ display: 'flex', gap: '10px', verticalAlign: 'middle', alignItems: 'center'}}>  <nys-icon name="info" size="xl" style={{margin: '20px 0' }}></nys-icon> You must use `slot="description"` on your embedded HTML for it to work properly. </div>
 <Canvas of={NysSelectStories.DescriptionSlot} />
 
-#### Error Message
+### Error Message
 In order to display an error message, you must pass in `showError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysSelectStories.ErrorMessage} />
 
-#### Tooltip
+### Tooltip
 Pass in the `tooltip` prop to display a tooltip as a hint for users. \
 **Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
 <Canvas of={NysSelectStories.Tooltip} />

--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -2,7 +2,6 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-select";
 import "@nysds/nys-icon";
-import "@nysds/nys-tooltip";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
 
@@ -17,7 +16,6 @@ interface NysSelectArgs {
   required: boolean;
   optional: boolean;
   form: string;
-  tooltip: string;
   width: string;
   options: string;
   showError: boolean;
@@ -37,7 +35,7 @@ const meta: Meta<NysSelectArgs> = {
     required: { control: "boolean" },
     optional: { control: "boolean" },
     form: { control: "text" },
-    tooltip: { control: "text" },
+
     width: { control: "select", options: ["sm", "md", "lg", "full"] },
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
@@ -59,7 +57,6 @@ export const Basic: Story = {
   args: {
     label: "Select your favorite borough",
     value: "",
-    tooltip: "",
     disabled: false,
     required: false,
     optional: false,
@@ -76,7 +73,6 @@ export const Basic: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -130,7 +126,6 @@ export const OptionsLabelSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -175,7 +170,6 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -223,7 +217,6 @@ export const Disabled: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -269,7 +262,6 @@ export const Required: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -316,7 +308,6 @@ export const Width: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -367,7 +358,6 @@ export const ErrorMessage: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -418,7 +408,6 @@ export const Optional: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -436,56 +425,6 @@ export const Optional: Story = {
       source: {
         code: `
 <nys-select label="Select your favorite borough" optional>
-  <nys-option value="bronx" label="The Bronx"></nys-option>
-  <nys-option value="brooklyn" label="Brooklyn"></nys-option>
-  <nys-option value="manhattan" label="Manhattan"></nys-option>
-  <nys-option value="staten_island" label="Staten Island"></nys-option>
-  <nys-option value="queens" label="Queens"></nys-option>  
-</nys-select>`,
-
-        type: "auto",
-      },
-    },
-  },
-};
-
-
-export const Tooltip: Story = {
-  args: {
-    label: "Select your favorite borough",
-    value: "",
-    tooltip: "Choose the borough you identify with most",
-  },
-
-  render: (args) => html`
-    <nys-select
-      .id=${args.id}
-      .name=${args.name}
-      .label=${args.label}
-      .description=${args.description}
-      .value=${args.value}
-      .disabled=${args.disabled}
-      .required=${args.required}
-      .optional=${args.optional}
-      .form=${args.form}
-      .tooltip=${args.tooltip}
-      .width=${args.width}
-      .showError=${args.showError}
-      .errorMessage=${args.errorMessage}
-    >
-      <nys-option value="bronx" label="The Bronx"></nys-option>
-      <nys-option value="brooklyn" label="Brooklyn"></nys-option>
-      <nys-option value="manhattan" label="Manhattan"></nys-option>
-      <nys-option value="staten_island" label="Staten Island"></nys-option>
-      <nys-option value="queens" label="Queens"></nys-option>
-    </nys-select>
-  `,
-
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-select label="Select your favorite borough" tooltip="Choose the borough you identify with most">
   <nys-option value="bronx" label="The Bronx"></nys-option>
   <nys-option value="brooklyn" label="Brooklyn"></nys-option>
   <nys-option value="manhattan" label="Manhattan"></nys-option>

--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -1,9 +1,10 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-select";
+import "@nysds/nys-icon";
+import "@nysds/nys-tooltip";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
-import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
 interface NysSelectArgs {
@@ -16,6 +17,7 @@ interface NysSelectArgs {
   required: boolean;
   optional: boolean;
   form: string;
+  tooltip: string;
   width: string;
   options: string;
   showError: boolean;
@@ -35,6 +37,7 @@ const meta: Meta<NysSelectArgs> = {
     required: { control: "boolean" },
     optional: { control: "boolean" },
     form: { control: "text" },
+    tooltip: { control: "text" },
     width: { control: "select", options: ["sm", "md", "lg", "full"] },
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
@@ -56,6 +59,7 @@ export const Basic: Story = {
   args: {
     label: "Select your favorite borough",
     value: "",
+    tooltip: "",
     disabled: false,
     required: false,
     optional: false,
@@ -72,6 +76,7 @@ export const Basic: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -125,6 +130,7 @@ export const OptionsLabelSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -169,6 +175,7 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -216,6 +223,7 @@ export const Disabled: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -261,6 +269,7 @@ export const Required: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -307,6 +316,7 @@ export const Width: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -357,6 +367,7 @@ export const ErrorMessage: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -407,6 +418,7 @@ export const Optional: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .width=${args.width}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -424,6 +436,56 @@ export const Optional: Story = {
       source: {
         code: `
 <nys-select label="Select your favorite borough" optional>
+  <nys-option value="bronx" label="The Bronx"></nys-option>
+  <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+  <nys-option value="manhattan" label="Manhattan"></nys-option>
+  <nys-option value="staten_island" label="Staten Island"></nys-option>
+  <nys-option value="queens" label="Queens"></nys-option>  
+</nys-select>`,
+
+        type: "auto",
+      },
+    },
+  },
+};
+
+
+export const Tooltip: Story = {
+  args: {
+    label: "Select your favorite borough",
+    value: "",
+    tooltip: "Choose the borough you identify with most",
+  },
+
+  render: (args) => html`
+    <nys-select
+      .id=${args.id}
+      .name=${args.name}
+      .label=${args.label}
+      .description=${args.description}
+      .value=${args.value}
+      .disabled=${args.disabled}
+      .required=${args.required}
+      .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
+      .width=${args.width}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    >
+      <nys-option value="bronx" label="The Bronx"></nys-option>
+      <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+      <nys-option value="manhattan" label="Manhattan"></nys-option>
+      <nys-option value="staten_island" label="Staten Island"></nys-option>
+      <nys-option value="queens" label="Queens"></nys-option>
+    </nys-select>
+  `,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-select label="Select your favorite borough" tooltip="Choose the borough you identify with most">
   <nys-option value="bronx" label="The Bronx"></nys-option>
   <nys-option value="brooklyn" label="Brooklyn"></nys-option>
   <nys-option value="manhattan" label="Manhattan"></nys-option>

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -16,7 +16,7 @@ export class NysSelect extends LitElement {
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String, reflect: true }) form = "";
-  @property({ type: String }) tooltip = "";
+  @property({ type: String }) _tooltip = "";
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
@@ -247,7 +247,7 @@ export class NysSelect extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
-          tooltip=${this.tooltip}
+          tooltip=${this._tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -15,6 +15,7 @@ export class NysSelect extends LitElement {
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String }) form = "";
+  @property({ type: String }) tooltip = "";
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
@@ -245,6 +246,7 @@ export class NysSelect extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
+          tooltip=${this.tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -15,12 +15,8 @@ export class NysSelect extends LitElement {
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
-<<<<<<< HEAD
-  @property({ type: String }) form = "";
-  @property({ type: String }) tooltip = "";
-=======
   @property({ type: String, reflect: true }) form = "";
->>>>>>> a0722a7cc7bd4bb66c3ce84fbf89c2ae998165ee
+  @property({ type: String }) tooltip = "";
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -247,7 +247,7 @@ export class NysSelect extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
-          tooltip=${this._tooltip}
+          _tooltip=${this._tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textarea/src/nys-textarea.mdx
+++ b/packages/nys-textarea/src/nys-textarea.mdx
@@ -27,41 +27,39 @@ The **`nys-textarea`** is a reusable web component for use in New York State dig
 
 <Controls />
 
-### Variants
+## Options
 
-### Basic Text Area
-
-#### Width
+### Width
 If no width is provided, the `nys-textarea` will default to `full`. Supported widths are `sm`, `md`, `lg`, and `full`.\
 Width `full` will take up the full width of the parent container.\
 If an invalid option is assigned to `width`, it will be ignored and default to `full`.
 <Canvas of={NysTextareaStories.Width} />
-#### Rows
+### Rows
 The `rows` attribute specifies the visible height of a text area, in number of lines.\
 The default value is `rows="4"`
 <Canvas of={NysTextareaStories.Rows} />
-#### Resize
+### Resize
 By default the user can resize the `nys-textarea` vertically. If you want to disallow resizing altogether add `resize="none"`\
 Note: resize is not affected by setting `nys-textarea` to `disabled` or `readonly` and they are independent.
 <Canvas of={NysTextareaStories.Resize} />
-#### Description Slot
+### Description Slot
 You can supply a description via our `description` prop for plain text or by embedding HTML within our component via our slot for higher customization.
 <Canvas of={NysTextareaStories.DescriptionSlot} />
-#### Values and Placeholders
+### Values and Placeholders
 <Canvas of={NysTextareaStories.ValueAndPlaceholder} />
-#### Disabled and Readonly
+### Disabled and Readonly
 <Canvas of={NysTextareaStories.Disabled} />
 <Canvas of={NysTextareaStories.Readonly} />
-#### Maxlength
+### Maxlength
 <Canvas of={NysTextareaStories.Maxlength} />
-#### Required
+### Required
 <Canvas of={NysTextareaStories.Required} />
-#### Optional
+### Optional
 Adding the `optional` prop will add an optional flag to the input.
 <Canvas of={NysTextareaStories.Optional} />
-#### Error Message
+### Error Message
 <Canvas of={NysTextareaStories.ErrorMessage} />
-#### Tooltip
+### Tooltip
 Pass in the `tooltip` prop to display a tooltip as a hint for users. \
 **Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
 <Canvas of={NysTextareaStories.Tooltip} />

--- a/packages/nys-textarea/src/nys-textarea.mdx
+++ b/packages/nys-textarea/src/nys-textarea.mdx
@@ -61,6 +61,11 @@ Adding the `optional` prop will add an optional flag to the input.
 <Canvas of={NysTextareaStories.Optional} />
 #### Error Message
 <Canvas of={NysTextareaStories.ErrorMessage} />
+#### Tooltip
+Pass in the `tooltip` prop to display a tooltip as a hint for users. \
+**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
+<Canvas of={NysTextareaStories.Tooltip} />
+
 
 ## Usage
 

--- a/packages/nys-textarea/src/nys-textarea.mdx
+++ b/packages/nys-textarea/src/nys-textarea.mdx
@@ -59,10 +59,6 @@ Adding the `optional` prop will add an optional flag to the input.
 <Canvas of={NysTextareaStories.Optional} />
 ### Error Message
 <Canvas of={NysTextareaStories.ErrorMessage} />
-### Tooltip
-Pass in the `tooltip` prop to display a tooltip as a hint for users. \
-**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
-<Canvas of={NysTextareaStories.Tooltip} />
 
 
 ## Usage

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -1,8 +1,6 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-textarea";
-import "@nysds/nys-icon";
-import "@nysds/nys-tooltip";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
 
@@ -23,7 +21,6 @@ interface NysTextareaArgs {
   width: string;
   rows: string;
   resize: string;
-  tooltip: string;
   showError: boolean;
   errorMessage: string;
 }
@@ -44,7 +41,7 @@ const meta: Meta<NysTextareaArgs> = {
     optional: { control: "boolean" },
     form: { control: "text" },
     maxlength: { control: "text" },
-    tooltip: { control: "text" },
+
     width: {
       control: "select",
       options: ["sm", "md", "lg", "full"],
@@ -72,7 +69,6 @@ export const Basic: Story = {
   args: {
     label: "Label",
     value: "",
-    tooltip: "",
     disabled: false,
     readonly: false,
     required: false,
@@ -92,7 +88,6 @@ export const Basic: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -126,7 +121,6 @@ export const Width: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -162,7 +156,6 @@ export const Rows: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -201,7 +194,6 @@ export const Resize: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -235,7 +227,6 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -255,7 +246,6 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -300,7 +290,6 @@ export const ValueAndPlaceholder: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -339,7 +328,6 @@ export const Disabled: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -375,7 +363,6 @@ export const Readonly: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -416,7 +403,6 @@ export const Maxlength: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -456,7 +442,6 @@ export const Required: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -494,7 +479,6 @@ export const ErrorMessage: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -537,7 +521,6 @@ export const Optional: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -555,43 +538,3 @@ export const Optional: Story = {
     },
   },
 };
-
-export const Tooltip: Story = {
-  args: {
-    label: "Label",
-    value: "",
-    tooltip: "Provide additional details if needed",
-  },
-
-  render: (args) =>
-    html` <nys-textarea
-      .id=${args.id}
-      .name=${args.name}
-      .label=${args.label}
-      .description=${args.description}
-      .placeholder=${args.placeholder}
-      .value=${args.value}
-      .disabled=${args.disabled}
-      .readonly=${args.readonly}
-      .required=${args.required}
-      .optional=${args.optional}
-      .form=${args.form}
-      .tooltip=${args.tooltip}
-      .maxlength=${args.maxlength}
-      .width=${args.width}
-      .rows=${args.rows}
-      .resize=${args.resize}
-      .showError=${args.showError}
-      .errorMessage=${args.errorMessage}
-    ></nys-textarea>`,
-
-  parameters: {
-    docs: {
-      source: {
-        code: `<nys-textarea label="label" tooltip="Provide additional details if needed"></nys-textarea>`,
-        type: "auto",
-      },
-    },
-  },
-};
-

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -1,6 +1,8 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-textarea";
+import "@nysds/nys-icon";
+import "@nysds/nys-tooltip";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
 
@@ -21,6 +23,7 @@ interface NysTextareaArgs {
   width: string;
   rows: string;
   resize: string;
+  tooltip: string;
   showError: boolean;
   errorMessage: string;
 }
@@ -41,6 +44,7 @@ const meta: Meta<NysTextareaArgs> = {
     optional: { control: "boolean" },
     form: { control: "text" },
     maxlength: { control: "text" },
+    tooltip: { control: "text" },
     width: {
       control: "select",
       options: ["sm", "md", "lg", "full"],
@@ -68,6 +72,7 @@ export const Basic: Story = {
   args: {
     label: "Label",
     value: "",
+    tooltip: "",
     disabled: false,
     readonly: false,
     required: false,
@@ -87,6 +92,7 @@ export const Basic: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -120,6 +126,7 @@ export const Width: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -155,6 +162,7 @@ export const Rows: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -193,6 +201,7 @@ export const Resize: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -226,6 +235,7 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -245,6 +255,7 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -289,6 +300,7 @@ export const ValueAndPlaceholder: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -327,6 +339,7 @@ export const Disabled: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -362,6 +375,7 @@ export const Readonly: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -402,6 +416,7 @@ export const Maxlength: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -441,6 +456,7 @@ export const Required: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -478,6 +494,7 @@ export const ErrorMessage: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -520,6 +537,7 @@ export const Optional: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .maxlength=${args.maxlength}
       .width=${args.width}
       .rows=${args.rows}
@@ -537,3 +555,43 @@ export const Optional: Story = {
     },
   },
 };
+
+export const Tooltip: Story = {
+  args: {
+    label: "Label",
+    value: "",
+    tooltip: "Provide additional details if needed",
+  },
+
+  render: (args) =>
+    html` <nys-textarea
+      .id=${args.id}
+      .name=${args.name}
+      .label=${args.label}
+      .description=${args.description}
+      .placeholder=${args.placeholder}
+      .value=${args.value}
+      .disabled=${args.disabled}
+      .readonly=${args.readonly}
+      .required=${args.required}
+      .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
+      .maxlength=${args.maxlength}
+      .width=${args.width}
+      .rows=${args.rows}
+      .resize=${args.resize}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    ></nys-textarea>`,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `<nys-textarea label="label" tooltip="Provide additional details if needed"></nys-textarea>`,
+        type: "auto",
+      },
+    },
+  },
+};
+

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -249,7 +249,7 @@ export class NysTextarea extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
-          tooltip=${this._tooltip}
+          _tooltip=${this._tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -17,6 +17,7 @@ export class NysTextarea extends LitElement {
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String }) form = "";
+  @property({ type: String }) tooltip = "";
   @property({ type: Number }) maxlength = null;
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
   @property({ reflect: true })
@@ -248,6 +249,7 @@ export class NysTextarea extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
+          tooltip=${this.tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -16,12 +16,8 @@ export class NysTextarea extends LitElement {
   @property({ type: Boolean, reflect: true }) readonly = false;
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
-<<<<<<< HEAD
-  @property({ type: String }) form = "";
-  @property({ type: String }) tooltip = "";
-=======
   @property({ type: String, reflect: true }) form = "";
->>>>>>> a0722a7cc7bd4bb66c3ce84fbf89c2ae998165ee
+  @property({ type: String }) tooltip = "";
   @property({ type: Number }) maxlength = null;
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
   @property({ reflect: true })

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -17,7 +17,7 @@ export class NysTextarea extends LitElement {
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String, reflect: true }) form = "";
-  @property({ type: String }) tooltip = "";
+  @property({ type: String }) _tooltip = "";
   @property({ type: Number }) maxlength = null;
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
   @property({ reflect: true })
@@ -249,7 +249,7 @@ export class NysTextarea extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
-          tooltip=${this.tooltip}
+          tooltip=${this._tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -72,6 +72,10 @@ Use `width="lg"` or `width="full"` on `<nys-textinput>` to give users enough spa
 #### Error Message
 Note: in order to display an error message, you must pass in `hasError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysTextinputStories.ErrorMessage} />
+#### Tooltip
+Pass in the `tooltip` prop to display a tooltip as a hint for users. \
+**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
+<Canvas of={NysTextinputStories.Tooltip} />
 
 ## Usage
 

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -72,10 +72,6 @@ Use `width="lg"` or `width="full"` on `<nys-textinput>` to give users enough spa
 ### Error Message
 Note: in order to display an error message, you must pass in `hasError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysTextinputStories.ErrorMessage} />
-### Tooltip
-Pass in the `tooltip` prop to display a tooltip as a hint for users. \
-**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
-<Canvas of={NysTextinputStories.Tooltip} />
 
 ## Usage
 

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -28,51 +28,51 @@ The **`nys-textinput`** is a reusable web component for use in New York State di
 
 <Controls />
 
-### Variants
+## Options
 
-#### Width
+### Width
 If no width is provided, the `nys-textinput` will default to `full`. Supported widths are `sm`, `md`, `lg`, and `full`.\
 Width `full` will take up the full width of the parent container.\
 If an invalid option is assigned to `width`, it will be ignored and default to `full`.
 <Canvas of={NysTextinputStories.Width} />
-#### Different Input Types
+### Different Input Types
 Note: Accepted types are: `text` `email` `number` `password` `search` `tel` `url`. Any other input defaults to `type="text"`\
 Certain types will apply additional styling onto the input field. For `type="password"` the input will be automatically hidden.
 For `type="tel"` an input mask will appear to style the input properly.
 <Canvas of={NysTextinputStories.Password} />
 <Canvas of={NysTextinputStories.Telephone} />
-#### Values and Placeholders
+### Values and Placeholders
 <Canvas of={NysTextinputStories.ValueAndPlaceholder} />
-#### Disabled and Readonly
+### Disabled and Readonly
 <Canvas of={NysTextinputStories.Disabled} />
 <Canvas of={NysTextinputStories.Readonly} />
-#### Max Min and Step
+### Max Min and Step
 Note: `max` `min` `step` only apply when `type="number"`
 <Canvas of={NysTextinputStories.MaxMinAndStep} />
-#### Maxlength
+### Maxlength
 <Canvas of={NysTextinputStories.Maxlength} />
-#### Pattern
+### Pattern
 Note: Takes in valid regex
 <Canvas of={NysTextinputStories.Pattern} />
-#### Required
+### Required
 <Canvas of={NysTextinputStories.Required} />
-#### Optional
+### Optional
 Adding the `optional` prop will add an optional flag to the input.
 <Canvas of={NysTextinputStories.Optional} />
-#### Description Slot
+### Description Slot
 You can supply a description via our `description` prop for plain text or by embedding HTML within our component via our slot for higher customization.
 <Canvas of={NysTextinputStories.DescriptionSlot} />
-#### Slotted Button
+### Slotted Button
 Note: You can add a button to the input by adding a `slot="startButton"` or `slot="endButton"`.
 This will add a button to the left or right of the input respectively.\
 Use a `<nys-button>` for the slotted button. Do not use both `startButton` and `endButton` on the same input.\
 The slotted button will automatically be `size="sm"` and `variant="filled"` and support the disabled state of the input.\
 Use `width="lg"` or `width="full"` on `<nys-textinput>` to give users enough space to enter text when a button is present.
 <Canvas of={NysTextinputStories.SlottedButton} />
-#### Error Message
+### Error Message
 Note: in order to display an error message, you must pass in `hasError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysTextinputStories.ErrorMessage} />
-#### Tooltip
+### Tooltip
 Pass in the `tooltip` prop to display a tooltip as a hint for users. \
 **Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
 <Canvas of={NysTextinputStories.Tooltip} />

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -21,13 +21,13 @@ interface NysTextinputArgs {
   required: boolean;
   optional: boolean;
   form: string;
+  tooltip: string;
   pattern: string;
   maxlength: string;
   width: string;
   step: string;
   min: string;
   max: string;
-  tooltip: string;
   showError: boolean;
   errorMessage: string;
 }

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -5,6 +5,7 @@ import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
 import "@nysds/nys-button";
 import "@nysds/nys-icon";
+import "@nysds/nys-tooltip";
 
 // Define the structure of the args used in the stories
 interface NysTextinputArgs {
@@ -26,6 +27,7 @@ interface NysTextinputArgs {
   step: string;
   min: string;
   max: string;
+  tooltip: string;
   showError: boolean;
   errorMessage: string;
 }
@@ -49,6 +51,7 @@ const meta: Meta<NysTextinputArgs> = {
     required: { control: "boolean" },
     optional: { control: "boolean" },
     form: { control: "text" },
+    tooltip: { control: "text" },
     pattern: { control: "text" },
     maxlength: { control: "text" },
     width: {
@@ -80,6 +83,7 @@ export const Basic: Story = {
     label: "Label",
     value: "",
     name: "myTextInputDemo",
+    tooltip: "",
     disabled: false,
     readonly: false,
     required: false,
@@ -100,6 +104,7 @@ export const Basic: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -141,6 +146,7 @@ export const Width: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -188,6 +194,7 @@ export const Password: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -235,6 +242,7 @@ export const SlottedButton: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -296,6 +304,7 @@ export const ValueAndPlaceholder: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -344,6 +353,7 @@ export const Disabled: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -387,6 +397,7 @@ export const Readonly: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -438,6 +449,7 @@ export const MaxMinAndStep: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -490,6 +502,7 @@ export const Maxlength: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -544,6 +557,7 @@ export const Pattern: Story = {
         .required=${args.required}
         .optional=${args.optional}
         .form=${args.form}
+        .tooltip=${args.tooltip}
         .pattern=${args.pattern}
         .maxlength=${args.maxlength}
         .width=${args.width}
@@ -594,6 +608,7 @@ export const Required: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -634,6 +649,7 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -656,6 +672,7 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -708,6 +725,7 @@ export const ErrorMessage: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -756,6 +774,7 @@ export const Optional: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -799,6 +818,7 @@ export const Telephone: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
+      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -818,6 +838,58 @@ export const Telephone: Story = {
   name="myTextInputDemo"
   label="Phone Number"
   type="tel"
+>
+</nys-textinput>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Tooltip: Story = {
+  args: {
+    label: "Phone Number",
+    value: "",
+    name: "myTextInputDemo",
+    type: "tel",
+    tooltip: "Include area code",
+  },
+
+  render: (args) => html`
+    <nys-textinput
+      .id=${args.id}
+      .name=${args.name}
+      .type=${args.type}
+      .label=${args.label}
+      .description=${args.description}
+      .placeholder=${args.placeholder}
+      .value=${args.value}
+      .disabled=${args.disabled}
+      .readonly=${args.readonly}
+      .required=${args.required}
+      .optional=${args.optional}
+      .form=${args.form}
+      .tooltip=${args.tooltip}
+      .pattern=${args.pattern}
+      .maxlength=${args.maxlength}
+      .width=${args.width}
+      .step=${args.step}
+      .min=${args.min}
+      .max=${args.max}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    ></nys-textinput>
+  `,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-textinput
+  name="myTextInputDemo"
+  label="Phone Number"
+  type="tel"
+  tooltip="Include area code"
 >
 </nys-textinput>`,
         type: "auto",

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -5,7 +5,6 @@ import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
 import "@nysds/nys-button";
 import "@nysds/nys-icon";
-import "@nysds/nys-tooltip";
 
 // Define the structure of the args used in the stories
 interface NysTextinputArgs {
@@ -21,7 +20,6 @@ interface NysTextinputArgs {
   required: boolean;
   optional: boolean;
   form: string;
-  tooltip: string;
   pattern: string;
   maxlength: string;
   width: string;
@@ -51,7 +49,7 @@ const meta: Meta<NysTextinputArgs> = {
     required: { control: "boolean" },
     optional: { control: "boolean" },
     form: { control: "text" },
-    tooltip: { control: "text" },
+
     pattern: { control: "text" },
     maxlength: { control: "text" },
     width: {
@@ -83,7 +81,6 @@ export const Basic: Story = {
     label: "Label",
     value: "",
     name: "myTextInputDemo",
-    tooltip: "",
     disabled: false,
     readonly: false,
     required: false,
@@ -104,7 +101,6 @@ export const Basic: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -146,7 +142,6 @@ export const Width: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -194,7 +189,6 @@ export const Password: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -242,7 +236,6 @@ export const SlottedButton: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -304,7 +297,6 @@ export const ValueAndPlaceholder: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -353,7 +345,6 @@ export const Disabled: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -397,7 +388,6 @@ export const Readonly: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -449,7 +439,6 @@ export const MaxMinAndStep: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -502,7 +491,6 @@ export const Maxlength: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -557,7 +545,6 @@ export const Pattern: Story = {
         .required=${args.required}
         .optional=${args.optional}
         .form=${args.form}
-        .tooltip=${args.tooltip}
         .pattern=${args.pattern}
         .maxlength=${args.maxlength}
         .width=${args.width}
@@ -608,7 +595,6 @@ export const Required: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -649,7 +635,6 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -672,7 +657,6 @@ export const DescriptionSlot: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -725,7 +709,6 @@ export const ErrorMessage: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -774,7 +757,6 @@ export const Optional: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -818,7 +800,6 @@ export const Telephone: Story = {
       .required=${args.required}
       .optional=${args.optional}
       .form=${args.form}
-      .tooltip=${args.tooltip}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -838,58 +819,6 @@ export const Telephone: Story = {
   name="myTextInputDemo"
   label="Phone Number"
   type="tel"
->
-</nys-textinput>`,
-        type: "auto",
-      },
-    },
-  },
-};
-
-export const Tooltip: Story = {
-  args: {
-    label: "Phone Number",
-    value: "",
-    name: "myTextInputDemo",
-    type: "tel",
-    tooltip: "Include area code",
-  },
-
-  render: (args) => html`
-    <nys-textinput
-      .id=${args.id}
-      .name=${args.name}
-      .type=${args.type}
-      .label=${args.label}
-      .description=${args.description}
-      .placeholder=${args.placeholder}
-      .value=${args.value}
-      .disabled=${args.disabled}
-      .readonly=${args.readonly}
-      .required=${args.required}
-      .optional=${args.optional}
-      .form=${args.form}
-      .tooltip=${args.tooltip}
-      .pattern=${args.pattern}
-      .maxlength=${args.maxlength}
-      .width=${args.width}
-      .step=${args.step}
-      .min=${args.min}
-      .max=${args.max}
-      .showError=${args.showError}
-      .errorMessage=${args.errorMessage}
-    ></nys-textinput>
-  `,
-
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-textinput
-  name="myTextInputDemo"
-  label="Phone Number"
-  type="tel"
-  tooltip="Include area code"
 >
 </nys-textinput>`,
         type: "auto",

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -43,6 +43,7 @@ export class NysTextinput extends LitElement {
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String }) form = "";
+  @property({ type: String }) tooltip = "";
   @property({ type: String }) pattern = "";
   @property({ type: Number }) maxlength = null;
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
@@ -396,6 +397,7 @@ export class NysTextinput extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
+          tooltip=${this.tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -42,12 +42,8 @@ export class NysTextinput extends LitElement {
   @property({ type: Boolean, reflect: true }) readonly = false;
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
-<<<<<<< HEAD
-  @property({ type: String }) form = "";
-  @property({ type: String }) tooltip = "";
-=======
   @property({ type: String, reflect: true }) form = "";
->>>>>>> a0722a7cc7bd4bb66c3ce84fbf89c2ae998165ee
+  @property({ type: String }) tooltip = "";
   @property({ type: String }) pattern = "";
   @property({ type: Number }) maxlength = null;
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -396,7 +396,7 @@ export class NysTextinput extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
-          tooltip=${this._tooltip}
+          _tooltip=${this._tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -43,7 +43,7 @@ export class NysTextinput extends LitElement {
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String, reflect: true }) form = "";
-  @property({ type: String }) tooltip = "";
+  @property({ type: String }) _tooltip = "";
   @property({ type: String }) pattern = "";
   @property({ type: Number }) maxlength = null;
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
@@ -396,7 +396,7 @@ export class NysTextinput extends LitElement {
           label=${this.label}
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
-          tooltip=${this.tooltip}
+          tooltip=${this._tooltip}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-tooltip/src/nys-tooltip.mdx
+++ b/packages/nys-tooltip/src/nys-tooltip.mdx
@@ -37,6 +37,7 @@ If an id is not passed, a unique id will be generated.
 ## Best Practices for Wrapping Elements
 
 ### Use only`nys-components` like `nys-icon` and `nys-button`
+**Note:** Don’t hide critical info in tooltips. Reserve them for optional help.
 
 The `nys-tooltip` is meant to wrap a single visual or interactive element. It works best with `nys-icon` or `nys-button`
 - Keyboard and screen reader support is built in

--- a/packages/nys-tooltip/src/nys-tooltip.ts
+++ b/packages/nys-tooltip/src/nys-tooltip.ts
@@ -92,6 +92,9 @@ export class NysTooltip extends LitElement {
     if (changedProps.has("text")) {
       this._passAria(firstEl);
     }
+    if (changedProps.has("focusable")) {
+      this._applyFocusBehavior(firstEl);
+    }
   }
 
   /******************** Event Handlers ********************/


### PR DESCRIPTION
# Summary
Add the `tooltip` prop to all form-related components. Additional cleanup on `nys-label` and storybook heading revisions.

## Breaking change
This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues
Closes #734 🎟️