### PR TITLE
Fix: Table missing default background color

### DIFF
--- a/packages/nys-table/src/nys-table.scss
+++ b/packages/nys-table/src/nys-table.scss
@@ -49,6 +49,7 @@
   table {
     width: var(--_nys-table-width);
     border-collapse: collapse;
+    background-color: var(--_nys-table-background-color);
   }
 
   caption {


### PR DESCRIPTION
## before:

<img width="834" height="500" alt="image" src="https://github.com/user-attachments/assets/73f37fd8-2365-4efe-a970-dd506216c06a" />


## after: 

<img width="1528" height="982" alt="image" src="https://github.com/user-attachments/assets/bbb3b08e-d9a1-4491-9826-c8b828bf95fd" />
