### PR TITLE
Fix: Remove double focus a11y VO on `nys-checkbox`

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -490,6 +490,7 @@ export class NysCheckbox extends LitElement {
           ${(this.label || this.other) &&
           html`
             <nys-label
+              aria-hidden="true"
               tooltip=${this.tooltip}
               label="${this.label || (this.other ? "Other" : "")}"
               description=${ifDefined(this.description || undefined)}


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
When in voiceover, when you tab into a `nys-checkbox`, press left/right and note how the previous version would focus on the label itself also. This PR removes that.

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  


## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1285 🎟️
