### PR TITLE
Hot Fix: `nys-breadcrumb` to change `button`-> `a` 

### DIFF
--- a/packages/nys-breadcrumbs/src/nys-breadcrumbs.scss
+++ b/packages/nys-breadcrumbs/src/nys-breadcrumbs.scss
@@ -146,6 +146,7 @@
     border: none;
     padding: 0;
     background-color: inherit;
+    text-decoration: none;
     font-family: var(--_nys-breadcrumbs-font-family);
     font-size: var(--_nys-breadcrumbs-font-size);
     font-weight: var(--_nys-breadcrumbs-font-weight);

--- a/packages/nys-breadcrumbs/src/nys-breadcrumbs.stories.ts
+++ b/packages/nys-breadcrumbs/src/nys-breadcrumbs.stories.ts
@@ -107,7 +107,6 @@ export const WithoutCurrentPage: Story = {
         <li><a href="/">Home</a></li>
         <li><a href="/services">Services</a></li>
         <li><a href="/tickets">Ticket System</a></li>
-        <li><a href="/tickets">Not a clickable</a></li>
       </ol>
     </nys-breadcrumbs>
   `,

--- a/packages/nys-breadcrumbs/src/nys-breadcrumbs.ts
+++ b/packages/nys-breadcrumbs/src/nys-breadcrumbs.ts
@@ -329,11 +329,14 @@ export class NysBreadcrumbs extends LitElement {
         ellipsis.classList.add("nys-breadcrumbs__ellipsis");
 
         // Ellipse button
-        const button = document.createElement("button");
+        const button = document.createElement("a");
         button.classList.add("ellipsis-btn");
         button.setAttribute("aria-label", "Show more links");
+        button.setAttribute("role", "button");
+        button.setAttribute("href", "#");
         button.textContent = "…";
-        button.addEventListener("click", () => {
+        button.addEventListener("click", (e) => {
+          e.preventDefault();
           this._manuallyExpanded = true;
           this.collapsed = false;
           this._handleSlotChange();


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Based on Ethan's findings from A11y, the ellipses `button` tag will be changed to an `a` tag within the upcoming `nys-breadcrumb` component


## Breaking change


This is **not** a breaking change.  

