### PR TITLE
Unavheader/icon fix

### DIFF
--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -266,7 +266,7 @@ export class NysUnavHeader extends LitElement {
                           variant="ghost"
                           label="Translate"
                           size="sm"
-                          prefixIcon="language_filled"
+                          prefixIcon="language"
                           suffixIcon=${this.languageVisible
                             ? "chevron_up"
                             : "chevron_down"}


### PR DESCRIPTION
was using different icons at the mobile and desktop breakpoints