### PR TITLE
Hot Fix: Add space keyboard event for `nys-breadcrumbs` ellipses

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1723,11 +1723,14 @@
           ],
           "events": [
             {
-              "name": "nys-breadcrumbs-expand",
+              "name": "nys-expand",
               "type": {
                 "text": "CustomEvent"
-              },
-              "description": "Fired when the user clicks the ellipsis to expand the trail."
+              }
+            },
+            {
+              "description": "Fired when the user clicks the ellipsis to expand the trail.",
+              "name": "nys-breadcrumbs-expand"
             }
           ],
           "attributes": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -15321,7 +15321,7 @@
     },
     "packages/mcp-server": {
       "name": "@nysds/mcp-server",
-      "version": "1.16.2-alpha1",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/packages/nys-breadcrumbs/src/nys-breadcrumbs.test.ts
+++ b/packages/nys-breadcrumbs/src/nys-breadcrumbs.test.ts
@@ -223,7 +223,7 @@ describe("nys-breadcrumbs", () => {
     expect(ellipsis).to.exist;
   });
 
-  it("expands trail when ellipsis is clicked and fires nys-breadcrumbs-expand", async () => {
+  it("expands trail when ellipsis is clicked and fires nys-expand", async () => {
     mockDesktop();
 
     const el = await fixture<NysBreadcrumbs>(
@@ -241,7 +241,7 @@ describe("nys-breadcrumbs", () => {
     await el.updateComplete;
 
     let expandFired = false;
-    el.addEventListener("nys-breadcrumbs-expand", () => {
+    el.addEventListener("nys-expand", () => {
       expandFired = true;
     });
 

--- a/packages/nys-breadcrumbs/src/nys-breadcrumbs.ts
+++ b/packages/nys-breadcrumbs/src/nys-breadcrumbs.ts
@@ -335,13 +335,19 @@ export class NysBreadcrumbs extends LitElement {
         button.setAttribute("role", "button");
         button.setAttribute("href", "#");
         button.textContent = "…";
-        button.addEventListener("click", (e) => {
+
+        const expandTrail = (e: Event) => {
           e.preventDefault();
           this._manuallyExpanded = true;
           this.collapsed = false;
           this._handleSlotChange();
           this._dispatchExpandEvent();
           this._moveFocusToFirstExpandCrumb();
+        };
+
+        button.addEventListener("click", expandTrail);
+        button.addEventListener("keydown", (e: KeyboardEvent) => {
+          if (e.key === " ") expandTrail(e);
         });
 
         // Chevron Icon

--- a/packages/nys-breadcrumbs/src/nys-breadcrumbs.ts
+++ b/packages/nys-breadcrumbs/src/nys-breadcrumbs.ts
@@ -376,7 +376,7 @@ export class NysBreadcrumbs extends LitElement {
    */
   private _dispatchExpandEvent() {
     this.dispatchEvent(
-      new CustomEvent("nys-breadcrumbs-expand", {
+      new CustomEvent("nys-expand", {
         detail: { id: this.id },
         bubbles: true,
         composed: true,

--- a/packages/react/NysBreadcrumbs.d.ts
+++ b/packages/react/NysBreadcrumbs.d.ts
@@ -67,6 +67,9 @@ Override when multiple crumbs exist on the same page. */
   /** Allows developers to make HTML elements focusable, allow or prevent them from being sequentially focusable (usually with the `Tab` key, hence the name) and determine their relative ordering for sequential focus navigation. */
   tabIndex?: number;
 
+  /** undefined */
+  onNysExpand?: (event: CustomEvent) => void;
+
   /** Fired when the user clicks the ellipsis to expand the trail. */
   onNysBreadcrumbsExpand?: (event: CustomEvent) => void;
 }
@@ -77,7 +80,8 @@ Override when multiple crumbs exist on the same page. */
  *
  *
  * ### **Events:**
- *  - **nys-breadcrumbs-expand** - Fired when the user clicks the ellipsis to expand the trail.
+ *  - **nys-expand**
+ * - **nys-breadcrumbs-expand** - Fired when the user clicks the ellipsis to expand the trail.
  *
  * ### **Slots:**
  *  - _default_ - One or more `nys-breadcrumbitem` elements defining the trail.

--- a/packages/react/NysBreadcrumbs.js
+++ b/packages/react/NysBreadcrumbs.js
@@ -16,6 +16,7 @@ export const NysBreadcrumbs = forwardRef((props, forwardedRef) => {
   } = props;
 
   /** Event listeners - run once */
+  useEventListener(ref, "nys-expand", props.onNysExpand);
   useEventListener(ref, "nys-breadcrumbs-expand", props.onNysBreadcrumbsExpand);
 
   return React.createElement(

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -191,8 +191,10 @@ The user can still expand the trail by clicking the ellipsis. */
   /** Prevents interaction. */
   disabled?: boolean;
 
+  /**  */
+  "onnys-expand"?: (e: CustomEvent<CustomEvent>) => void;
   /** Fired when the user clicks the ellipsis to expand the trail. */
-  "onnys-breadcrumbs-expand"?: (e: CustomEvent<CustomEvent>) => void;
+  "onnys-breadcrumbs-expand"?: (e: CustomEvent<never>) => void;
 };
 
 export type NysButtonProps = {
@@ -1066,7 +1068,8 @@ export type CustomElements = {
    *
    *
    * ### **Events:**
-   *  - **nys-breadcrumbs-expand** - Fired when the user clicks the ellipsis to expand the trail.
+   *  - **nys-expand**
+   * - **nys-breadcrumbs-expand** - Fired when the user clicks the ellipsis to expand the trail.
    *
    * ### **Slots:**
    *  - _default_ - One or more `nys-breadcrumbitem` elements defining the trail.


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
Add an event listener for "space" to account for space expanding out the `nys-breadcrumbs` ellipses collapse state

## Breaking change

This is **not** a breaking change.  

