### PR TITLE
Fix: `nys-textinput` "other" text input now disables

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.test.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.test.ts
@@ -469,6 +469,17 @@ describe("nys-checkbox", () => {
     expect(otherCheckbox.showOtherError).to.be.false;
   });
 
+  it("disables textinput when 'other' checkbox is checked and disabled", async () => {
+    const el = await fixture<NysCheckbox>(html`
+      <nys-checkbox other checked disabled></nys-checkbox>
+    `);
+    await el.updateComplete;
+
+    const textInput = el.shadowRoot?.querySelector("nys-textinput");
+    expect(textInput).to.exist;
+    expect(textInput!.hasAttribute("disabled")).to.be.true;
+  });
+
   it("_handleInvalid always calls preventDefault", async () => {
     const el = await fixture<NysCheckboxgroup>(html`
       <nys-checkboxgroup required>

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -513,6 +513,7 @@ export class NysCheckbox extends LitElement {
                   ariaLabel="Other"
                   aria-invalid=${this.showOtherError ? "true" : "false"}
                   width=${this.isMobile ? "full" : "md"}
+                  ?disabled=${this.disabled}
                 ></nys-textinput>
               `
             : ""}


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Fix issue with `nys-textinput` "other" text input previously not disabling.
P.S. The `nys-radiobutton/group` is undergoing massive code changes. The issue found here will be fixed for the radio when that PR comes out. 

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1574 🎟️
