### PR TITLE
Fix: A11y heading for `nys-globalfooter`

### DIFF
--- a/packages/nys-globalfooter/src/nys-globalfooter.ts
+++ b/packages/nys-globalfooter/src/nys-globalfooter.ts
@@ -74,9 +74,9 @@ export class NysGlobalFooter extends LitElement {
       <footer class="nys-globalfooter">
         <div class="nys-globalfooter__main-container">
           ${!this.homepageLink?.trim()
-            ? html`<p class="nys-globalfooter__name">${this.agencyName}</p>`
+            ? html`<h2 class="nys-globalfooter__name">${this.agencyName}</h2>`
             : html`<a href=${this.homepageLink?.trim()}>
-                <p class="nys-globalfooter__name">${this.agencyName}</p>
+                <h2 class="nys-globalfooter__name">${this.agencyName}</h2>
               </a>`}
           ${this.slotHasContent
             ? html`<div class="nys-globalfooter__content">


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Made p tag to h2 in global footer
<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change


This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes #979 🎟️
