### PR TITLE
Fix: `nys-button` icon alignment

### DIFF
--- a/packages/nys-button/src/nys-button.scss
+++ b/packages/nys-button/src/nys-button.scss
@@ -55,6 +55,7 @@
   --_nys-button-text-decoration: none;
   display: inline-flex;
   width: fit-content;
+  vertical-align: middle
 }
 
 /* Sizes */

--- a/packages/nys-button/src/nys-button.stories.ts
+++ b/packages/nys-button/src/nys-button.stories.ts
@@ -104,6 +104,8 @@ export const Basic: Story = {
       .ariaDescription=${args.ariaDescription}
       @nys-click=${() => alert("Button clicked")}
     ></nys-button>
+    <nys-button suffixIcon="open_in_new" label="Sign in"></nys-button><nys-button prefixIcon="open_in_new" label="Sign out"></nys-button>
+<nys-button suffixIcon="open_in_new" label="Sign in"></nys-button>
   `,
   parameters: {
     docs: {

--- a/packages/nys-button/src/nys-button.stories.ts
+++ b/packages/nys-button/src/nys-button.stories.ts
@@ -104,8 +104,6 @@ export const Basic: Story = {
       .ariaDescription=${args.ariaDescription}
       @nys-click=${() => alert("Button clicked")}
     ></nys-button>
-    <nys-button suffixIcon="open_in_new" label="Sign in"></nys-button><nys-button prefixIcon="open_in_new" label="Sign out"></nys-button>
-<nys-button suffixIcon="open_in_new" label="Sign in"></nys-button>
   `,
   parameters: {
     docs: {


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Fix bug with the prefix and suffix icons, causing buttons to mis-align when used next to each other.

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change


This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1493 🎟️

## Screenshot
Before vs After
<img width="547" height="100" alt="Screenshot 2026-05-01 at 4 47 08 PM" src="https://github.com/user-attachments/assets/427d1f03-2544-4c4c-8707-50a3bbeef299" />
<img width="552" height="114" alt="Screenshot 2026-05-01 at 4 46 52 PM" src="https://github.com/user-attachments/assets/c6538413-f4b1-4d80-96db-a31fe5104e73" />
