### PR TITLE
Enhancement: invert prop

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.mdx
+++ b/packages/nys-checkbox/src/nys-checkbox.mdx
@@ -59,6 +59,10 @@ The error message will appear **ONLY** when the `showError` attribute is set to 
 ### Slots
 When the description requires more complexity than a simple `string` value,  add your HTML content directly within the component as slot content, rather than setting a `description` prop. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`
 <Canvas of={NysCheckboxStories.Slot} />
+## Invert
+Set the `invert` when the component is on a dark background. \
+You can set `invert` on `nys-checkboxgroup` to apply it to all checkboxes, or on a single `nys-checkbox` if only one needs it.
+<Canvas of={NysCheckboxStories.Invert} />
 
 ## Usage
 

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -17,6 +17,7 @@ interface NysCheckboxArgs {
   value: string;
   required: boolean;
   optional: boolean;
+  invert: boolean;
   showError: boolean;
   errorMessage: string;
   form: string | null;
@@ -36,6 +37,7 @@ const meta: Meta<NysCheckboxArgs> = {
     disabled: { control: "boolean" },
     required: { control: "boolean" },
     optional: { control: "boolean" },
+    invert: { control: "boolean" },
     value: { control: "text" },
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
@@ -68,6 +70,7 @@ export const Basic: Story = {
     errorMessage: "",
     tile: false,
     optional: false,
+    invert: false,
   },
   render: (args) => html`
     <nys-checkboxgroup
