### PR TITLE
Fix: `nys-fileinput` keydown clicking button twice 

### DIFF
--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -476,11 +476,17 @@ export class NysFileinput extends LitElement {
             ${this._dragActive ? "drag-active" : ""}
             ${this._isDropDisabled ? "disabled" : ""}
             ${this.showError && !this._isDropDisabled ? "error" : ""}"
-            @click=${this._isDropDisabled ? null : this._openFileDialog}
-            @keydown=${(e: KeyboardEvent) =>
-              !this._isDropDisabled &&
-              (e.key === "Enter" || e.key === " ") &&
-              this._openFileDialog()}
+            @click=${this._isDropDisabled
+              ? null
+              : (e: MouseEvent) => {
+                  const target = e.target as HTMLElement;
+
+                  // Ignore clicks that originated within a nys-button
+                  if (target.closest("nys-button")) return;
+
+                  // Only handle direct wrapper clicks (outside of buttons)
+                  this._openFileDialog();
+                }}
             @dragover=${this._isDropDisabled ? null : this._onDragOver}
             @dragleave=${this._isDropDisabled ? null : this._onDragLeave}
             @drop=${this._isDropDisabled ? null : this._onDrop}
@@ -496,6 +502,11 @@ export class NysFileinput extends LitElement {
                     ariaLabel=${this._buttonAriaLabel}
                     ariaDescription=${this._buttonAriaDescription}
                     ?disabled=${this._isDropDisabled}
+                    @nys-click="${(e: CustomEvent) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      this._openFileDialog();
+                    }}"
                   ></nys-button>
                   <p>or drag here</p>`}
           </div>`}


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Fix the issue where keydown in the dropzone area will click the button twice.

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change


This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes #1028 🎟️
