### PR TITLE
Enhancement: nys-pagination - disable prev/next buttons

### DIFF
--- a/packages/nys-pagination/src/nys-pagination.ts
+++ b/packages/nys-pagination/src/nys-pagination.ts
@@ -127,43 +127,39 @@ export class NysPagination extends LitElement {
     }
 
     return html`<div class="nys-pagination">
-      ${this.currentPage > 1
-        ? html`
-            <nys-button
-              id="previous"
-              label="Previous"
-              prefixIcon="chevron_left"
-              variant="outline"
-              @nys-click="${() => this._handlePageClick(this.currentPage - 1)}"
-            ></nys-button>
-            <nys-button
-              id="previous--mobile"
-              prefixIcon="chevron_left"
-              ariaLabel="Previous Page"
-              variant="outline"
-              @nys-click="${() => this._handlePageClick(this.currentPage - 1)}"
-            ></nys-button>
-          `
-        : null}
+      <nys-button
+        id="previous"
+        label="Previous"
+        prefixIcon="chevron_left"
+        variant="outline"
+        ?disabled=${this.currentPage === 1}
+        @nys-click="${() => this._handlePageClick(this.currentPage - 1)}"
+      ></nys-button>
+      <nys-button
+        id="previous--mobile"
+        prefixIcon="chevron_left"
+        ariaLabel="Previous Page"
+        variant="outline"
+        ?disabled=${this.currentPage === 1}
+        @nys-click="${() => this._handlePageClick(this.currentPage - 1)}"
+      ></nys-button>
       ${this.renderPageButtons()}
-      ${this.currentPage < this.totalPages
-        ? html`
-            <nys-button
-              id="next"
-              label="Next"
-              suffixIcon="chevron_right"
-              variant="outline"
-              @nys-click="${() => this._handlePageClick(this.currentPage + 1)}"
-            ></nys-button>
-            <nys-button
-              id="next--mobile"
-              suffixIcon="chevron_right"
-              ariaLabel="Next Page"
-              variant="outline"
-              @nys-click="${() => this._handlePageClick(this.currentPage + 1)}"
-            ></nys-button>
-          `
-        : null}
+      <nys-button
+        id="next"
+        label="Next"
+        suffixIcon="chevron_right"
+        variant="outline"
+        ?disabled=${this.currentPage === this.totalPages}
+        @nys-click="${() => this._handlePageClick(this.currentPage + 1)}"
+      ></nys-button>
+      <nys-button
+        id="next--mobile"
+        suffixIcon="chevron_right"
+        ariaLabel="Next Page"
+        variant="outline"
+        ?disabled=${this.currentPage === this.totalPages}
+        @nys-click="${() => this._handlePageClick(this.currentPage + 1)}"
+      ></nys-button>
     </div>`;
   }
   /****************** 🪡 for 1.10.0 ******************/


### PR DESCRIPTION
change to disabling next and previous when on last/first buttons instead of hiding them
<img width="237" height="56" alt="image" src="https://github.com/user-attachments/assets/7546a075-db5a-41da-bf0e-000c38a60b69" />
<img width="314" height="61" alt="image" src="https://github.com/user-attachments/assets/f76179a5-282f-4d44-9548-315f81c06ecc" />
<img width="238" height="53" alt="image" src="https://github.com/user-attachments/assets/23ce41de-2fc9-4eb5-a66c-5f5bc6ec1245" />

