### PR TITLE
Fix: setting null values programtically

### DIFF
--- a/packages/nys-combobox/src/nys-combobox.test.ts
+++ b/packages/nys-combobox/src/nys-combobox.test.ts
@@ -1229,4 +1229,36 @@ describe("nys-combobox", () => {
     expect(eventDetail.value).to.equal("app");
     expect(eventDetail.id).to.equal(el.id);
   });
+
+  // -------------------------------------------------------------------------
+  // Regression test: clearing "value" prop must sync setFormValue()
+  // -------------------------------------------------------------------------
+  it("programmatically setting value to empty string or null updates FormData", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <nys-combobox name="test-field">
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+        </nys-combobox>
+      </form>
+    `);
+
+    const el = form.querySelector<NysCombobox>("nys-combobox")!;
+    await el.updateComplete;
+
+    el.value = "apple";
+    await el.updateComplete;
+    expect(new FormData(form).get("test-field")).to.equal("apple");
+
+    el.value = "";
+    await el.updateComplete;
+    expect(new FormData(form).get("test-field")).to.not.equal("apple");
+
+    el.value = "banana";
+    await el.updateComplete;
+
+    (el as any).value = null;
+    await el.updateComplete;
+    expect(new FormData(form).get("test-field")).to.not.equal("banana");
+  });
 });

--- a/packages/nys-combobox/src/nys-combobox.ts
+++ b/packages/nys-combobox/src/nys-combobox.ts
@@ -137,6 +137,8 @@ export class NysCombobox extends LitElement {
       const option = this._options.find((opt) => opt.value === this.value);
       this._selectedLabel = option ? option.label : "";
       this._filterText = this._selectedLabel;
+
+      this._setValue();
     }
 
     if (changedProperties.has("_isOpen") && this._isOpen) {

--- a/packages/nys-datepicker/src/nys-datepicker.test.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.test.ts
@@ -795,6 +795,35 @@ describe("nys-datepicker", () => {
     expect(inputDetail.value).to.be.instanceOf(Date);
   });
 
+  // -------------------------------------------------------------------------
+  // Regression test: clearing "value" prop must sync setFormValue()
+  // -------------------------------------------------------------------------
+  it("programmatically setting value to undefined or empty string updates FormData", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <nys-datepicker name="test-date"></nys-datepicker>
+      </form>
+    `);
+
+    const el = form.querySelector<NysDatepicker>("nys-datepicker")!;
+    await el.updateComplete;
+
+    el.value = new Date(2026, 0, 10);
+    await el.updateComplete;
+    expect(new FormData(form).get("test-date")).to.equal("2026-01-10");
+
+    el.value = undefined;
+    await el.updateComplete;
+    expect(new FormData(form).get("test-date")).to.not.equal("2026-01-10");
+
+    el.value = new Date(2026, 5, 15);
+    await el.updateComplete;
+
+    (el as any).value = "";
+    await el.updateComplete;
+    expect(new FormData(form).get("test-date")).to.not.equal("2026-06-15");
+  });
+
   /*** A11y Test ***/
   it("passes the a11y audit", async () => {
     const el = await fixture(

--- a/packages/nys-datepicker/src/nys-datepicker.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.ts
@@ -192,6 +192,25 @@ export class NysDatepicker extends LitElement {
     setTimeout(() => this._onDocumentClick(), 0);
   }
 
+  updated(changedProperties: Map<string | number | symbol, unknown>): void {
+    super.updated(changedProperties);
+
+    if (changedProperties.has("value")) {
+      const prev = changedProperties.get("value");
+      const curr = this.value;
+      // Only sync if the value actually changed to empty/null from outside
+      if (
+        (curr === undefined || curr === null || curr === "") &&
+        prev !== curr
+      ) {
+        this._internals.setFormValue("");
+        this._manageRequire();
+      } else if (curr && !(curr instanceof Date)) {
+        this._setValue(curr);
+      }
+    }
+  }
+
   private async _whenWcDatepickerReady(): Promise<WcDatepicker | null> {
     await customElements.whenDefined("wc-datepicker");
 

--- a/packages/nys-datepicker/src/nys-datepicker.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.ts
@@ -197,16 +197,13 @@ export class NysDatepicker extends LitElement {
 
     if (changedProperties.has("value")) {
       const prev = changedProperties.get("value");
-      const curr = this.value;
-      // Only sync if the value actually changed to empty/null from outside
-      if (
-        (curr === undefined || curr === null || curr === "") &&
-        prev !== curr
-      ) {
+      const current = this.value;
+
+      if (!current && prev !== current) {
         this._internals.setFormValue("");
         this._manageRequire();
-      } else if (curr && !(curr instanceof Date)) {
-        this._setValue(curr);
+      } else if (current) {
+        this._setValue(current); // handles both Date and string
       }
     }
   }

--- a/packages/nys-select/src/nys-select.test.ts
+++ b/packages/nys-select/src/nys-select.test.ts
@@ -379,4 +379,35 @@ describe("nys-select", () => {
     const select = el.shadowRoot!.querySelector("select")!;
     expect(select.value).to.equal("b");
   });
+  // -------------------------------------------------------------------------
+  // Regression test: clearing "value" prop must sync setFormValue()
+  // -------------------------------------------------------------------------
+  it("programmatically setting value to empty string or null updates FormData", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <nys-select name="test-field">
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+        </nys-select>
+      </form>
+    `);
+
+    const el = form.querySelector<NysSelect>("nys-select")!;
+    await el.updateComplete;
+
+    el.value = "apple";
+    await el.updateComplete;
+    expect(new FormData(form).get("test-field")).to.equal("apple");
+
+    el.value = "";
+    await el.updateComplete;
+    expect(new FormData(form).get("test-field")).to.not.equal("apple");
+
+    el.value = "banana";
+    await el.updateComplete;
+
+    (el as any).value = null;
+    await el.updateComplete;
+    expect(new FormData(form).get("test-field")).to.not.equal("banana");
+  });
 });

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -165,7 +165,7 @@ export class NysSelect extends LitElement {
     const assignedElements = slot.assignedElements({ flatten: true });
 
     assignedElements.forEach((node) => {
-      // ---- Handle <nys-option> ----
+      // ---- Handle <nys-option> ---- (May consider removing this since depreciated since 2.0 release)
       if (node instanceof NysOption) {
         const optionElement = document.createElement("option");
         optionElement.value = node.value;
@@ -401,6 +401,7 @@ export class NysSelect extends LitElement {
       if (selectElement) {
         selectElement.value = this.value;
       }
+      this._setValue();
     }
   }
 

--- a/packages/nys-textarea/src/nys-textarea.test.ts
+++ b/packages/nys-textarea/src/nys-textarea.test.ts
@@ -428,6 +428,33 @@ it("fires nys-selectionchange with correct detail on selectionchange", async () 
   expect(eventDetail.id).to.equal(el.id);
 });
 
+// -------------------------------------------------------------------------
+// Regression test: clearing "value" prop must sync setFormValue()
+// -------------------------------------------------------------------------
+it("programmatically setting value to empty string or null updates FormData", async () => {
+  const form = await fixture<HTMLFormElement>(html`
+    <form>
+      <nys-textarea name="test-field" value="stale-value"></nys-textarea>
+    </form>
+  `);
+
+  const el = form.querySelector<NysTextarea>("nys-textarea")!;
+  await el.updateComplete;
+
+  expect(new FormData(form).get("test-field")).to.equal("stale-value");
+
+  el.value = "";
+  await el.updateComplete;
+  expect(new FormData(form).get("test-field")).to.equal("");
+
+  el.value = "stale-value";
+  await el.updateComplete;
+
+  (el as any).value = null;
+  await el.updateComplete;
+  expect(new FormData(form).get("test-field")).to.equal(null);
+});
+
 // Accessibility Tests
 /*
  * Ensure that the <textarea> element is correctly associated with a label:

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -112,21 +112,6 @@ export class NysTextarea extends LitElement {
   /** Error message text. Shown only when `showError` is true. */
   @property({ type: String }) errorMessage = "";
 
-  async updated(changedProperties: Map<string | number | symbol, unknown>) {
-    await Promise.resolve();
-    if (changedProperties.has("rows")) {
-      this.rows = this.rows ?? 4;
-    }
-    if (
-      changedProperties.has("readonly") ||
-      changedProperties.has("required")
-    ) {
-      const input = this.shadowRoot?.querySelector("textarea");
-
-      if (input) input.required = this.required && !this.readonly;
-    }
-  }
-
   private _hasUserInteracted = false; // need this flag for "eager mode"
   private _internals: ElementInternals;
 
@@ -159,6 +144,25 @@ export class NysTextarea extends LitElement {
   firstUpdated() {
     // This ensures our element always participates in the form
     this._setValue();
+  }
+
+  async updated(changedProperties: Map<string | number | symbol, unknown>) {
+    await Promise.resolve();
+
+    if (changedProperties.has("value")) {
+      this._setValue();
+    }
+    if (changedProperties.has("rows")) {
+      this.rows = this.rows ?? 4;
+    }
+    if (
+      changedProperties.has("readonly") ||
+      changedProperties.has("required")
+    ) {
+      const input = this.shadowRoot?.querySelector("textarea");
+
+      if (input) input.required = this.required && !this.readonly;
+    }
   }
 
   /**

--- a/packages/nys-textinput/src/nys-textinput.test.ts
+++ b/packages/nys-textinput/src/nys-textinput.test.ts
@@ -511,6 +511,34 @@ describe("nys-textinput", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Regression test: clearing "value" prop must sync setFormValue()
+  // -------------------------------------------------------------------------
+
+  it("programmatically setting value to empty string or null updates FormData", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <nys-textinput name="test-field" value="stale-value"></nys-textinput>
+      </form>
+    `);
+
+    const el = form.querySelector<NysTextinput>("nys-textinput")!;
+    await el.updateComplete;
+
+    expect(new FormData(form).get("test-field")).to.equal("stale-value");
+
+    el.value = "";
+    await el.updateComplete;
+    expect(new FormData(form).get("test-field")).to.equal("");
+
+    el.value = "stale-value";
+    await el.updateComplete;
+
+    (el as any).value = null;
+    await el.updateComplete;
+    expect(new FormData(form).get("test-field")).to.equal(null);
+  });
+
+  // -------------------------------------------------------------------------
   // Accessibility
   // -------------------------------------------------------------------------
   it("passes the a11y audit", async () => {

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -183,6 +183,10 @@ export class NysTextinput extends LitElement {
 
   // Ensure the "width" property is valid after updates
   async updated(changedProperties: Map<string | number | symbol, unknown>) {
+    if (changedProperties.has("value")) {
+      this._setValue();
+    }
+
     if (changedProperties.has("disabled")) {
       this._validateButtonSlot("startButton");
       this._validateButtonSlot("endButton");

--- a/src/templates/component.template.hbs
+++ b/src/templates/component.template.hbs
@@ -61,6 +61,12 @@ export class Nys{{capitalize componentName}} extends LitElement {
     // This ensures our element always participates in the form
     this._setValue(this.value);
   }
+
+  updated(changedProperties: Map<string | number | symbol, unknown></string>) {
+    if (changedProperties.has("value")) {
+      this._setValue();
+    }
+  }
   {{else}}
   // Lifecycle Methods
   constructor() {


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Fix incorrect assertions of value when updated to null or empty by JavaScript.
<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1455 🎟️

## Testing
Implemented special test functions and scenarios on React Demo while doing this. Reach out to me if async video is needed @esteinborn @emilygorelik 