### PR TITLE
Fix: `nys-dropdown` focus ring persisting on `nys-dropdownmenuitem`

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -5454,6 +5454,15 @@
             },
             {
               "kind": "field",
+              "name": "_lastFocusedIndex",
+              "type": {
+                "text": "number"
+              },
+              "privacy": "private",
+              "default": "0"
+            },
+            {
+              "kind": "field",
               "name": "GAP",
               "type": {
                 "text": "number"
@@ -5500,8 +5509,17 @@
             },
             {
               "kind": "method",
-              "name": "_focusOnFirstItem",
-              "privacy": "private"
+              "name": "_focusOnItem",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "index",
+                  "default": "0",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ]
             },
             {
               "kind": "method",
@@ -5666,10 +5684,15 @@
               ]
             },
             {
-              "kind": "field",
-              "name": "_handleTriggerKeydown",
+              "kind": "method",
+              "name": "_handleMenuClick",
               "privacy": "private",
               "description": "Event Handlers\n--------------------------------------------------------------------------"
+            },
+            {
+              "kind": "field",
+              "name": "_handleTriggerKeydown",
+              "privacy": "private"
             },
             {
               "kind": "field",

--- a/packages/nys-dropdownmenu/src/nys-dropdownmenu.scss
+++ b/packages/nys-dropdownmenu/src/nys-dropdownmenu.scss
@@ -26,19 +26,22 @@
   --_nys-dropdownmenu-font-family: var(
     --nys-font-family-ui,
     var(
-      --nys-font-family-sans,
-      "Proxima Nova",
-      "Helvetica Neue",
-      "Helvetica",
-      "Arial",
-      sans-serif
-    )
+        --nys-font-family-sans,
+        "Proxima Nova",
+        "Helvetica Neue",
+        "Helvetica",
+        "Arial",
+        sans-serif
+      )
+      &: focus,
+    &: focus-visible {outline: none;}
   );
 
   /* Dropdownmenu Item Styles */
   --_nys-dropdownmenuitem-color: var(--nys-color-text, #1b1b1b);
   --_nys-dropdownmenuitem-gap: var(--nys-space-100, 8px);
-  --_nys-dropdownmenuitem-padding: var(--nys-space-200, 16px) var(--nys-space-100, 8px);
+  --_nys-dropdownmenuitem-padding: var(--nys-space-200, 16px)
+    var(--nys-space-100, 8px);
   --_nys-dropdownmenuitem-border-radius: var(--nys-radius-md, 4px);
   --_nys-dropdownmenuitem-background-color: var(--nys-color-white, #ffffff);
   --_nys-dropdownmenuitem-background-color--hover: var(
@@ -133,7 +136,8 @@
       background-color: var(--_nys-dropdownmenuitem-background-color--active);
     }
 
-    &:focus-visible:not(:focus):not(.disabled):not([aria-disabled="true"]) {
+    &:focus-visible:not(.disabled):not([aria-disabled="true"]) {
+      position: relative;
       outline: var(--_nys-dropdownmenuitem-outline-width) solid
         var(--_nys-dropdownmenuitem-outline-color);
     }

--- a/packages/nys-dropdownmenu/src/nys-dropdownmenu.scss
+++ b/packages/nys-dropdownmenu/src/nys-dropdownmenu.scss
@@ -33,8 +33,6 @@
         "Arial",
         sans-serif
       )
-      &: focus,
-    &: focus-visible {outline: none;}
   );
 
   /* Dropdownmenu Item Styles */
@@ -136,7 +134,7 @@
       background-color: var(--_nys-dropdownmenuitem-background-color--active);
     }
 