@@ -75,6 +78,7 @@ export const Basic: Story = {
       description="Choose from the options below"
       size=${args.size}
       .tile=${args.tile}
+      ?invert=${args.invert}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
@@ -165,6 +169,7 @@ export const Grouping: Story = {
         description=${args.description}
         size=${args.size}
         .tile=${args.tile}
+        ?invert=${args.invert}
         .showError=${args.showError}
         .errorMessage=${args.errorMessage}
         .form=${args.form}
@@ -287,6 +292,7 @@ export const Disabled: Story = {
       .disabled=${args.disabled}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .label=${args.label}
       .description=${args.description}
       .name=${args.name}
@@ -300,6 +306,7 @@ export const Disabled: Story = {
       .disabled=${args.disabled}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .label=${args.label}
       .description=${args.description}
       .name=${args.name}
@@ -349,6 +356,7 @@ export const Size: Story = {
       description="Choose from the options below"
       size=${args.size}
       .tile=${args.tile}
+      ?invert=${args.invert}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
@@ -438,6 +446,7 @@ export const Tile: Story = {
       description="Choose from the options below"
       size=${args.size}
       .tile=${args.tile}
+      ?invert=${args.invert}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
@@ -541,6 +550,7 @@ export const Required: Story = {
       .errorMessage=${args.errorMessage}
       .form=${args.form}
       .tile=${args.tile}
+      ?invert=${args.invert}
     ></nys-checkbox>
   `,
   parameters: {
@@ -590,6 +600,7 @@ export const ErrorMessage: Story = {
       .errorMessage=${args.errorMessage}
       .form=${args.form}
       .tile=${args.tile}
+      ?invert=${args.invert}
     ></nys-checkbox>
   `,
   parameters: {
@@ -638,6 +649,7 @@ export const Slot: Story = {
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
+      ?invert=${args.invert}
     >
       <p slot="description">
         ${args.description}<a href="https://www.ny.gov/" target="__blank"
@@ -685,6 +697,7 @@ export const Optional: Story = {
       description="Choose from the options below"
       size=${args.size}
       .tile=${args.tile}
+      ?invert=${args.invert}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
       .form=${args.form}
@@ -757,6 +770,108 @@ export const Optional: Story = {
 
         `,
 
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Invert: Story = {
+  args: {
+    checked: true,
+    disabled: false,
+    required: false,
+    label: "Adirondacks",
+    description: "",
+    name: "landmarks",
+    value: "adirondacks",
+    showError: false,
+    errorMessage: "",
+    tile: false,
+    optional: false,
+    invert: true,
+  },
+  render: (args) => html`
+    <div
+      style="display: flex; background-color: var(--nys-color-ink, #1b1b1b); padding: var(--nys-space-800, 64px);"
+    >
+      <nys-checkboxgroup
+        label="Select your favorite New York landmarks"
+        description="Choose from the options below"
+        size=${args.size}
+        .tile=${args.tile}
+        ?invert=${args.invert}
+        .showError=${args.showError}
+        .errorMessage=${args.errorMessage}
+        .form=${args.form}
+      >
+        <nys-checkbox
+          .checked=${args.checked}
+          .disabled=${args.disabled}
+          .required=${args.required}
+          .optional=${args.optional}
+          .label=${args.label}
+          .description=${args.description}
+          .name=${args.name}
+          .value=${args.value}
+        ></nys-checkbox>
+        <nys-checkbox
+          name="landmarks"
+          value="finger-lakes"
+          label="Finger Lakes"
+          checked
+        ></nys-checkbox>
+        <nys-checkbox
+          name="landmarks"
+          value="catskills"
+          label="Catskills"
+          checked
+        ></nys-checkbox>
+        <nys-checkbox
+          name="landmarks"
+          value="niagara-falls"
+          label="Niagara Falls"
+          checked
+        ></nys-checkbox>
+        <nys-checkbox
+          name="landmarks"
+          value="coney-island"
+          label="Coney Island"
+        ></nys-checkbox>
+        <nys-checkbox
+          name="landmarks"
+          value="mount-greylock"
+          label="Mount Greylock"
+          description="This is disabled because it's not in New York."
+          disabled
+        ></nys-checkbox>
+      </nys-checkboxgroup>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-checkboxgroup
+  label="Select your favorite New York landmarks"
+  description="Choose from the options below"
+  invert
+>
+  <nys-checkbox
+    label="Adirondacks"
+    name="landmarks"
+    value="adirondacks"
+    errorMessage="You must select this box to continue"
+    checked
+  ></nys-checkbox>
+  <nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="catskills" label="Catskills" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="niagara-falls" label="Niagara Falls" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="coney-island" label="Coney Island"></nys-checkbox>
+  <nys-checkbox label="Mount Greylock" description="This is disabled because it's not in New York." disabled></nys-checkbox>
+</nys-checkboxgroup>
+
+        `,
         type: "auto",
       },
     },

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -20,6 +20,7 @@ export class NysCheckbox extends LitElement {
   @property({ type: String }) errorMessage = "";
   @property({ type: Boolean }) groupExist = false;
   @property({ type: Boolean, reflect: true }) tile = false;
+  @property({ type: Boolean, reflect: true }) invert = false;
   private static readonly VALID_SIZES = ["sm", "md"] as const;
   private _size: (typeof NysCheckbox.VALID_SIZES)[number] = "md";
 
@@ -283,6 +284,7 @@ export class NysCheckbox extends LitElement {
             label=${this.label}
             description=${ifDefined(this.description ?? undefined)}
             flag=${ifDefined(this.required ? "required" : undefined)}
+            ?invert=${this.invert}
           >
             <slot name="description" slot="description"
               >${this.description}</slot

--- a/packages/nys-checkbox/src/nys-checkboxgroup.ts
+++ b/packages/nys-checkbox/src/nys-checkboxgroup.ts
@@ -15,6 +15,7 @@ export class NysCheckboxgroup extends LitElement {
   @property({ type: String }) description = "";
   @property({ type: Boolean, reflect: true }) tile = false;
   @property({ type: String }) _tooltip = "";
+  @property({ type: Boolean, reflect: true }) invert = false;
   @property({ type: String, reflect: true }) form: string | null = null;
 
   @state() private _slottedDescriptionText = "";
@@ -84,6 +85,9 @@ export class NysCheckboxgroup extends LitElement {
     }
     if (changedProperties.has("tile")) {
       this._updateCheckboxTile();
+    }
+    if (changedProperties.has("invert")) {
+      this._updateCheckboxInvert();
     }
     if (changedProperties.has("showError")) {
       this._updateCheckboxShowError();
@@ -161,6 +165,17 @@ export class NysCheckboxgroup extends LitElement {
         checkbox.toggleAttribute("tile", true);
       } else {
         checkbox.removeAttribute("tile");
+      }
+    });
+  }
+
+  private _updateCheckboxInvert() {
+    const checkboxes = this.querySelectorAll("nys-checkbox");
+    checkboxes.forEach((checkbox) => {
+      if (this.invert) {
+        checkbox.toggleAttribute("invert", true);
+      } else {
+        checkbox.removeAttribute("invert");
       }
     });
   }
@@ -282,6 +297,7 @@ export class NysCheckboxgroup extends LitElement {
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
           tooltip=${this._tooltip}
+          ?invert=${this.invert}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-divider/src/nys-divider.mdx
+++ b/packages/nys-divider/src/nys-divider.mdx
@@ -8,7 +8,7 @@ import "@nysds/nys-badge"
 
 # Divider
 
-The **`nys-divider`** component is a reusable web component for use in New York State digital products.
+The **`nys-divider`** component separates content and visually divides sections within layouts.
 
 <div class="nys-grid-row nys-grid-gap-1">
   <nys-badge label="Stable" prefixIcon="code"></nys-badge>

--- a/packages/nys-fileinput/src/nys-fileinput.mdx
+++ b/packages/nys-fileinput/src/nys-fileinput.mdx
@@ -59,6 +59,10 @@ Set `disabled` to prevent interaction with the file input. Useful when the input
 You can supply a description via our `description` prop for plain text or by embedding HTML within our component via our slot for higher customization.
 <Canvas of={NysFileinputStories.DescriptionSlot} />
 
+## Invert
+Set the `invert` when the component is on a dark background.
+<Canvas of={NysFileinputStories.Invert} />
+
 ## Usage
 
 ### When to use this component

--- a/packages/nys-fileinput/src/nys-fileinput.stories.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.stories.ts
@@ -21,6 +21,7 @@ interface NysFileinputArgs {
   errorMessage: string;
   showError: boolean;
   dropzone: boolean;
+  invert: boolean;
   form: string;
 }
 
@@ -45,6 +46,7 @@ const meta: Meta<NysFileinputArgs> = {
     errorMessage: { control: "text" },
     showError: { control: "boolean" },
     dropzone: { control: "boolean" },
+    invert: { control: "boolean" },
     form: { control: "text" },
   },
   parameters: {
@@ -74,6 +76,7 @@ export const Basic: Story = {
     errorMessage: "",
     showError: false,
     dropzone: false,
+    invert: false,
   },
   render: (args) => html`
     <nys-fileinput
@@ -90,6 +93,7 @@ export const Basic: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      ?invert=${args.invert}
       .form=${args.form}
     ></nys-fileinput>
   `,
@@ -132,6 +136,7 @@ export const Dropzone: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      ?invert=${args.invert}
       .form=${args.form}
     ></nys-fileinput>
   `,
@@ -174,6 +179,7 @@ export const Width: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      ?invert=${args.invert}
       .form=${args.form}
     ></nys-fileinput>
   `,
@@ -216,6 +222,7 @@ export const Multiple: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      ?invert=${args.invert}
       .form=${args.form}
     ></nys-fileinput>
   `,
@@ -261,6 +268,7 @@ export const Disabled: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      ?invert=${args.invert}
       .form=${args.form}
     ></nys-fileinput>
   `,
@@ -288,6 +296,7 @@ export const DescriptionSlot: Story = {
     name: "fileinput-slot",
     label: "Upload a file",
     width: "full",
+    invert: false,
   },
   render: (args) => html`
     <nys-fileinput
@@ -304,6 +313,7 @@ export const DescriptionSlot: Story = {
       .errorMessage=${args.errorMessage}
       ?showError=${args.showError}
       ?dropzone=${args.dropzone}
+      ?invert=${args.invert}
       .form=${args.form}
     >
       <span slot="description">
@@ -327,6 +337,63 @@ export const DescriptionSlot: Story = {
     <a href="https://www.ny.gov" target="_blank" rel="noopener">ny.gov</a>
   </span>
 </nys-fileinput>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Invert: Story = {
+  args: {
+    id: "fileinput1",
+    name: "fileinput1",
+    label: "Upload a file",
+    description: "Accepted file types: .jpg, .png, .pdf",
+    width: "full",
+    multiple: false,
+    accept: "image/png, image/jpeg, .pdf",
+    required: false,
+    disabled: false,
+    errorMessage: "",
+    showError: false,
+    dropzone: false,
+    invert: true,
+  },
+  render: (args) => html`
+    <div
+      style="display: flex; background-color: var(--nys-color-ink, #1b1b1b); padding: var(--nys-space-800, 64px);"
+    >
+      <nys-fileinput
+        .id=${args.id}
+        .name=${args.name}
+        .label=${args.label}
+        .description=${args.description}
+        .width=${args.width}
+        ?multiple=${args.multiple}
+        .accept=${args.accept}
+        ?required=${args.required}
+        ?optional=${args.optional}
+        ?disabled=${args.disabled}
+        .errorMessage=${args.errorMessage}
+        ?showError=${args.showError}
+        ?dropzone=${args.dropzone}
+        ?invert=${args.invert}
+        .form=${args.form}
+      ></nys-fileinput>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-fileinput
+  id="fileinput1"
+  name="fileinput1"
+  label="Upload a file"
+  description="Accepted file types: .jpg, .png, .pdf"
+  accept="image/png, image/jpeg, .pdf"
+  invert
+></nys-fileinput>`,
         type: "auto",
       },
     },

--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -30,6 +30,7 @@ export class NysFileinput extends LitElement {
   @property({ type: String }) errorMessage = "";
   @property({ type: Boolean }) dropzone = false;
   @property({ type: String, reflect: true }) width: "lg" | "full" = "full";
+  @property({ type: Boolean, reflect: true }) invert = false;
 
   static styles = styles;
 
@@ -436,6 +437,7 @@ export class NysFileinput extends LitElement {
         description=${this.description}
         flag=${this.required ? "required" : this.optional ? "optional" : ""}
         _tooltip=${this._tooltip}
+        ?invert=${this.invert}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-label/src/nys-label.stories.ts
+++ b/packages/nys-label/src/nys-label.stories.ts
@@ -9,7 +9,8 @@ interface NysLabelArgs {
   label: string;
   description: string;
   flag: "required" | "optional";
-  tooltip?: string;
+  tooltip: string;
+  invert: boolean;
 }
 
 const meta: Meta<NysLabelArgs> = {
@@ -26,6 +27,7 @@ const meta: Meta<NysLabelArgs> = {
       defaultValue: { summary: `null` },
     },
     tooltip: { control: { type: "text" } },
+    invert: { control: "boolean" },
   },
   parameters: {
     docs: {
@@ -45,6 +47,7 @@ export const Basic: Story = {
     label: "This is a basic nys-label",
     description: "",
     tooltip: "",
+    invert: false,
   },
   render: (args) =>
     html`<nys-label
@@ -52,6 +55,7 @@ export const Basic: Story = {
       description=${args.description}
       flag=${args.flag}
       tooltip=${args.tooltip}
+      ?invert=${args.invert}
     ></nys-label>`,
   parameters: {
     docs: {

--- a/packages/nys-label/src/nys-label.styles.ts
+++ b/packages/nys-label/src/nys-label.styles.ts
@@ -86,4 +86,14 @@ export default css`
   .nys-label__tooltip-icon {
     margin-top: -2px;
   }
+
+  .nys-label.invert .nys-label__label,
+  .nys-label.invert .nys-label__description,
+  .nys-label.invert .nys-label__optional {
+    color: var(--nys-color-text-inverse, #fff);
+  }
+
+  .nys-label.invert .nys-label__tooltip-icon {
+    color: var(--nys-color-ink-inverse, #fff);
+  }
 `;

--- a/packages/nys-label/src/nys-label.ts
+++ b/packages/nys-label/src/nys-label.ts
@@ -23,9 +23,7 @@ export class NysLabel extends LitElement {
     return html`
       <div class="nys-label ${this.invert ? "invert" : ""}">
         <div class="nys-label__tooltip-wrapper">
-          <label
-            for=${this.for}
-            class="nys-label__label"
+          <label for=${this.for} class="nys-label__label"
             >${this.label}
             ${this.flag === "required"
               ? html`<div class="nys-label__required">*</div>`
@@ -47,10 +45,7 @@ export class NysLabel extends LitElement {
               </nys-tooltip>`
             : ""}
         </div>
-        <label
-          for=${this.for}
-          class="nys-label__description"
-        >
+        <label for=${this.for} class="nys-label__description">
           <slot name="description">${this.description}</slot>
         </label>
       </div>

--- a/packages/nys-label/src/nys-label.ts
+++ b/packages/nys-label/src/nys-label.ts
@@ -7,7 +7,7 @@ export class NysLabel extends LitElement {
   @property({ type: String }) label = "";
   @property({ type: String }) description = "";
   @property({ type: String }) flag = "";
-  @property({ type: Boolean, reflect: true }) tooltipInverted = false;
+  @property({ type: Boolean, reflect: true }) invert = false;
   @property({ type: String })
   get tooltip() {
     return this._tooltip;
@@ -21,9 +21,11 @@ export class NysLabel extends LitElement {
 
   render() {
     return html`
-      <div class="nys-label">
+      <div class="nys-label ${this.invert ? "invert" : ""}">
         <div class="nys-label__tooltip-wrapper">
-          <label for=${this.for} class="nys-label__label"
+          <label
+            for=${this.for}
+            class="nys-label__label"
             >${this.label}
             ${this.flag === "required"
               ? html`<div class="nys-label__required">*</div>`
@@ -37,7 +39,7 @@ export class NysLabel extends LitElement {
                 text="${this._tooltip}"
                 position="top"
                 focusable
-                ?inverted=${this.tooltipInverted}
+                ?inverted=${this.invert}
               >
                 <div class="nys-label__tooltip-icon">
                   <nys-icon name="info" size="3xl"></nys-icon>
@@ -45,7 +47,10 @@ export class NysLabel extends LitElement {
               </nys-tooltip>`
             : ""}
         </div>
-        <label for=${this.for} class="nys-label__description">
+        <label
+          for=${this.for}
+          class="nys-label__description"
+        >
           <slot name="description">${this.description}</slot>
         </label>
       </div>

--- a/packages/nys-modal/src/nys-modal.mdx
+++ b/packages/nys-modal/src/nys-modal.mdx
@@ -117,8 +117,8 @@ The `nys-modal` component includes the following accessibility-focused features:
 
 - Trap focus inside the modal so keyboard users can’t tab to background content.
 - Return focus to the triggering element when the modal closes.
-- Support keyboard interaction — allow Esc to close the modal.
-- Announce the modal to screen readers using role="dialog" or role="alertdialog" and aria-modal="true".
+- Support keyboard interaction: allow "esc" key to close the modal.
+- Announce the modal to screen readers using role="dialog".
 - Prevent background scroll so users don’t lose context.
 
 ## Slots

--- a/packages/nys-modal/src/nys-modal.mdx
+++ b/packages/nys-modal/src/nys-modal.mdx
@@ -65,9 +65,7 @@ Use the default slot to add content such as text, links, or other elements insid
 <Canvas of={NysModalStories.BasicSlot} />
 
 ### Adding action buttons
-Set the modal’s visibility using the `open` (boolean) property on `<nys-modal>`.
-Buttons (recommended `<nys-button>`) placed in the `actions` slot can update the `open` property to close the modal or confirm an action.
-
+Control a modal’s visibility with the `open` (boolean) property on `<nys-modal>`. Place action buttons (typically `<nys-button>`) inside the actions slot to close the modal or confirm a task by updating the `open` property.
 **Tip:** By convention, the secondary/cancel button is usually placed first, followed by the primary/confirm button. This helps maintain consistent UX and accessibility patterns.
 <Canvas of={NysModalStories.ActionButtonSlot} />
 

--- a/packages/nys-modal/src/nys-modal.stories.ts
+++ b/packages/nys-modal/src/nys-modal.stories.ts
@@ -125,8 +125,8 @@ export const Basic: Story = {
     Cuomo consequat.
   </p>
   <div slot="actions">
-    <nys-button label="Not now" variant="text" onClick={your logic here}></nys-button>
-    <nys-button label="Update" onClick={your logic here}></nys-button>
+    <nys-button label="Not now" variant="text" onClick="{your logic here}"</nys-button>
+    <nys-button label="Update" onClick="{your logic here}"></nys-button>
   </div>
 </nys-modal>`,
         type: "auto",

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -59,6 +59,9 @@ Note: in order to display an error message, you must pass in `showError` to the 
 When the description requires more complexity than a simple `string` value, use the `slot="description"` to hold the text. This allows the developer to include HTML in the description, such as `<a>` or `<strong>`\
 Note: Both `nys-radiobutton` and `nys-radiogroup` support the description slot.
 <Canvas of={NysRadiobuttonStories.Slot} />
+## Invert
+Set the `invert` when the component is on a dark background.
+<Canvas of={NysRadiobuttonStories.Invert} />
 
 ## Usage
 

--- a/packages/nys-radiobutton/src/nys-radiobutton.mdx
+++ b/packages/nys-radiobutton/src/nys-radiobutton.mdx
@@ -60,7 +60,7 @@ When the description requires more complexity than a simple `string` value, use 
 Note: Both `nys-radiobutton` and `nys-radiogroup` support the description slot.
 <Canvas of={NysRadiobuttonStories.Slot} />
 ## Invert
-Set the `invert` when the component is on a dark background.
+Set the `invert` on `<nys-radiogroup>` when the component is on a dark background.
 <Canvas of={NysRadiobuttonStories.Invert} />
 
 ## Usage

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -19,6 +19,7 @@ interface NysRadiobuttonArgs {
   form: string | null;
   required: boolean;
   optional: boolean;
+  invert: boolean;
   showError: boolean;
   errorMessage: string;
 }
@@ -37,9 +38,9 @@ const meta: Meta<NysRadiobuttonArgs> = {
     disabled: { control: "boolean" },
     value: { control: "text" },
     form: { control: "text" },
-
     required: { control: "boolean" },
     optional: { control: "boolean" },
+    invert: { control: "boolean" },
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
   },
@@ -69,6 +70,7 @@ export const Basic: Story = {
     required: false,
     optional: false,
     showError: false,
+    invert: false,
   },
   render: (args) => html`
     <nys-radiogroup
@@ -80,6 +82,7 @@ export const Basic: Story = {
       .errorMessage=${args.errorMessage}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
     >
       <nys-radiobutton
@@ -144,6 +147,7 @@ export const PartialEditableOptions: Story = {
       label="Choose your preferred work operating system."
       size=${args.size}
       .tile=${args.tile}
+      ?invert=${args.invert}
     >
       <nys-radiobutton
         .id=${args.id}
@@ -217,6 +221,7 @@ export const DisabledOptions: Story = {
       description="Note: You cannot change your title, if you believe you are ready to be promoted talk to your supervisor."
       size=${args.size}
       .tile=${args.tile}
+      ?invert=${args.invert}
     >
       <nys-radiobutton
         .id=${args.id}
@@ -301,6 +306,7 @@ export const Required: Story = {
       .tile=${args.tile}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -371,6 +377,7 @@ export const Size: Story = {
       .tile=${args.tile}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -447,6 +454,7 @@ export const Tile: Story = {
       .errorMessage=${args.errorMessage}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
     >
       <nys-radiobutton
@@ -516,6 +524,7 @@ export const ErrorMessage: Story = {
       .tile=${args.tile}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -585,6 +594,7 @@ export const Slot: Story = {
       .tile=${args.tile}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
+      ?invert=${args.invert}
     >
       <label slot="description">
         This is the location you use for your in office days.
@@ -661,6 +671,7 @@ export const Optional: Story = {
       .tile=${args.tile}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .showError=${args.showError}
       .errorMessage=${args.errorMessage}
@@ -708,6 +719,83 @@ export const Optional: Story = {
 </nys-radiogroup>
 `.trim(),
 
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Invert: Story = {
+  args: {
+    name: "office",
+    label: "Albany",
+    description: "Upstate New York",
+    value: "albany",
+    invert: true,
+  },
+  render: (args) => html`
+    <div
+      style="display: flex; background-color: var(--nys-color-ink, #1b1b1b); padding: var(--nys-space-800, 64px);"
+    >
+      <nys-radiogroup
+        label="What is your primary work location?"
+        size=${args.size}
+        .tile=${args.tile}
+        .showError=${args.showError}
+        .errorMessage=${args.errorMessage}
+        ?invert=${args.invert}
+      >
+        <label slot="description">
+          This is the location you use for your in office days.
+          <a href="https://www.ny.gov/" target="__blank">(slot)</a></label
+        >
+        <nys-radiobutton
+          .name=${args.name}
+          .checked=${args.checked}
+          .label=${args.label}
+          .description=${args.description}
+          .disabled=${args.disabled}
+          .value=${args.value}
+        ></nys-radiobutton>
+        <nys-radiobutton
+          .name=${args.name}
+          .checked=${false}
+          .label=${"Manhattan"}
+          .disabled=${args.disabled}
+          .value=${"manhattan"}
+        >
+          <label slot="description">
+            New York City
+            <a href="https://www.ny.gov/" target="__blank">(slot)</a></label
+          >
+        </nys-radiobutton>
+      </nys-radiogroup>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-radiogroup label="What is your primary work location?" invert>
+  <label slot="description">
+    This is the location you use for your in office days.
+    <a href="https://www.ny.gov/" target="__blank">(slot)</a></label
+  >
+  <nys-radiobutton
+    name="office"
+    label="Albany"
+    description="Upstate New York (prop)"
+    value="albany"
+  ></nys-radiobutton>
+  <nys-radiobutton
+    name="office"
+    label="Manhattan"
+    value="manhattan"
+  >
+    <label slot="description"> New York City <a href="https://www.ny.gov/" target="__blank">(slot)</a></label>
+  </nys-radiobutton>
+</nys-radiogroup>
+`.trim(),
         type: "auto",
       },
     },

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -15,6 +15,7 @@ export class NysRadiobutton extends LitElement {
   @property({ type: String }) id = "";
   @property({ type: String, reflect: true }) name = "";
   @property({ type: String }) value = "";
+  @property({ type: Boolean, reflect: true }) invert = false;
   @property({ type: String, reflect: true }) form: string | null = null;
   private static readonly VALID_SIZES = ["sm", "md"] as const;
   private _size: (typeof NysRadiobutton.VALID_SIZES)[number] = "md";
@@ -193,6 +194,7 @@ export class NysRadiobutton extends LitElement {
           for=${this.id}
           label=${this.label}
           description=${ifDefined(this.description || undefined)}
+          ?invert=${this.invert}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label> `}

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -15,6 +15,7 @@ export class NysRadiogroup extends LitElement {
   @property({ type: String }) description = "";
   @property({ type: Boolean, reflect: true }) tile = false;
   @property({ type: String }) _tooltip = "";
+  @property({ type: Boolean, reflect: true }) invert = false;
   @property({ type: String, reflect: true }) form: string | null = null;
 
   @state() private selectedValue: string | null = null;
@@ -90,6 +91,9 @@ export class NysRadiogroup extends LitElement {
     }
     if (changedProperties.has("tile")) {
       this._updateRadioButtonsTile();
+    }
+    if (changedProperties.has("invert")) {
+      this._updateRadioButtonsInvert();
     }
     if (changedProperties.has("showError")) {
       this._updateRadioButtonsShowError();
@@ -259,6 +263,17 @@ export class NysRadiogroup extends LitElement {
     });
   }
 
+  private _updateRadioButtonsInvert() {
+    const radioButtons = this.querySelectorAll("nys-radiobutton");
+    radioButtons.forEach((radioButton) => {
+      if (this.invert) {
+        radioButton.toggleAttribute("invert", true);
+      } else {
+        radioButton.removeAttribute("invert");
+      }
+    });
+  }
+
   private _updateRadioButtonsShowError() {
     const radioButtons = this.querySelectorAll("nys-radiobutton");
     radioButtons.forEach((radioButton) => {
@@ -357,6 +372,7 @@ export class NysRadiogroup extends LitElement {
         description=${this.description}
         flag=${this.required ? "required" : this.optional ? "optional" : ""}
         _tooltip=${this._tooltip}
+        ?invert=${this.invert}
       >
         <slot name="description" slot="description">${this.description}</slot>
       </nys-label>

--- a/packages/nys-select/src/nys-select.mdx
+++ b/packages/nys-select/src/nys-select.mdx
@@ -54,6 +54,10 @@ You can supply a description via our `description` prop for plain text or by emb
 In order to display an error message, you must pass in `showError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysSelectStories.ErrorMessage} />
 
+## Invert
+Set the `invert` when the component is on a dark background.
+<Canvas of={NysSelectStories.Invert} />
+
 ## Usage
 
 ### When to use this component

--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -15,11 +15,12 @@ interface NysSelectArgs {
   disabled: boolean;
   required: boolean;
   optional: boolean;
-  form: string | null;
+  invert: boolean;
   width: "sm" | "md" | "lg" | "full";
   options: string;
   showError: boolean;
   errorMessage: string;
+  form: string | null;
 }
 
 const meta: Meta<NysSelectArgs> = {
@@ -35,7 +36,7 @@ const meta: Meta<NysSelectArgs> = {
     required: { control: "boolean" },
     optional: { control: "boolean" },
     form: { control: "text" },
-
+    invert: { control: "boolean" },
     width: { control: "select", options: ["sm", "md", "lg", "full"] },
     showError: { control: "boolean" },
     errorMessage: { control: "text" },
@@ -61,6 +62,7 @@ export const Basic: Story = {
     required: false,
     optional: false,
     showError: false,
+    invert: false,
   },
   render: (args) => html`
     <nys-select
@@ -72,6 +74,7 @@ export const Basic: Story = {
       .disabled=${args.disabled}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -115,6 +118,7 @@ export const OptionsLabelSlot: Story = {
       .disabled=${args.disabled}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -132,52 +136,6 @@ export const OptionsLabelSlot: Story = {
       source: {
         code: `
 <nys-select label="Select your favorite borough">
-  <nys-option value="bronx">The Bronx</nys-option>
-  <nys-option value="brooklyn">Brooklyn</nys-option>
-  <nys-option value="manhattan">Manhattan</nys-option>
-  <nys-option value="staten_island">Staten Island</nys-option>
-  <nys-option value="queens">Queens</nys-option>
-</nys-select>`,
-        type: "auto",
-      },
-    },
-  },
-};
-
-export const DescriptionSlot: Story = {
-  args: {
-    label: "Select your favorite borough",
-    description: "This is a slot",
-    value: "",
-  },
-  render: (args) => html`
-    <nys-select
-      .id=${args.id}
-      .name=${args.name}
-      .label=${args.label}
-      .value=${args.value}
-      .disabled=${args.disabled}
-      .required=${args.required}
-      .optional=${args.optional}
-      .form=${args.form}
-      .width=${args.width}
-      .showError=${args.showError}
-      .errorMessage=${args.errorMessage}
-    >
-      <label slot="description">${args.description}</label>
-      <nys-option value="bronx">The Bronx</nys-option>
-      <nys-option value="brooklyn">Brooklyn</nys-option>
-      <nys-option value="manhattan">Manhattan</nys-option>
-      <nys-option value="staten_island">Staten Island</nys-option>
-      <nys-option value="queens">Queens</nys-option>
-    </nys-select>
-  `,
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-select label="Select your favorite borough">
-  <label slot="description">This is a slot</label>
   <nys-option value="bronx">The Bronx</nys-option>
   <nys-option value="brooklyn">Brooklyn</nys-option>
   <nys-option value="manhattan">Manhattan</nys-option>
@@ -206,6 +164,7 @@ export const Disabled: Story = {
       .disabled=${args.disabled}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -251,6 +210,7 @@ export const Required: Story = {
       .disabled=${args.disabled}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -280,6 +240,55 @@ export const Required: Story = {
   },
 };
 
+export const Optional: Story = {
+  args: {
+    label: "Select your favorite borough",
+    value: "",
+    optional: true,
+  },
+
+  render: (args) => html`
+    <nys-select
+      .id=${args.id}
+      .name=${args.name}
+      .label=${args.label}
+      .description=${args.description}
+      .value=${args.value}
+      .disabled=${args.disabled}
+      .required=${args.required}
+      .optional=${args.optional}
+      ?invert=${args.invert}
+      .form=${args.form}
+      .width=${args.width}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    >
+      <nys-option value="bronx" label="The Bronx"></nys-option>
+      <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+      <nys-option value="manhattan" label="Manhattan"></nys-option>
+      <nys-option value="staten_island" label="Staten Island"></nys-option>
+      <nys-option value="queens" label="Queens"></nys-option>
+    </nys-select>
+  `,
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-select label="Select your favorite borough" optional>
+  <nys-option value="bronx" label="The Bronx"></nys-option>
+  <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+  <nys-option value="manhattan" label="Manhattan"></nys-option>
+  <nys-option value="staten_island" label="Staten Island"></nys-option>
+  <nys-option value="queens" label="Queens"></nys-option>
+</nys-select>`,
+
+        type: "auto",
+      },
+    },
+  },
+};
+
 export const Width: Story = {
   args: {
     label: "Select your favorite borough",
@@ -297,6 +306,7 @@ export const Width: Story = {
       .disabled=${args.disabled}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -330,6 +340,53 @@ export const Width: Story = {
   },
 };
 
+export const DescriptionSlot: Story = {
+  args: {
+    label: "Select your favorite borough",
+    description: "This is a slot",
+    value: "",
+  },
+  render: (args) => html`
+    <nys-select
+      .id=${args.id}
+      .name=${args.name}
+      .label=${args.label}
+      .value=${args.value}
+      .disabled=${args.disabled}
+      .required=${args.required}
+      .optional=${args.optional}
+      ?invert=${args.invert}
+      .form=${args.form}
+      .width=${args.width}
+      .showError=${args.showError}
+      .errorMessage=${args.errorMessage}
+    >
+      <label slot="description">${args.description}</label>
+      <nys-option value="bronx">The Bronx</nys-option>
+      <nys-option value="brooklyn">Brooklyn</nys-option>
+      <nys-option value="manhattan">Manhattan</nys-option>
+      <nys-option value="staten_island">Staten Island</nys-option>
+      <nys-option value="queens">Queens</nys-option>
+    </nys-select>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-select label="Select your favorite borough">
+  <label slot="description">This is a slot</label>
+  <nys-option value="bronx">The Bronx</nys-option>
+  <nys-option value="brooklyn">Brooklyn</nys-option>
+  <nys-option value="manhattan">Manhattan</nys-option>
+  <nys-option value="staten_island">Staten Island</nys-option>
+  <nys-option value="queens">Queens</nys-option>
+</nys-select>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
 export const ErrorMessage: Story = {
   args: {
     label: "Select your favorite borough",
@@ -347,6 +404,7 @@ export const ErrorMessage: Story = {
       .disabled=${args.disabled}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .width=${args.width}
       .showError=${args.showError}
@@ -380,48 +438,50 @@ export const ErrorMessage: Story = {
   },
 };
 
-export const Optional: Story = {
+export const Invert: Story = {
   args: {
     label: "Select your favorite borough",
     value: "",
-    optional: true,
+    invert: true,
   },
-
   render: (args) => html`
-    <nys-select
-      .id=${args.id}
-      .name=${args.name}
-      .label=${args.label}
-      .description=${args.description}
-      .value=${args.value}
-      .disabled=${args.disabled}
-      .required=${args.required}
-      .optional=${args.optional}
-      .form=${args.form}
-      .width=${args.width}
-      .showError=${args.showError}
-      .errorMessage=${args.errorMessage}
+    <div
+      style="display: flex; background-color: var(--nys-color-ink, #1b1b1b); padding: var(--nys-space-800, 64px);"
     >
-      <nys-option value="bronx" label="The Bronx"></nys-option>
-      <nys-option value="brooklyn" label="Brooklyn"></nys-option>
-      <nys-option value="manhattan" label="Manhattan"></nys-option>
-      <nys-option value="staten_island" label="Staten Island"></nys-option>
-      <nys-option value="queens" label="Queens"></nys-option>
-    </nys-select>
+      <nys-select
+        .id=${args.id}
+        .name=${args.name}
+        .label=${args.label}
+        .description=${args.description}
+        .value=${args.value}
+        .disabled=${args.disabled}
+        .required=${args.required}
+        .optional=${args.optional}
+        ?invert=${args.invert}
+        .form=${args.form}
+        .width=${args.width}
+        .showError=${args.showError}
+        .errorMessage=${args.errorMessage}
+      >
+        <nys-option value="bronx" label="The Bronx"></nys-option>
+        <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+        <nys-option value="manhattan" label="Manhattan"></nys-option>
+        <nys-option value="staten_island" label="Staten Island"></nys-option>
+        <nys-option value="queens" label="Queens"></nys-option>
+      </nys-select>
+    </div>
   `,
-
   parameters: {
     docs: {
       source: {
         code: `
-<nys-select label="Select your favorite borough" optional>
+<nys-select label="Select your favorite borough" invert>
   <nys-option value="bronx" label="The Bronx"></nys-option>
   <nys-option value="brooklyn" label="Brooklyn"></nys-option>
   <nys-option value="manhattan" label="Manhattan"></nys-option>
   <nys-option value="staten_island" label="Staten Island"></nys-option>
   <nys-option value="queens" label="Queens"></nys-option>
 </nys-select>`,
-
         type: "auto",
       },
     },

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -17,6 +17,7 @@ export class NysSelect extends LitElement {
   @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String }) _tooltip = "";
   @property({ type: String, reflect: true }) form: string | null = null;
+  @property({ type: Boolean, reflect: true }) invert = false;
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
@@ -248,6 +249,7 @@ export class NysSelect extends LitElement {
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
           _tooltip=${this._tooltip}
+          ?invert=${this.invert}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textarea/src/nys-textarea.mdx
+++ b/packages/nys-textarea/src/nys-textarea.mdx
@@ -59,6 +59,9 @@ Adding the `optional` prop will add an optional flag to the input.
 <Canvas of={NysTextareaStories.Optional} />
 ### Error Message
 <Canvas of={NysTextareaStories.ErrorMessage} />
+## Invert
+Set the `invert` when the component is on a dark background.
+<Canvas of={NysTextareaStories.Invert} />
 
 
 ## Usage

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -587,10 +587,7 @@ export const Invert: Story = {
     docs: {
       source: {
         code: `
-<nys-textarea label="Label" description="Prop: description"></nys-textarea>
-<nys-textarea label="Label">
-  <label slot="description">Slot: description</label>
-</nys-textarea>
+<nys-textarea label="Label" description="Prop: description" invert></nys-textarea>
         `,
         type: "auto",
       },

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -16,6 +16,7 @@ interface NysTextareaArgs {
   readonly: boolean;
   required: boolean;
   optional: boolean;
+  invert: boolean;
   form: string | null;
   maxlength: number | null;
   width: "sm" | "md" | "lg" | "full";
@@ -39,6 +40,7 @@ const meta: Meta<NysTextareaArgs> = {
     readonly: { control: "boolean" },
     required: { control: "boolean" },
     optional: { control: "boolean" },
+    invert: { control: "boolean" },
     form: { control: "text" },
     maxlength: { control: "text" },
 
@@ -74,6 +76,7 @@ export const Basic: Story = {
     required: false,
     optional: false,
     showError: false,
+    invert: false,
   },
   render: (args) => html`
     <nys-textarea
@@ -87,6 +90,7 @@ export const Basic: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -120,6 +124,7 @@ export const Width: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -155,6 +160,7 @@ export const Rows: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -193,6 +199,7 @@ export const Resize: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -226,6 +233,7 @@ export const DescriptionSlot: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -245,6 +253,7 @@ export const DescriptionSlot: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -289,6 +298,7 @@ export const ValueAndPlaceholder: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -327,6 +337,7 @@ export const Disabled: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -362,6 +373,7 @@ export const Readonly: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -402,6 +414,7 @@ export const Maxlength: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -441,6 +454,7 @@ export const Required: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -478,6 +492,7 @@ export const ErrorMessage: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -520,6 +535,7 @@ export const Optional: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .maxlength=${args.maxlength}
       .width=${args.width}
@@ -533,6 +549,49 @@ export const Optional: Story = {
     docs: {
       source: {
         code: `<nys-textarea optional label="label"></nys-textarea>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Invert: Story = {
+  args: { label: "Label", description: "description", value: "", invert: true },
+  render: (args) => html`
+    <div
+      style="display: flex; background-color: var(--nys-color-ink, #1b1b1b); padding: var(--nys-space-800, 64px);"
+    >
+      <nys-textarea
+        .id=${args.id}
+        .name=${args.name}
+        .label=${args.label}
+        .description=${"Prop: " + args.description}
+        .placeholder=${args.placeholder}
+        .value=${args.value}
+        .disabled=${args.disabled}
+        .readonly=${args.readonly}
+        .required=${args.required}
+        .optional=${args.optional}
+        ?invert=${args.invert}
+        .form=${args.form}
+        .maxlength=${args.maxlength}
+        .width=${args.width}
+        .rows=${args.rows}
+        .resize=${args.resize}
+        .showError=${args.showError}
+        .errorMessage=${args.errorMessage}
+      ></nys-textarea>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-textarea label="Label" description="Prop: description"></nys-textarea>
+<nys-textarea label="Label">
+  <label slot="description">Slot: description</label>
+</nys-textarea>
+        `,
         type: "auto",
       },
     },

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -17,6 +17,7 @@ export class NysTextarea extends LitElement {
   @property({ type: Boolean, reflect: true }) required = false;
   @property({ type: Boolean, reflect: true }) optional = false;
   @property({ type: String }) _tooltip = "";
+  @property({ type: Boolean, reflect: true }) invert = false;
   @property({ type: String, reflect: true }) form: string | null = null;
   @property({ type: Number }) maxlength = null;
   private static readonly VALID_WIDTHS = ["sm", "md", "lg", "full"] as const;
@@ -250,6 +251,7 @@ export class NysTextarea extends LitElement {
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
           _tooltip=${this._tooltip}
+          ?invert=${this.invert}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -72,6 +72,9 @@ Use `width="lg"` or `width="full"` on `<nys-textinput>` to give users enough spa
 ### Error Message
 Note: in order to display an error message, you must pass in `hasError` to the component. Setting `errorMessage` does not display the message by default.
 <Canvas of={NysTextinputStories.ErrorMessage} />
+## Invert
+Set the `invert` when the component is on a dark background.
+<Canvas of={NysTextinputStories.Invert} />
 
 ## Usage
 

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -19,6 +19,7 @@ interface NysTextinputArgs {
   readonly: boolean;
   required: boolean;
   optional: boolean;
+  invert: boolean;
   form: string | null;
   pattern: string;
   maxlength: number | null;
@@ -48,6 +49,7 @@ const meta: Meta<NysTextinputArgs> = {
     readonly: { control: "boolean" },
     required: { control: "boolean" },
     optional: { control: "boolean" },
+    invert: { control: "boolean" },
     form: { control: "text" },
 
     pattern: { control: "text" },
@@ -86,6 +88,7 @@ export const Basic: Story = {
     required: false,
     optional: false,
     showError: false,
+    invert: false,
   },
   render: (args) => html`
     <nys-textinput
@@ -100,6 +103,7 @@ export const Basic: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -141,6 +145,7 @@ export const Width: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -188,6 +193,7 @@ export const Password: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -235,6 +241,7 @@ export const SlottedButton: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -296,6 +303,7 @@ export const ValueAndPlaceholder: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -344,6 +352,7 @@ export const Disabled: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -387,6 +396,7 @@ export const Readonly: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -438,6 +448,7 @@ export const MaxMinAndStep: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -490,6 +501,7 @@ export const Maxlength: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -544,6 +556,7 @@ export const Pattern: Story = {
         .readonly=${args.readonly}
         .required=${args.required}
         .optional=${args.optional}
+        ?invert=${args.invert}
         .form=${args.form}
         .pattern=${args.pattern}
         .maxlength=${args.maxlength}
@@ -594,6 +607,7 @@ export const Required: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -634,6 +648,7 @@ export const DescriptionSlot: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -656,6 +671,7 @@ export const DescriptionSlot: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -708,6 +724,7 @@ export const ErrorMessage: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -756,6 +773,7 @@ export const Optional: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -799,6 +817,7 @@ export const Telephone: Story = {
       .readonly=${args.readonly}
       .required=${args.required}
       .optional=${args.optional}
+      ?invert=${args.invert}
       .form=${args.form}
       .pattern=${args.pattern}
       .maxlength=${args.maxlength}
@@ -821,6 +840,58 @@ export const Telephone: Story = {
   type="tel"
 >
 </nys-textinput>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const Invert: Story = {
+  args: {
+    label: "Label",
+    description: "Prop: description",
+    value: "",
+    invert: true,
+  },
+  render: (args) => html`
+    <div
+      style="display: flex; background-color: var(--nys-color-ink, #1b1b1b); padding: var(--nys-space-800, 64px);"
+    >
+      <nys-textinput
+        .id=${args.id}
+        name="descriptionProp"
+        .type=${args.type}
+        .label=${args.label}
+        .description=${args.description}
+        .placeholder=${args.placeholder}
+        .value=${args.value}
+        .disabled=${args.disabled}
+        .readonly=${args.readonly}
+        .required=${args.required}
+        .optional=${args.optional}
+        ?invert=${args.invert}
+        .form=${args.form}
+        .pattern=${args.pattern}
+        .maxlength=${args.maxlength}
+        .width=${args.width}
+        .step=${args.step}
+        .min=${args.min}
+        .max=${args.max}
+        .showError=${args.showError}
+        .errorMessage=${args.errorMessage}
+      ></nys-textinput>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-textinput
+  name="descriptionProp"
+  label="Label"
+  description="Slot: description"
+  invert
+></nys-textinput>`,
         type: "auto",
       },
     },

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -52,6 +52,7 @@ export class NysTextinput extends LitElement {
   @property({ type: Number }) step: number | null = null;
   @property({ type: Number }) min: number | null = null;
   @property({ type: Number }) max: number | null = null;
+  @property({ type: Boolean, reflect: true }) invert = false;
   @property({ type: Boolean, reflect: true }) showError = false;
   @property({ type: String }) errorMessage = "";
   @state() private showPassword = false;
@@ -397,6 +398,7 @@ export class NysTextinput extends LitElement {
           description=${this.description}
           flag=${this.required ? "required" : this.optional ? "optional" : ""}
           _tooltip=${this._tooltip}
+          ?invert=${this.invert}
         >
           <slot name="description" slot="description">${this.description}</slot>
         </nys-label>

--- a/packages/nys-toggle/src/nys-toggle.mdx
+++ b/packages/nys-toggle/src/nys-toggle.mdx
@@ -53,6 +53,10 @@ Supported sizes are `sm` and `md`. **Default size for toggle component is `md`.*
 To remove icons from the toggle switch, use the `NoIcons` boolean property.
 <Canvas of={NysToggleStories.NoIcons} />
 
+## Invert
+Set the `invert` when the component is on a dark background.
+<Canvas of={NysToggleStories.Invert} />
+
 ## Usage
 
 ### When to use this component

--- a/packages/nys-toggle/src/nys-toggle.stories.ts
+++ b/packages/nys-toggle/src/nys-toggle.stories.ts
@@ -14,6 +14,7 @@ interface NysToggleArgs {
   label: string;
   description: string;
   size: "sm" | "md";
+  invert: boolean;
 }
 
 const meta: Meta<NysToggleArgs> = {
@@ -27,6 +28,7 @@ const meta: Meta<NysToggleArgs> = {
     disabled: { control: "boolean" },
     noIcon: { control: "boolean" },
     size: { control: "select", options: ["sm", "md"] },
+    invert: { control: "boolean" },
   },
   parameters: {
     docs: {
@@ -51,6 +53,7 @@ export const Basic: Story = {
     checked: false,
     disabled: false,
     noIcon: false,
+    invert: false,
   },
   render: (args) =>
     html` <nys-toggle
@@ -62,6 +65,7 @@ export const Basic: Story = {
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
       .size=${args.size}
+      ?invert=${args.invert}
     ></nys-toggle>`,
   parameters: {
     docs: {
@@ -96,6 +100,7 @@ export const Checked: Story = {
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
       .size=${args.size}
+      ?invert=${args.invert}
     >
     </nys-toggle>`,
   parameters: {
@@ -132,6 +137,7 @@ export const UncheckedDisabled: Story = {
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
       .size=${args.size}
+      ?invert=${args.invert}
     >
     </nys-toggle>`,
   parameters: {
@@ -169,6 +175,7 @@ export const CheckedDisabled: Story = {
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
       .size=${args.size}
+      ?invert=${args.invert}
     >
     </nys-toggle>`,
   parameters: {
@@ -205,6 +212,7 @@ export const HelpTexts: Story = {
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
       .size=${args.size}
+      ?invert=${args.invert}
     >
       <p slot="description">
         This slot is called 'description' (<a
@@ -225,6 +233,7 @@ export const HelpTexts: Story = {
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
       .size=${args.size}
+      ?invert=${args.invert}
     >
     </nys-toggle>
   `,
@@ -268,9 +277,10 @@ export const Sizes: Story = {
       .checked=${args.checked}
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
-      size="sm">
+      size="sm"
+    >
     </nys-toggle>
-    </br>
+    <br />
     <nys-toggle
       label='Medium (size="md")'
       .name=${args.name}
@@ -282,7 +292,7 @@ export const Sizes: Story = {
       size="md"
     >
     </nys-toggle>
-    `,
+  `,
   parameters: {
     docs: {
       source: {
@@ -328,6 +338,7 @@ export const NoIcons: Story = {
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
       .size=${args.size}
+      ?invert=${args.invert}
     >
     </nys-toggle>`,
   parameters: {
@@ -364,6 +375,7 @@ export const Labels: Story = {
       .disabled=${args.disabled}
       ?noIcon=${args.noIcon}
       .size=${args.size}
+      ?invert=${args.invert}
     >
     </nys-toggle>`,
   parameters: {
@@ -375,6 +387,48 @@ export const Labels: Story = {
   name="toggle-switch"
   value="access"
 >
+</nys-toggle>
+        `.trim(),
+      },
+    },
+  },
+};
+
+export const Invert: Story = {
+  args: {
+    label: "Toggle Switch",
+    name: "toggle-switch",
+    value: "access",
+    invert: true,
+  },
+  render: (args) => html`
+    <div
+      style="display: flex; background-color: var(--nys-color-ink, #1b1b1b); padding: var(--nys-space-800, 64px);"
+    >
+      <nys-toggle
+        .label=${args.label}
+        description="This description was passed in as a property"
+        .name=${args.name}
+        .value=${args.value}
+        .checked=${args.checked}
+        .disabled=${args.disabled}
+        ?noIcon=${args.noIcon}
+        .size=${args.size}
+        ?invert=${args.invert}
+      >
+      </nys-toggle>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-toggle
+  label="Toggle Switch"
+  description="This description was passed in as a property"
+  name="toggle-switch"
+  value="access"
+  invert>
 </nys-toggle>
         `.trim(),
       },

--- a/packages/nys-toggle/src/nys-toggle.styles.ts
+++ b/packages/nys-toggle/src/nys-toggle.styles.ts
@@ -260,6 +260,11 @@ export default css`
     --_nys-toggle-size--knob: var(--nys-size-250, 20px);
   }
 
+  /* Text Invert */
+  .nys-toggle__text.invert {
+    --_nys-toggle-color: var(--nys-color-text-reverse, #fff);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     :host {
       --toggle-transition-duration: 0s; /* Disable animation */

--- a/packages/nys-toggle/src/nys-toggle.ts
+++ b/packages/nys-toggle/src/nys-toggle.ts
@@ -16,6 +16,7 @@ export class NysToggle extends LitElement {
   @property({ type: Boolean, reflect: true }) checked = false;
   @property({ type: Boolean, reflect: true }) disabled = false;
   @property({ type: Boolean }) noIcon = false;
+  @property({ type: Boolean, reflect: true }) invert = false;
   private static readonly VALID_SIZES = ["sm", "md"] as const;
 
   // Private property to store the internal `size` value, restricted to the valid types. Default is "md".
@@ -137,7 +138,7 @@ export class NysToggle extends LitElement {
               </div>
             </span>
           </div>
-          <div class="nys-toggle__text">
+          <div class="nys-toggle__text ${this.invert ? "invert" : ""}">
             <div class="nys-toggle__label">${this.label}</div>
             <slot name="description">${this.description}</slot>
           </div>


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
Add `invert` prop to form-related components. 

**Note**: some form-related components will not need this, like nys-button, due to how they are surrounded by a container with color already.

⚠️ _May need to change nys-tooltip prop inverted to be invert (for another PR)_
⚠️ _May need designers to take on how each component looks on dark backgrounds...this PR solves the text on dark background issue by inverting it (for another PR)_

- [x] checkbox/group
- [x] fileinput
- [x] radiobutton/group
- [x] select
- [x] textarea
- [x] textinput
- [x] toggle

## Breaking change

This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes #879 🎟️

<!--
Every pull request should resolve an open issue.
If no issue exists, please create one so we can track the changes at:
https://github.com/its-hcd/nysds/issues/new/choose
-->

## Screenshot
<img width="432" height="387" alt="Screenshot 2025-10-03 at 3 55 22 PM" src="https://github.com/user-attachments/assets/691c582f-a5ea-460a-9455-c59e42fc3760" />
