### PR TITLE
Fix: `nys-checkbox` A11y test fail & labels not toggling checkbox

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -72,6 +72,7 @@ export class NysCheckbox extends LitElement {
     // This ensures our element always participates in the form
     this._setValue();
     this._manageRequire();
+    this._manageLabelClick();
   }
 
   // This callback is automatically called when the parent form is reset.
@@ -175,6 +176,15 @@ export class NysCheckbox extends LitElement {
     }
   }
 
+  private _manageLabelClick = () => {
+    const labelEl = this.shadowRoot?.querySelector("nys-label");
+    const inputEl = this.shadowRoot?.querySelector("input");
+
+    if (labelEl && inputEl) {
+      labelEl.addEventListener("click", () => inputEl.click());
+    }
+  };
+
   /******************** Event Handlers ********************/
   private _emitChangeEvent() {
     this.dispatchEvent(
@@ -231,7 +241,7 @@ export class NysCheckbox extends LitElement {
 
   render() {
     return html`
-      <label class="nys-checkbox">
+      <div class="nys-checkbox">
         <div class="nys-checkbox__checkboxwrapper">
           <input
             id="${this.id}"
@@ -267,6 +277,7 @@ export class NysCheckbox extends LitElement {
         </div>
         ${this.label &&
         html`
+          <label for=${this.id} class="sr-only">${this.label}</label>
           <nys-label
             for=${this.id}
             label=${this.label}
@@ -278,7 +289,7 @@ export class NysCheckbox extends LitElement {
             >
           </nys-label>
         `}
-      </label>
+      </div>
       ${this.parentElement?.tagName.toLowerCase() !== "nys-checkboxgroup"
         ? html`<nys-errormessage
             id="single-error-message"

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -261,6 +261,7 @@ export class NysCheckbox extends LitElement {
             @focus="${this._handleFocus}"
             @blur="${this._handleBlur}"
             @keydown="${this._handleKeydown}"
+            aria-label="${this.label}"
           />
           ${this.checked
             ? html`<nys-icon
@@ -277,7 +278,6 @@ export class NysCheckbox extends LitElement {
         </div>
         ${this.label &&
         html`
-          <label for=${this.id} class="sr-only">${this.label}</label>
           <nys-label
             for=${this.id}
             label=${this.label}

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -241,7 +241,7 @@ export class NysCheckbox extends LitElement {
 
   render() {
     return html`
-      <div class="nys-checkbox">
+      <label class="nys-checkbox">
         <div class="nys-checkbox__checkboxwrapper">
           <input
             id="${this.id}"
@@ -289,7 +289,7 @@ export class NysCheckbox extends LitElement {
             >
           </nys-label>
         `}
-      </div>
+      </label>
       ${this.parentElement?.tagName.toLowerCase() !== "nys-checkboxgroup"
         ? html`<nys-errormessage
             id="single-error-message"


### PR DESCRIPTION
# Summary

Addresses a fix for the build test fail on `nys-checkbox` and fixes the text clicking not toggling the status of the checkbox

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

_Indicate if this update is a breaking change with **one** of the following statements:_

This is **not** a breaking change.  


## Related issues

Closes #930 🎟️