### PR TITLE
Prep for 1.18.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nysds/components",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nysds/components",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -15312,7 +15312,7 @@
     },
     "packages/mcp-server": {
       "name": "@nysds/mcp-server",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -15322,8 +15322,8 @@
         "nysds-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@nysds/styles": "^1.18.1",
-        "@nysds/tokens": "^1.18.1",
+        "@nysds/styles": "^1.18.3",
+        "@nysds/tokens": "^1.18.3",
         "@types/node": "^22.0.0",
         "typescript": "^5.9.3"
       }
@@ -15347,10 +15347,10 @@
     },
     "packages/nys-accordion": {
       "name": "@nysds/nys-accordion",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15360,11 +15360,11 @@
     },
     "packages/nys-alert": {
       "name": "@nysds/nys-alert",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-button": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15374,10 +15374,10 @@
     },
     "packages/nys-avatar": {
       "name": "@nysds/nys-avatar",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15387,11 +15387,11 @@
     },
     "packages/nys-backtotop": {
       "name": "@nysds/nys-backtotop",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-button": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15401,10 +15401,10 @@
     },
     "packages/nys-badge": {
       "name": "@nysds/nys-badge",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15414,10 +15414,10 @@
     },
     "packages/nys-breadcrumbs": {
       "name": "@nysds/nys-breadcrumbs",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15427,10 +15427,10 @@
     },
     "packages/nys-button": {
       "name": "@nysds/nys-button",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15440,12 +15440,12 @@
     },
     "packages/nys-checkbox": {
       "name": "@nysds/nys-checkbox",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-errormessage": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1",
-        "@nysds/nys-label": "^1.18.1"
+        "@nysds/nys-errormessage": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3",
+        "@nysds/nys-label": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15455,7 +15455,7 @@
     },
     "packages/nys-combobox": {
       "name": "@nysds/nys-combobox",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15465,13 +15465,13 @@
     },
     "packages/nys-datepicker": {
       "name": "@nysds/nys-datepicker",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1",
-        "@nysds/nys-errormessage": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1",
-        "@nysds/nys-label": "^1.18.1",
+        "@nysds/nys-button": "^1.18.3",
+        "@nysds/nys-errormessage": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3",
+        "@nysds/nys-label": "^1.18.3",
         "wc-datepicker": "^0.10.0"
       },
       "devDependencies": {
@@ -15482,7 +15482,7 @@
     },
     "packages/nys-divider": {
       "name": "@nysds/nys-divider",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15492,10 +15492,10 @@
     },
     "packages/nys-dropdownmenu": {
       "name": "@nysds/nys-dropdownmenu",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15505,10 +15505,10 @@
     },
     "packages/nys-errormessage": {
       "name": "@nysds/nys-errormessage",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15518,13 +15518,13 @@
     },
     "packages/nys-fileinput": {
       "name": "@nysds/nys-fileinput",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1",
-        "@nysds/nys-errormessage": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1",
-        "@nysds/nys-label": "^1.18.1"
+        "@nysds/nys-button": "^1.18.3",
+        "@nysds/nys-errormessage": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3",
+        "@nysds/nys-label": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15534,10 +15534,10 @@
     },
     "packages/nys-globalfooter": {
       "name": "@nysds/nys-globalfooter",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-divider": "^1.18.1"
+        "@nysds/nys-divider": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15547,10 +15547,10 @@
     },
     "packages/nys-globalheader": {
       "name": "@nysds/nys-globalheader",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15560,7 +15560,7 @@
     },
     "packages/nys-icon": {
       "name": "@nysds/nys-icon",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15570,11 +15570,11 @@
     },
     "packages/nys-label": {
       "name": "@nysds/nys-label",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1",
-        "@nysds/nys-tooltip": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3",
+        "@nysds/nys-tooltip": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15584,10 +15584,10 @@
     },
     "packages/nys-modal": {
       "name": "@nysds/nys-modal",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1"
+        "@nysds/nys-button": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15597,10 +15597,10 @@
     },
     "packages/nys-pagination": {
       "name": "@nysds/nys-pagination",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1"
+        "@nysds/nys-button": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15610,11 +15610,11 @@
     },
     "packages/nys-radiobutton": {
       "name": "@nysds/nys-radiobutton",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-errormessage": "^1.18.1",
-        "@nysds/nys-label": "^1.18.1"
+        "@nysds/nys-errormessage": "^1.18.3",
+        "@nysds/nys-label": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15624,12 +15624,12 @@
     },
     "packages/nys-select": {
       "name": "@nysds/nys-select",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-errormessage": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1",
-        "@nysds/nys-label": "^1.18.1"
+        "@nysds/nys-errormessage": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3",
+        "@nysds/nys-label": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15639,7 +15639,7 @@
     },
     "packages/nys-skipnav": {
       "name": "@nysds/nys-skipnav",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15649,10 +15649,10 @@
     },
     "packages/nys-stepper": {
       "name": "@nysds/nys-stepper",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1"
+        "@nysds/nys-button": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15662,10 +15662,10 @@
     },
     "packages/nys-tab": {
       "name": "@nysds/nys-tab",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "1.18.1"
+        "@nysds/nys-button": "1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15675,11 +15675,11 @@
     },
     "packages/nys-table": {
       "name": "@nysds/nys-table",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-button": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15689,12 +15689,12 @@
     },
     "packages/nys-textarea": {
       "name": "@nysds/nys-textarea",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-errormessage": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1",
-        "@nysds/nys-label": "^1.18.1"
+        "@nysds/nys-errormessage": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3",
+        "@nysds/nys-label": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15704,12 +15704,12 @@
     },
     "packages/nys-textinput": {
       "name": "@nysds/nys-textinput",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-errormessage": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1",
-        "@nysds/nys-label": "^1.18.1"
+        "@nysds/nys-errormessage": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3",
+        "@nysds/nys-label": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15719,10 +15719,10 @@
     },
     "packages/nys-toggle": {
       "name": "@nysds/nys-toggle",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-icon": "^1.18.1"
+        "@nysds/nys-icon": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15732,7 +15732,7 @@
     },
     "packages/nys-tooltip": {
       "name": "@nysds/nys-tooltip",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15742,7 +15742,7 @@
     },
     "packages/nys-unavfooter": {
       "name": "@nysds/nys-unavfooter",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15752,12 +15752,12 @@
     },
     "packages/nys-unavheader": {
       "name": "@nysds/nys-unavheader",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/nys-button": "^1.18.1",
-        "@nysds/nys-icon": "^1.18.1",
-        "@nysds/nys-textinput": "^1.18.1"
+        "@nysds/nys-button": "^1.18.3",
+        "@nysds/nys-icon": "^1.18.3",
+        "@nysds/nys-textinput": "^1.18.3"
       },
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15767,7 +15767,7 @@
     },
     "packages/nys-video": {
       "name": "@nysds/nys-video",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "devDependencies": {
         "lit": "^3.3.1",
@@ -15777,10 +15777,10 @@
     },
     "packages/styles": {
       "name": "@nysds/styles",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "dependencies": {
-        "@nysds/tokens": "1.18.1"
+        "@nysds/tokens": "1.18.3"
       },
       "devDependencies": {
         "vite": "^7.3.1"
@@ -15788,7 +15788,7 @@
     },
     "packages/tokens": {
       "name": "@nysds/tokens",
-      "version": "1.18.1",
+      "version": "1.18.3",
       "license": "MIT",
       "devDependencies": {
         "@terrazzo/cli": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/components",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "New York State's design system and code component library.",
   "type": "module",
   "workspaces": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/mcp-server",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "MCP server for the New York State Design System. Exposes components, tokens, and documentation to AI assistants.",
   "type": "module",
   "bin": {
@@ -30,8 +30,8 @@
     "zod": "^3.25"
   },
   "devDependencies": {
-    "@nysds/styles": "^1.18.1",
-    "@nysds/tokens": "^1.18.1",
+    "@nysds/styles": "^1.18.3",
+    "@nysds/tokens": "^1.18.3",
     "@types/node": "^22.0.0",
     "typescript": "^5.9.3"
   },

--- a/packages/nys-accordion/package.json
+++ b/packages/nys-accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-accordion",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Accordion component from the NYS Design System.",
   "module": "dist/nys-accordion.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-alert/package.json
+++ b/packages/nys-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-alert",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Alert component from the NYS Design System.",
   "module": "dist/nys-alert.js",
   "types": "dist/index.d.ts",
@@ -23,8 +23,8 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-button": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-button": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-avatar/package.json
+++ b/packages/nys-avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-avatar",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Avatar component from the NYS Design System.",
   "module": "dist/nys-avatar.js",
   "exports": {
@@ -22,7 +22,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-backtotop/package.json
+++ b/packages/nys-backtotop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-backtotop",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Back To Top component from the NYS Design System.",
   "module": "dist/nys-backtotop.js",
   "types": "dist/index.d.ts",
@@ -23,8 +23,8 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-button": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-button": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-badge/package.json
+++ b/packages/nys-badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-badge",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Badge component from the NYS Design System.",
   "module": "dist/nys-badge.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-breadcrumbs/package.json
+++ b/packages/nys-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-breadcrumbs",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Breadcrumbs component from the NYS Design System.",
   "module": "dist/nys-breadcrumbs.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-button/package.json
+++ b/packages/nys-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-button",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Button component from the NYS Design System.",
   "module": "dist/nys-button.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-checkbox/package.json
+++ b/packages/nys-checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-checkbox",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Checkbox component from the NYS Design System.",
   "module": "dist/nys-checkbox.js",
   "types": "dist/index.d.ts",
@@ -23,9 +23,9 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-label": "^1.18.1",
-    "@nysds/nys-errormessage": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-label": "^1.18.3",
+    "@nysds/nys-errormessage": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-combobox/package.json
+++ b/packages/nys-combobox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-combobox",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Combobox component from the NYS Design System.",
   "module": "dist/nys-combobox.js",
   "types": "dist/index.d.ts",

--- a/packages/nys-datepicker/package.json
+++ b/packages/nys-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-datepicker",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Datepicker component from the NYS Design System.",
   "module": "dist/nys-datepicker.js",
   "types": "dist/index.d.ts",
@@ -23,10 +23,10 @@
     "lit-analyze": "lit-analyzer '*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-button": "^1.18.1",
-    "@nysds/nys-label": "^1.18.1",
-    "@nysds/nys-errormessage": "^1.18.1",
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-button": "^1.18.3",
+    "@nysds/nys-label": "^1.18.3",
+    "@nysds/nys-errormessage": "^1.18.3",
     "wc-datepicker": "^0.10.0"
   },
   "devDependencies": {

--- a/packages/nys-divider/package.json
+++ b/packages/nys-divider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-divider",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Divider component from the NYS Design System.",
   "module": "dist/nys-divider.js",
   "types": "dist/index.d.ts",

--- a/packages/nys-dropdownmenu/package.json
+++ b/packages/nys-dropdownmenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-dropdownmenu",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Dropdownmenu component from the NYS Design System.",
   "module": "dist/nys-dropdownmenu.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-errormessage/package.json
+++ b/packages/nys-errormessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-errormessage",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Errormessage component from the NYS Design System.",
   "module": "dist/nys-errormessage.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-fileinput/package.json
+++ b/packages/nys-fileinput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-fileinput",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Fileinput component from the NYS Design System.",
   "module": "dist/nys-fileinput.js",
   "types": "dist/index.d.ts",
@@ -23,10 +23,10 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-button": "^1.18.1",
-    "@nysds/nys-label": "^1.18.1",
-    "@nysds/nys-errormessage": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-button": "^1.18.3",
+    "@nysds/nys-label": "^1.18.3",
+    "@nysds/nys-errormessage": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-globalfooter/package.json
+++ b/packages/nys-globalfooter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-globalfooter",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Globalfooter component from the NYS Design System.",
   "module": "dist/nys-globalfooter.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-divider": "^1.18.1"
+    "@nysds/nys-divider": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-globalheader/package.json
+++ b/packages/nys-globalheader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-globalheader",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Globalheader component from the NYS Design System.",
   "module": "dist/nys-globalheader.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-icon/package.json
+++ b/packages/nys-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-icon",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Icon component from the NYS Design System.",
   "module": "dist/nys-icon.js",
   "types": "dist/index.d.ts",

--- a/packages/nys-label/package.json
+++ b/packages/nys-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-label",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Label component from the NYS Design System.",
   "module": "dist/nys-label.js",
   "types": "dist/index.d.ts",
@@ -23,8 +23,8 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-tooltip": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-tooltip": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-modal/package.json
+++ b/packages/nys-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-modal",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Modal component from the NYS Design System.",
   "module": "dist/nys-modal.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
     "test:watch": "vite build && wtr --watch"
   },
   "dependencies": {
-    "@nysds/nys-button": "^1.18.1"
+    "@nysds/nys-button": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-pagination/package.json
+++ b/packages/nys-pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-pagination",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Pagination component from the NYS Design System.",
   "module": "dist/nys-pagination.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-button": "^1.18.1"
+    "@nysds/nys-button": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-radiobutton/package.json
+++ b/packages/nys-radiobutton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-radiobutton",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Radiobutton component from the NYS Design System.",
   "module": "dist/nys-radiobutton.js",
   "types": "dist/index.d.ts",
@@ -23,8 +23,8 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-label": "^1.18.1",
-    "@nysds/nys-errormessage": "^1.18.1"
+    "@nysds/nys-label": "^1.18.3",
+    "@nysds/nys-errormessage": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-select/package.json
+++ b/packages/nys-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-select",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Select component from the NYS Design System.",
   "module": "dist/nys-select.js",
   "exports": {
@@ -22,9 +22,9 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-label": "^1.18.1",
-    "@nysds/nys-errormessage": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-label": "^1.18.3",
+    "@nysds/nys-errormessage": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-skipnav/package.json
+++ b/packages/nys-skipnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-skipnav",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Skipnav component from the NYS Design System.",
   "module": "dist/nys-skipnav.js",
   "types": "dist/index.d.ts",

--- a/packages/nys-stepper/package.json
+++ b/packages/nys-stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-stepper",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Stepper component from the NYS Design System.",
   "module": "dist/nys-stepper.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-button": "^1.18.1"
+    "@nysds/nys-button": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-tab/package.json
+++ b/packages/nys-tab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-tab",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Tab component from the NYS Design System.",
   "module": "dist/nys-tab.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "lit-analyze": "lit-analyzer '*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-button": "1.18.1"
+    "@nysds/nys-button": "1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-table/package.json
+++ b/packages/nys-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-table",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Table component from the NYS Design System.",
   "module": "dist/nys-table.js",
   "types": "dist/index.d.ts",
@@ -23,8 +23,8 @@
     "lit-analyze": "lit-analyzer '*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-button": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-button": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-textarea/package.json
+++ b/packages/nys-textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-textarea",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Textarea component from the NYS Design System.",
   "module": "dist/nys-textarea.js",
   "types": "dist/index.d.ts",
@@ -23,9 +23,9 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-label": "^1.18.1",
-    "@nysds/nys-errormessage": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-label": "^1.18.3",
+    "@nysds/nys-errormessage": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-textinput/package.json
+++ b/packages/nys-textinput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-textinput",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Textinput component from the NYS Design System.",
   "module": "dist/nys-textinput.js",
   "exports": {
@@ -22,9 +22,9 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-label": "^1.18.1",
-    "@nysds/nys-errormessage": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-label": "^1.18.3",
+    "@nysds/nys-errormessage": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-toggle/package.json
+++ b/packages/nys-toggle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-toggle",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Toggle component from the NYS Design System.",
   "module": "dist/nys-toggle.js",
   "exports": {
@@ -22,7 +22,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-tooltip/package.json
+++ b/packages/nys-tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-tooltip",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Tooltip component from the NYS Design System.",
   "module": "dist/nys-tooltip.js",
   "types": "dist/index.d.ts",

--- a/packages/nys-unavfooter/package.json
+++ b/packages/nys-unavfooter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-unavfooter",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Unavfooter component from the NYS Design System.",
   "module": "dist/nys-unavfooter.js",
   "types": "dist/index.d.ts",

--- a/packages/nys-unavheader/package.json
+++ b/packages/nys-unavheader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-unavheader",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Unavheader component from the NYS Design System.",
   "module": "dist/nys-unavheader.js",
   "types": "dist/index.d.ts",
@@ -23,9 +23,9 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
-    "@nysds/nys-icon": "^1.18.1",
-    "@nysds/nys-button": "^1.18.1",
-    "@nysds/nys-textinput": "^1.18.1"
+    "@nysds/nys-icon": "^1.18.3",
+    "@nysds/nys-button": "^1.18.3",
+    "@nysds/nys-textinput": "^1.18.3"
   },
   "devDependencies": {
     "lit": "^3.3.1",

--- a/packages/nys-video/package.json
+++ b/packages/nys-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/nys-video",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "The Video Player component from the NYS Design System.",
   "module": "dist/nys-video.js",
   "types": "dist/index.d.ts",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nysds/styles",
   "type": "module",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "CSS variables, styles, and themes for the New York State Design System",
   "main": "dist/nysds.min.css",
   "style": "dist/nysds.min.css",
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@nysds/tokens": "1.18.1"
+    "@nysds/tokens": "1.18.3"
   },
   "devDependencies": {
     "vite": "^7.3.1"

--- a/packages/styles/src/nysds.scss
+++ b/packages/styles/src/nysds.scss
@@ -7,7 +7,7 @@
    * Part of the New York State Design System (NYSDS)
    * Repository: https://github.com/its-hcd/nysds
    * License: MIT
-   * Version: 1.18.1
+   * Version: 1.18.3
 */
 
 

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nysds/tokens",
-  "version": "1.18.1",
+  "version": "1.18.3",
   "description": "Design tokens for the New York State Design System in DTCG 2025.10 format",
   "type": "module",
   "main": "src/tokens.json",

--- a/plopfile.js
+++ b/plopfile.js
@@ -19,7 +19,7 @@ export default function (plop) {
         type: "input",
         name: "versionNumber",
         message: "Version Number",
-        default: "1.18.1", //update this to the latest version when new release is made
+        default: "1.18.3", //update this to the latest version when new release is made
       },
       {
         type: "confirm",

--- a/src/scripts/add-banner-tokens.mjs
+++ b/src/scripts/add-banner-tokens.mjs
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, readdirSync } from "fs";
 import { join } from "path";
 
 const banner = `/*!
- * New York State Design System v1.18.1
+ * New York State Design System v1.18.3
  * Description: A design system for New York State's digital products.
  * Repository: https://github.com/its-hcd/nysds
  * License: MIT

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,7 @@
     { "path": "packages/nys-avatar" },
     { "path": "packages/nys-backtotop" },
     { "path": "packages/nys-badge" },
+    { "path": "packages/nys-breadcrumbs" },
     { "path": "packages/nys-button" },
     { "path": "packages/nys-checkbox" },
     { "path": "packages/nys-combobox" },
@@ -24,12 +25,14 @@
     { "path": "packages/nys-select" },
     { "path": "packages/nys-skipnav" },
     { "path": "packages/nys-stepper" },
+    { "path": "packages/nys-tab" },
     { "path": "packages/nys-table" },
     { "path": "packages/nys-textarea" },
     { "path": "packages/nys-textinput" },
     { "path": "packages/nys-toggle" },
     { "path": "packages/nys-tooltip" },
     { "path": "packages/nys-unavfooter" },
-    { "path": "packages/nys-unavheader" }
+    { "path": "packages/nys-unavheader" },
+    { "path": "packages/nys-video" }
   ]
 }


### PR DESCRIPTION
Prep for 1.18.3

Skipping 1.18.2 because of a broken @nysds/angular package that used that same version, causing us to not be able to release this as 1.18.2