### PR TITLE
Fix: button keyboard

### DIFF
--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -136,9 +136,7 @@ export class NysButton extends LitElement {
 
   private _manageFormAction() {
     // If an onClick function is provided, call it
-    console.log("_manageFormAction", this.onClick);
     if (typeof this.onClick === "function" && this.onClick !== null) {
-      console.log("Executing onClick prop");
       this.onClick(new Event("click")); // Call user-provided onClick function with a fake click event
     }
 
@@ -176,7 +174,6 @@ export class NysButton extends LitElement {
       event.preventDefault();
       return;
     }
-    console.log("Clicking once");
     this._manageFormAction();
     this.dispatchEvent(new Event("nys-click"));
   }


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
Make sure the keyboard event for `<nys-button onClick="doFunction();"></nys-button>` works.

WHY does it click but not do keyboard?
```
  /**
   * Vanilla JS & Native HTML keydown solution:
   * The <nys-button onClick="doFunction();"></nys-button> onClick is an attribute here.
   * Thus, we call it here. Otherwise, at this point, this.onClick is null as it isn't prop, but a string attribute
   * In vanilla HTML/JS, clicking executes the attribute function, BUT now with keydown, hence this solution.
   */
```
## Breaking change
This is **not** a breaking change.  
