### PR TITLE
Feature: Tab Explicit Ordering

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,6 +23,12 @@ NYSDS (New York State Design System) — a Lit 3 web components monorepo providi
 - `npm run storybook` — Storybook on port 6006
 - `npm run gen` — Scaffold a new component
 
+## Testing
+
+**Do not run tests yourself.** Instead, prompt the user to run tests to avoid unnecessary token consumption. When tests need to be run:
+- Suggest the user run `npm run test` or the appropriate per-package test command
+- Let the user decide whether to run tests and share the output if needed
+
 ## Architecture
 
 ### Monorepo Layout

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -10908,7 +10908,7 @@
                   "description": "The `Event` fired by the `<slot>` element on slot change."
                 }
               ],
-              "description": "Handles `slotchange` on the default slot.\n\nIterates over all assigned elements and moves each `<nys-tab>` into\n`.nys-tabgroup__tabs` and each `<nys-tabpanel>` into\n`.nys-tabgroup__panels`, preserving relative order. After sorting,\ncalls `_applySelection` using the first element that already has a\n`selected` attribute, or index `0` if none is found."
+              "description": "Handles `slotchange` on the default slot.\n\nIterates over all assigned elements and moves each `<nys-tab>` into\n`.nys-tabgroup__tabs` and each `<nys-tabpanel>` into\n`.nys-tabgroup__panels`. If a panel has an `aria-labelledby` attribute,\nit is explicitly paired with the tab it references; otherwise panels are\npaired with tabs by index order. After sorting, calls `_applySelection`\nusing the first element that already has a `selected` attribute, or\nindex `0` if none is found."
             },
             {
               "kind": "method",

--- a/packages/nys-tab/src/nys-tab.scss
+++ b/packages/nys-tab/src/nys-tab.scss
@@ -25,7 +25,9 @@
   --_nys-tab-background-color--active: var(--nys-color-theme-weak, #cddde9);
   --_nys-tab-background-color--disabled: var(--_nys-tab-background-color);
   --_nys-tab-background-color--selected: var(--nys-color-neutral-10, #f6f6f6);
-  --_nys-tab-color: var(--nys-color-ink);
+  --_nys-tab-color: var(--nys-color-text-weak, #4A4D4F);
+  --_nys-tab-color--selected: var(--nys-color-text, #1B1B1B);
+  --_nys-tab-color--disabled: var(--nys-color-text-disabled, #bec0c1);
   --_nys-tab-padding--x: var(--nys-space-150, 12px);
   --_nys-tab-padding--y: var(--nys-space-200, 16px);
 
@@ -89,7 +91,7 @@
 :host([disabled]) .nys-tab {
   background-color: var(--_nys-tab-background-color--disabled);
   border-color: var(--_nys-tab-border-color--disabled);
-  color: var(--nys-color-text-disabled, #bec0c1);
+  color: var(--_nys-tab-color--disabled);
   cursor: not-allowed;
   pointer-events: auto;
 }
@@ -106,6 +108,7 @@
 :host([selected]) .nys-tab {
   background-color: var(--_nys-tab-background-color--selected);
   border-color: var(--_nys-tab-border-color--selected);
+  color: var(--_nys-tab-color--selected);
 }
 
 :host([selected]:not([disabled])) .nys-tab:hover {

--- a/packages/nys-tab/src/nys-tab.test.ts
+++ b/packages/nys-tab/src/nys-tab.test.ts
@@ -348,4 +348,33 @@ describe("nys-tab a11y", () => {
       expect(panel.getAttribute("aria-labelledby")).to.equal(tabs[i].id);
     });
   });
+
+  it("pairs panels with tabs via explicit aria-labelledby references, ignoring DOM order", async () => {
+    const el = await fixture<NysTabgroup>(html`
+      <nys-tabgroup id="explicit-ordering">
+        <nys-tab label="1st Tab" id="tab-1"></nys-tab>
+        <nys-tab label="2nd Tab" id="tab-2"></nys-tab>
+        <nys-tab label="3rd Tab" id="tab-3"></nys-tab>
+        <nys-tabpanel aria-labelledby="tab-2">Content for tab 2</nys-tabpanel>
+        <nys-tabpanel aria-labelledby="tab-3">Content for tab 3</nys-tabpanel>
+        <nys-tabpanel aria-labelledby="tab-1">Content for tab 1</nys-tabpanel>
+      </nys-tabgroup>
+    `);
+    await el.updateComplete;
+
+    const tabs = (el as any)._getTabs();
+    const panels = (el as any)._getPanels();
+
+    expect(tabs[0].id).to.equal("tab-1");
+    expect(tabs[1].id).to.equal("tab-2");
+    expect(tabs[2].id).to.equal("tab-3");
+
+    expect(panels[0].textContent?.trim()).to.equal("Content for tab 1");
+    expect(panels[1].textContent?.trim()).to.equal("Content for tab 2");
+    expect(panels[2].textContent?.trim()).to.equal("Content for tab 3");
+
+    expect(panels[0].getAttribute("aria-labelledby")).to.equal("tab-1");
+    expect(panels[1].getAttribute("aria-labelledby")).to.equal("tab-2");
+    expect(panels[2].getAttribute("aria-labelledby")).to.equal("tab-3");
+  });
 });

--- a/packages/nys-tab/src/nys-tabgroup.ts
+++ b/packages/nys-tab/src/nys-tabgroup.ts
@@ -259,9 +259,11 @@ export class NysTabgroup extends LitElement {
    *
    * Iterates over all assigned elements and moves each `<nys-tab>` into
    * `.nys-tabgroup__tabs` and each `<nys-tabpanel>` into
-   * `.nys-tabgroup__panels`, preserving relative order. After sorting,
-   * calls `_applySelection` using the first element that already has a
-   * `selected` attribute, or index `0` if none is found.
+   * `.nys-tabgroup__panels`. If a panel has an `aria-labelledby` attribute,
+   * it is explicitly paired with the tab it references; otherwise panels are
+   * paired with tabs by index order. After sorting, calls `_applySelection`
+   * using the first element that already has a `selected` attribute, or
+   * index `0` if none is found.
    *
    * @param e - The `Event` fired by the `<slot>` element on slot change.
    * @returns void
@@ -277,7 +279,8 @@ export class NysTabgroup extends LitElement {
     if (!tabsContainer || !panelsContainer) return;
 
     const tabs: HTMLElement[] = [];
-    const panels: HTMLElement[] = [];
+    const panelsByRef = new Map<string, HTMLElement>();
+    const panelsWithoutRef: HTMLElement[] = [];
 
     assigned.forEach((child) => {
       const tag = child.tagName.toLowerCase();
@@ -286,9 +289,33 @@ export class NysTabgroup extends LitElement {
         tabs.push(child as HTMLElement);
       } else if (tag === "nys-tabpanel") {
         panelsContainer.appendChild(child);
-        panels.push(child as HTMLElement);
+        const panel = child as HTMLElement;
+        const ariaLabelledBy = panel.getAttribute("aria-labelledby");
+        if (ariaLabelledBy) {
+          panelsByRef.set(ariaLabelledBy, panel);
+        } else {
+          panelsWithoutRef.push(panel);
+        }
       }
     });
+
+    // Pair panels with tabs: explicit refs first, then remaining panels by index
+    const panels: HTMLElement[] = [];
+    tabs.forEach((tab) => {
+      const tabId = tab.id;
+      if (tabId && panelsByRef.has(tabId)) {
+        panels.push(panelsByRef.get(tabId)!);
+        panelsByRef.delete(tabId);
+      } else if (panelsWithoutRef.length > 0) {
+        panels.push(panelsWithoutRef.shift()!);
+      }
+    });
+
+    // Append any remaining panels with unresolved references
+    panelsByRef.forEach((panel) => panels.push(panel));
+
+    // Re-append panels in correct order so _getPanels() reads them in tab order
+    panels.forEach((panel) => panelsContainer.appendChild(panel));
 
     // Honor the first selected tab; ignore any others
     const declaredSelectedIndex = tabs.findIndex((t) =>


### PR DESCRIPTION
added in the functionality to allow the tabs and panels to be explicitly defined instead of just pairing them in the order they were passed in.

```
<nys-tabgroup id="explicit-ordering">
  <nys-tab label="1st Tab" id="tab-1"></nys-tab>
  <nys-tab label="2nd Tab" id="tab-2"></nys-tab>
  <nys-tab label="3rd Tab" id="tab-3"></nys-tab>
  <nys-tabpanel aria-labelledby="tab-2">Content for tab 2</nys-tabpanel>
  <nys-tabpanel aria-labelledby="tab-3">Content for tab 3</nys-tabpanel>
  <nys-tabpanel aria-labelledby="tab-1">Content for tab 1</nys-tabpanel>
</nys-tabgroup>
```

