### PR TITLE
Fix: Dispatch unique event in both `nys-checkbox` and `nys-radiobutton` "other" field

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -321,7 +321,6 @@ export class NysCheckbox extends LitElement {
       new CustomEvent("nys-other-input", {
         detail: {
           id: this.id,
-          checked: this.checked,
           name: this.name,
           value: this.value,
         },

--- a/packages/nys-radiobutton/src/nys-radiobutton.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.ts
@@ -210,7 +210,6 @@ export class NysRadiobutton extends LitElement {
       new CustomEvent("nys-other-input", {
         detail: {
           id: this.id,
-          checked: this.checked,
           name: this.name,
           value: this.value,
         },


### PR DESCRIPTION

# Summary
Fix issue with both `nys-checkbox` and `nys-radiobutton` "other" field dispatching `nys-change` event on both typing and clicking. Issue is resolved by separating the dispatch event for changing and typing within the textinput by dispatching a separate `nys-other-input` event.

## Breaking change
This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes #1324 🎟️
