### PR TITLE
Fix: `nys-datepicker` to set custom error message programmatically

### DIFF
--- a/packages/nys-datepicker/src/nys-datepicker.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.ts
@@ -324,6 +324,8 @@ export class NysDatepicker extends LitElement {
     const input = this.shadowRoot?.querySelector("input");
     if (!input) return;
 
+    if (!message && this.showError && this.errorMessage?.trim()) return;
+
     // Toggle the HTML <div> tag error message
     this.showError = !!message;
     // If user sets errorMessage, this will always override the native validation message


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Fix `nys-datepicker` to allow custom validation rendering with showError and errorMessage programmatically
<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  


## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1469 🎟️

## Testing
Done in the React Demo