### PR TITLE
dont show prefix if toggled off

### DIFF
--- a/packages/nys-badge/src/nys-badge.figma.ts
+++ b/packages/nys-badge/src/nys-badge.figma.ts
@@ -23,17 +23,19 @@ figma.connect<BadgeProps>("<FIGMA_BADGE>", {
     }),
     prefixIcon: figma.string("Prefix Icon"),
     suffixIcon: figma.string("Suffix Icon"),
-    prefixLabel: figma.string("↳ Prefix Label"),
+    prefixLabel: figma.boolean("Prefix Label", {
+      true: figma.string("↳ Prefix Label"),
+      false: undefined,
+    }),
     label: figma.string("Label"),
   },
-  example: (props) => html`
-    <nys-badge
+  example: (props) =>
+    html` <nys-badge
       label=${props.label}
       intent=${props.intent}
       size=${props.size}
       prefixIcon=${props.prefixIcon}
       suffixIcon=${props.suffixIcon}
       prefixLabel=${props.prefixLabel}
-    ></nys-badge>
-  `,
+    ></nys-badge>`,
 });


### PR DESCRIPTION
before if the field had an input but was toggled off it still showed up in the preview, now it does not