### PR TITLE
Fix: `nys-fileinput` validation

### DIFF
--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -20,7 +20,7 @@ export class NysFileinput extends LitElement {
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: Boolean }) multiple = false;
-  @property({ type: String, reflect: true }) form = "";
+  @property({ type: String, reflect: true }) form: string | null = null;
   @property({ type: String }) _tooltip = "";
   @property({ type: String }) accept = ""; // e.g. "image/*,.pdf"
   @property({ type: Boolean, reflect: true }) disabled = false;


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Fix the issue when `required` is set on `nys-fileinput`, it wasn't getting validated by the form submission. 

- [x] React Demo
- [x] Vanilla Demo _(though linking it also showed it worked before the fix??)_

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change


This is **not** a breaking change.  


## Related issues

Closes #916 🎟️
