### PR TITLE
Fix: align `nys-datepicker` error message with other form related components

### DIFF
--- a/packages/nys-datepicker/src/nys-datepicker.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.ts
@@ -303,7 +303,12 @@ export class NysDatepicker extends LitElement {
 
     this._manageRequire();
 
-    const message = input.validationMessage;
+    let message = "";
+    if (input.validity.valueMissing) {
+      message = this.errorMessage || "This field is required.";
+    } else {
+      message = input.validationMessage;
+    }
     this._setValidityMessage(message);
   }
 


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Fix bug where `nys-datepicker` required error message does not align with other form components.


<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  



## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1475 🎟️