### PR TITLE
Fix: Update valid sizes

### DIFF
--- a/packages/nys-icon/src/nys-icon.ts
+++ b/packages/nys-icon/src/nys-icon.ts
@@ -28,9 +28,9 @@ export class NysIcon extends LitElement {
     "18",
     "20",
     "24",
-    "30",
-    "36",
-    "48",
+    "32",
+    "40",
+    "50",
   ] as const;
 
   // Private property to store the internal `size` value, restricted to the valid types. Default is "md".


### PR DESCRIPTION
## Summary
Forgot to push the valid_size part for the new ramps on `nys-icon`

