### PR TITLE
BUG: Add missing nys-prefix for `nys-select`

### DIFF
--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -204,7 +204,7 @@ export class NysSelect extends LitElement {
     }
 
     this.dispatchEvent(
-      new CustomEvent("change", {
+      new CustomEvent("nys-change", {
         detail: { id: this.id, value: this.value },
         bubbles: true,
         composed: true,


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

NYS prefix for `nys-change` event is missing on `nys-select` component.

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  
