### PR TITLE
BUG: Remove unuse line of code

### DIFF
--- a/packages/nys-button/src/nys-button.scss
+++ b/packages/nys-button/src/nys-button.scss
@@ -1,9 +1,4 @@
   :host {
-    /* Need to match the width of the nys-button to the internal HTML button */
-    display: block;
-    width: fit-content;
-    height: fit-content;
-
     /* Global Button Styles */
     --_nys-button-width: fit-content;
     --_nys-button-height: var(--nys-size-600, 48px);


### PR DESCRIPTION
## Summary
Fix the issue with the width size acting strangely.

## Screenshot
Broken
<img width="416" height="313" alt="Screenshot 2025-12-15 at 12 44 01 PM" src="https://github.com/user-attachments/assets/c50383d3-d373-4845-bfef-0b915590ee33" />
VS fixed
<img width="544" height="284" alt="Screenshot 2025-12-15 at 12 44 43 PM" src="https://github.com/user-attachments/assets/dede55d6-41e0-4ddb-8719-d1e1ce0cfec7" />
