### PR TITLE
Fix: validity issue

### DIFF
--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -121,17 +121,14 @@ export class NysCheckboxgroup extends LitElement {
       const message = this.errorMessage || "Please select at least one option.";
       const firstCheckbox = this.querySelector("nys-checkbox");
       const firstCheckboxInput = firstCheckbox
-        ? await (firstCheckbox as any).getInputElement()
+        ? await (firstCheckbox as any).getInputElement().catch(() => null)
         : null;
 
-      let atLeastOneChecked = false;
       const checkboxes = this.querySelectorAll("nys-checkbox");
       // Loop through each child checkbox to see if one is checked.
-      checkboxes.forEach((checkbox: any) => {
-        if (checkbox.checked) {
-          atLeastOneChecked = true;
-        }
-      });
+      const atLeastOneChecked = Array.from(checkboxes).some(
+        (checkbox: any) => checkbox.checked,
+      );
 
       if (atLeastOneChecked) {
         this._internals.setValidity({});

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -116,7 +116,7 @@ export class NysCheckboxgroup extends LitElement {
   }
 
   // Updates the required attribute of each checkbox in the group
-  private async _manageCheckboxRequired() {
+  private async _manageRequire() {
     if (this.required) {
       const message = this.errorMessage || "Please select at least one option.";
       const firstCheckbox = this.querySelector("nys-checkbox");
@@ -209,7 +209,7 @@ export class NysCheckboxgroup extends LitElement {
     event.preventDefault();
 
     this.showError = true;
-    this._manageCheckboxRequired(); // Refresh validation message
+    this._manageRequire(); // Refresh validation message
 
     const firstCheckbox = this.querySelector("nys-checkbox");
     const firstCheckboxInput = firstCheckbox
@@ -271,7 +271,7 @@ export class NysCheckboxgroup extends LitElement {
 
     this._internals.setFormValue(selectedValues.join(", "));
 
-    this._manageCheckboxRequired();
+    this._manageRequire();
   }
 
   render() {

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -125,21 +125,37 @@ export class NysRadiogroup extends LitElement {
   private async _manageRequire() {
     const message = this.errorMessage || "Please select an option.";
 
-    const firstRadio = this.querySelector("nys-radiobutton");
-    const firstRadioInput = firstRadio
-      ? await (firstRadio as any).getInputElement()
-      : null;
+    // const firstRadio = this.querySelector("nys-radiobutton");
+    // const firstRadioInput = firstRadio
+    //   ? await (firstRadio as any).getInputElement()
+    //   : null;
 
-    if (firstRadioInput) {
+    // if (firstRadioInput) {
+    //   if (this.required && !this.selectedValue) {
+    //     this._internals.setValidity(
+    //       { valueMissing: true },
+    //       message,
+    //       firstRadioInput,
+    //     );
+    //   } else {
+    //     this.showError = false;
+    //     this._internals.setValidity({}, "", firstRadioInput);
+    //   }
+    // }
+
+    const radioButtons = Array.from(this.querySelectorAll("nys-radiobutton"));
+    const firstRadio = radioButtons[0] as HTMLElement;
+
+    if (firstRadio) {
       if (this.required && !this.selectedValue) {
         this._internals.setValidity(
           { valueMissing: true },
           message,
-          firstRadioInput,
+          firstRadio, // pass the custom element, not shadow input
         );
       } else {
         this.showError = false;
-        this._internals.setValidity({}, "", firstRadioInput);
+        this._internals.setValidity({}, "", firstRadio);
       }
     }
   }

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -125,24 +125,6 @@ export class NysRadiogroup extends LitElement {
   private async _manageRequire() {
     const message = this.errorMessage || "Please select an option.";
 
-    // const firstRadio = this.querySelector("nys-radiobutton");
-    // const firstRadioInput = firstRadio
-    //   ? await (firstRadio as any).getInputElement()
-    //   : null;
-
-    // if (firstRadioInput) {
-    //   if (this.required && !this.selectedValue) {
-    //     this._internals.setValidity(
-    //       { valueMissing: true },
-    //       message,
-    //       firstRadioInput,
-    //     );
-    //   } else {
-    //     this.showError = false;
-    //     this._internals.setValidity({}, "", firstRadioInput);
-    //   }
-    // }
-
     const radioButtons = Array.from(this.querySelectorAll("nys-radiobutton"));
     const firstRadio = radioButtons[0] as HTMLElement;
 


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
Attempt to fix an issue in the `nys-radiogroup` component where the `setValidity` call on `ElementInternals` was failing when the first child radio input element was not yet available. The error occurred when the component tried to validate the required state immediately on initialization.  


<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes #883 🎟️