-    &:focus-visible:not(.disabled):not([aria-disabled="true"]) {
+    &:focus-visible:not(.disabled):not([aria-disabled="true"]):not([focus-ring-false]) {
       position: relative;
       outline: var(--_nys-dropdownmenuitem-outline-width) solid
         var(--_nys-dropdownmenuitem-outline-color);

--- a/packages/nys-dropdownmenu/src/nys-dropdownmenu.ts
+++ b/packages/nys-dropdownmenu/src/nys-dropdownmenu.ts
@@ -61,6 +61,7 @@ export class NysDropdownMenu extends LitElement {
   private _trigger: HTMLElement | null = null;
   private _menuElement: HTMLElement | null = null;
   private _ariaTarget: HTMLElement | null = null;
+  private _lastFocusedIndex: number = 0;
   private readonly GAP = 4;
 
   /**
@@ -89,10 +90,7 @@ export class NysDropdownMenu extends LitElement {
     await this.updateComplete;
     this.applyInverseTransform();
     this._connectTrigger();
-
-    this.addEventListener("nys-click", () => {
-      this._closeDropdown();
-    });
+    this._handleMenuClick();
   }
   /**
    * Functions
@@ -162,7 +160,7 @@ export class NysDropdownMenu extends LitElement {
 
       await this.updateComplete;
       this._positionMenu();
-      this._focusOnFirstItem();
+      this._focusOnItem(this._lastFocusedIndex);
     } else {
       window.removeEventListener("scroll", this._handleWindowScroll, true);
       window.removeEventListener("resize", this._handleWindowResize);
@@ -202,10 +200,12 @@ export class NysDropdownMenu extends LitElement {
     }
   };
 
-  private async _focusOnFirstItem() {
+  private async _focusOnItem(index: number = 0) {
     await new Promise((resolve) => requestAnimationFrame(resolve));
     const items = this._getMenuItems();
-    if (items.length > 0) items[0].focus();
+    const target = items[Math.min(index, items.length - 1)];
+    console.log("_focusOnItem", target);
+    if (target) target.focus();
   }
 
   // In some iframes (like Storybook's) or embedded containers , parent elements may have CSS transforms applied, creating a new coordinate context.
@@ -415,6 +415,16 @@ export class NysDropdownMenu extends LitElement {
    * --------------------------------------------------------------------------
    */
 
+  private _handleMenuClick() {
+    this.addEventListener("nys-click", (e: CustomEvent) => {
+      const items = this._getMenuItems();
+      const targetCrumb = e.detail?.id;
+      const index = items.findIndex((item) => item.id === targetCrumb);
+      if (index !== -1) this._lastFocusedIndex = index;
+      this._closeDropdown();
+    });
+  }
+
   private _handleTriggerKeydown = (event: KeyboardEvent) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
@@ -441,6 +451,7 @@ export class NysDropdownMenu extends LitElement {
         event.preventDefault();
         const nextIndex =
           currentIndex < items.length - 1 ? currentIndex + 1 : 0;
+        this._lastFocusedIndex = nextIndex;
         items[nextIndex].focus();
         break;
       case "ArrowUp":
@@ -448,6 +459,7 @@ export class NysDropdownMenu extends LitElement {
         event.preventDefault();
         const prevIndex =
           currentIndex > 0 ? currentIndex - 1 : items.length - 1;
+        this._lastFocusedIndex = prevIndex;
         items[prevIndex].focus();
         break;
       case "Tab":

--- a/packages/nys-dropdownmenu/src/nys-dropdownmenu.ts
+++ b/packages/nys-dropdownmenu/src/nys-dropdownmenu.ts
@@ -204,8 +204,9 @@ export class NysDropdownMenu extends LitElement {
     await new Promise((resolve) => requestAnimationFrame(resolve));
     const items = this._getMenuItems();
     const target = items[Math.min(index, items.length - 1)];
-    console.log("_focusOnItem", target);
-    if (target) target.focus();
+    if (!target) return;
+
+    target.focus();
   }
 
   // In some iframes (like Storybook's) or embedded containers , parent elements may have CSS transforms applied, creating a new coordinate context.

--- a/packages/nys-dropdownmenu/src/nys-dropdownmenu.ts
+++ b/packages/nys-dropdownmenu/src/nys-dropdownmenu.ts
@@ -417,9 +417,9 @@ export class NysDropdownMenu extends LitElement {
    */
 
   private _handleMenuClick() {
-    this.addEventListener("nys-click", (e: CustomEvent) => {
+    this.addEventListener("nys-click", (e: Event) => {
       const items = this._getMenuItems();
-      const targetCrumb = e.detail?.id;
+      const targetCrumb = (e as CustomEvent).detail?.id;
       const index = items.findIndex((item) => item.id === targetCrumb);
       if (index !== -1) this._lastFocusedIndex = index;
       this._closeDropdown();


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

This is a bug fix that _focuses_ on fixing the persisting focus state on the first `nys-dropdownmenuitem`:
- Now have `nys-dropdown` focus ring persisting on previous selected `nys-dropdownmenuitem.`
- ~~Remove focus ring for mouse clicks~~

## Breaking change


This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1482 🎟️