### PR TITLE
Combobox: Fix empty submission bug

### DIFF
--- a/packages/nys-combobox/src/nys-combobox.ts
+++ b/packages/nys-combobox/src/nys-combobox.ts
@@ -243,7 +243,10 @@ export class NysCombobox extends LitElement {
     const validity = this._input.validity;
     let message = "";
 
-    if (validity.valueMissing) {
+    const isInvalid =
+      this._input && !this._options.some((opt) => opt.value === this.value);
+
+    if (validity.valueMissing || isInvalid) {
       message = "This field is required";
     } else {
       message = this._input.validationMessage;


### PR DESCRIPTION
Add in a check to see if the typed input doesn't match any option and if so clear and trigger an error. This was already working for keyboard navigation but not for mouse clicks. Now behavior is same.

closes #1400 