### PR TITLE
Fix: issue with spacebar styling for `nys-button`

### DIFF
--- a/packages/nys-button/src/nys-button.scss
+++ b/packages/nys-button/src/nys-button.scss
@@ -416,7 +416,8 @@
   border-color: var(--_nys-button-border-color--hover);
 }
 
-.nys-button:active {
+.nys-button:active,
+.nys-button.active {
   background-color: var(--_nys-button-background-color--active);
   color: var(--_nys-button-color--active);
   border-color: var(--_nys-button-border-color--active);

--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -292,6 +292,9 @@ export class NysButton extends LitElement {
       if (this.disabled) return;
 
       e.preventDefault();
+      const btn = this.renderRoot.querySelector(".nys-button");
+      btn?.classList.add("active");
+      setTimeout(() => btn?.classList.remove("active"), 150);
 
       if (this.href) {
         // Click the internal <a> so native navigation happens
@@ -305,6 +308,17 @@ export class NysButton extends LitElement {
         this._handleAnyAttributeFunction();
         this._handleClick(e);
       }
+    }
+  }
+
+  private _handleKeyup(e: KeyboardEvent) {
+    if (
+      e.code === "Space" ||
+      e.code === "Enter" ||
+      e.key === " " ||
+      e.key === "Enter"
+    ) {
+      this.renderRoot.querySelector(".nys-button")?.classList.remove("active");
     }
   }
 
@@ -356,6 +370,7 @@ export class NysButton extends LitElement {
                 @focus="${this._handleFocus}"
                 @blur="${this._handleBlur}"
                 @keydown="${this._handleKeydown}"
+                @keyup="${this._handleKeyup}"
                 tabindex="${this.disabled ? -1 : 0}"
                 aria-label=${ifDefined(
                   this.ariaLabel ||
@@ -407,6 +422,7 @@ export class NysButton extends LitElement {
               @focus="${this._handleFocus}"
               @blur="${this._handleBlur}"
               @keydown="${this._handleKeydown}"
+              @keyup="${this._handleKeyup}"
               tabindex="${this.disabled ? -1 : 0}"
               aria-label=${ifDefined(
                 this.ariaLabel ||


### PR DESCRIPTION

<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

The `nys-button`'s "space" keydown doesn't reflect styling.

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1535 🎟️
