### PR TITLE
Fix: Remove heading section when no prop provided

### DIFF
--- a/packages/nys-alert/src/nys-alert.ts
+++ b/packages/nys-alert/src/nys-alert.ts
@@ -235,7 +235,9 @@ export class NysAlert extends LitElement {
               role=${role}
               aria-live=${ifDefined(this.liveRegion)}
             >
-              <p class="nys-alert__header">${this.heading}</p>
+              ${this.heading?.trim()
+                ? html`<p class="nys-alert__header">${this.heading}</p>`
+                : ""}
               ${this._slotHasContent
                 ? html`<slot></slot>`
                 : this.text?.trim().length > 0


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
Remove heading from rendering when no `heading` prop for `nys-alert`

## Breaking change

This is **not** a breaking change.  

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1002 🎟️
