### PR TITLE
Enhancement: Add `@layer` cascade hierarchy to global stylesheets

### DIFF
--- a/packages/styles/src/core/reset.scss
+++ b/packages/styles/src/core/reset.scss
@@ -1,238 +1,237 @@
 @use "sass:map";
 @use "sass:list";
 
-/* === Selective Resets */
-
-/* Box Model */
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-/* Margin/Padding for Text Elements */
-
-body,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-ul,
-ol,
-blockquote,
-figure,
-pre {
-  margin: 0;
-  padding: 0;
-}
-
-/* Lists */
-
-ul,
-ol {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-/* === Global Styles */
-
-/* === Typography */
-
-html {
-  scroll-behavior: smooth;
-}
-
-body {
-  margin: 0;
-  font: var(--nys-font-size-md) / var(--nys-font-lineheight-md)
-    var(--nys-font-family-body);
-  color: var(--nys-color-ink);
-}
-
-small {
-  font: var(--nys-font-size-xs) / var(--nys-font-lineheight-xs)
-    var(--nys-font-family-body);
-}
-
-/* --- Headings --- */
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: var(--nys-font-family-heading);
-  font-weight: 700;
-}
-
-// Heading configuration map
-$headings: (
-  h1: (
-    letterspacing: negative-300,
-    margin-top: 600,
-    margin-bottom: 250,
-  ),
-  h2: (
-    letterspacing: negative-200,
-    margin-top: 500,
-    margin-bottom: 200,
-  ),
-  h3: (
-    letterspacing: negative-200,
-    margin-top: 400,
-    margin-bottom: 150,
-  ),
-  h4: (
-    letterspacing: null,
-    margin-top: 300,
-    margin-bottom: 100,
-  ),
-  h5: (
-    letterspacing: null,
-    margin-top: 250,
-    margin-bottom: 100,
-  ),
-  h6: (
-    letterspacing: null,
-    margin-top: 200,
-    margin-bottom: 100,
-  ),
-);
-
-@each $heading, $props in $headings {
-  #{$heading} {
-    font-size: var(--nys-font-size-#{$heading});
-    line-height: var(--nys-font-lineheight-#{$heading});
-
-    @if map.get($props, letterspacing) {
-      letter-spacing: var(
-        --nys-font-letterspacing-#{map.get($props, letterspacing)}
-      );
-    }
-
-    margin-top: var(--nys-space-#{map.get($props, margin-top)});
-    margin-bottom: var(--nys-space-#{map.get($props, margin-bottom)});
+@layer nysds.base {
+  /* === Selective Resets */
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
   }
-}
 
-/* Adjacent heading spacing */
-$heading-pairs: (h1 h2, h2 h3, h3 h4, h4 h5, h5 h6);
+  /* Margin/Padding for Text Elements */
 
-@each $pair in $heading-pairs {
-  #{list.nth($pair, 1)} + #{list.nth($pair, 2)} {
+  body,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  ul,
+  ol,
+  blockquote,
+  figure,
+  pre {
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Lists */
+
+  ul,
+  ol {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* === Global Styles */
+
+  /* === Typography */
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    margin: 0;
+    font: var(--nys-font-size-md) / var(--nys-font-lineheight-md)
+      var(--nys-font-family-body);
+    color: var(--nys-color-ink);
+  }
+
+  small {
+    font: var(--nys-font-size-xs) / var(--nys-font-lineheight-xs)
+      var(--nys-font-family-body);
+  }
+
+  /* --- Headings --- */
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--nys-font-family-heading);
+    font-weight: 700;
+  }
+
+  // Heading configuration map
+  $headings: (
+    h1: (
+      letterspacing: negative-300,
+      margin-top: 600,
+      margin-bottom: 250,
+    ),
+    h2: (
+      letterspacing: negative-200,
+      margin-top: 500,
+      margin-bottom: 200,
+    ),
+    h3: (
+      letterspacing: negative-200,
+      margin-top: 400,
+      margin-bottom: 150,
+    ),
+    h4: (
+      letterspacing: null,
+      margin-top: 300,
+      margin-bottom: 100,
+    ),
+    h5: (
+      letterspacing: null,
+      margin-top: 250,
+      margin-bottom: 100,
+    ),
+    h6: (
+      letterspacing: null,
+      margin-top: 200,
+      margin-bottom: 100,
+    ),
+  );
+
+  @each $heading, $props in $headings {
+    #{$heading} {
+      font-size: var(--nys-font-size-#{$heading});
+      line-height: var(--nys-font-lineheight-#{$heading});
+
+      @if map.get($props, letterspacing) {
+        letter-spacing: var(
+          --nys-font-letterspacing-#{map.get($props, letterspacing)}
+        );
+      }
+
+      margin-top: var(--nys-space-#{map.get($props, margin-top)});
+      margin-bottom: var(--nys-space-#{map.get($props, margin-bottom)});
+    }
+  }
+
+  /* Adjacent heading spacing */
+  $heading-pairs: (h1 h2, h2 h3, h3 h4, h4 h5, h5 h6);
+
+  @each $pair in $heading-pairs {
+    #{list.nth($pair, 1)} + #{list.nth($pair, 2)} {
+      margin-top: var(--nys-space-150);
+    }
+  }
+
+  /* --- Body Text --- */
+
+  p,
+  ul,
+  ol,
+  dl,
+  blockquote {
+    font: var(--nys-font-size-md) / var(--nys-font-lineheight-md)
+      var(--nys-font-family-body);
+    margin-bottom: var(--nys-space-150);
+  }
+
+  small {
+    margin-bottom: var(--nys-space-100);
+  }
+
+  p + p {
     margin-top: var(--nys-space-150);
   }
-}
 
-/* --- Body Text --- */
-
-p,
-ul,
-ol,
-dl,
-blockquote {
-  font: var(--nys-font-size-md) / var(--nys-font-lineheight-md)
-    var(--nys-font-family-body);
-  margin-bottom: var(--nys-space-150);
-}
-
-small {
-  margin-bottom: var(--nys-space-100);
-}
-
-p + p {
-  margin-top: var(--nys-space-150);
-}
-
-section + section {
-  margin-top: var(--nys-space-300);
-}
-
-@media (width >= 768px) {
   section + section {
-    margin-bottom: var(--nys-space-600);
-  }
-}
-
-/* --- Lists --- */
-
-ul,
-ol {
-  margin-top: 0;
-  padding-left: var(--nys-space-200);
-}
-
-blockquote > ul,
-blockquote > ol {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-/* Unordered Lists (Bullets) */
-$ul-styles: (disc, circle, square);
-
-@for $i from 1 through list.length($ul-styles) {
-  $selector: "ul";
-
-  @for $j from 2 through $i {
-    $selector: $selector + " ul";
+    margin-top: var(--nys-space-300);
   }
 
-  #{$selector} {
-    list-style-type: list.nth($ul-styles, $i);
-
-    @if $i > 1 {
-      padding-left: var(--nys-space-200);
+  @media (width >= 768px) {
+    section + section {
+      margin-bottom: var(--nys-space-600);
     }
   }
-}
 
-/* Ordered Lists (Numbers) */
-$ol-styles: (decimal, lower-alpha, lower-roman);
+  /* --- Lists --- */
 
-@for $i from 1 through list.length($ol-styles) {
-  $selector: "ol";
-
-  @for $j from 2 through $i {
-    $selector: $selector + " ol";
+  ul,
+  ol {
+    margin-top: 0;
+    padding-left: var(--nys-space-200);
   }
 
-  #{$selector} {
-    list-style-type: list.nth($ol-styles, $i);
+  blockquote > ul,
+  blockquote > ol {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 
-    @if $i > 1 {
-      padding-left: var(--nys-space-200);
+  /* Unordered Lists (Bullets) */
+  $ul-styles: (disc, circle, square);
+
+  @for $i from 1 through list.length($ul-styles) {
+    $selector: "ul";
+
+    @for $j from 2 through $i {
+      $selector: $selector + " ul";
+    }
+
+    #{$selector} {
+      list-style-type: list.nth($ul-styles, $i);
+
+      @if $i > 1 {
+        padding-left: var(--nys-space-200);
+      }
     }
   }
-}
 
-/* List Items */
+  /* Ordered Lists (Numbers) */
+  $ol-styles: (decimal, lower-alpha, lower-roman);
 
-li {
-  margin-bottom: var(--nys-space-100);
-}
+  @for $i from 1 through list.length($ol-styles) {
+    $selector: "ol";
 
-li::marker {
-  color: var(--nys-color-theme-primary, #000000);
-}
+    @for $j from 2 through $i {
+      $selector: $selector + " ol";
+    }
 
-/* --- Links --- */
+    #{$selector} {
+      list-style-type: list.nth($ol-styles, $i);
 
-a {
-  color: var(--nys-color-link);
-}
+      @if $i > 1 {
+        padding-left: var(--nys-space-200);
+      }
+    }
+  }
 
-a:hover,
-a:focus {
-  color: var(--nys-color-link-strong);
-}
+  /* List Items */
 
-a:active {
-  color: var(--nys-color-link-strongest);
+  li {
+    margin-bottom: var(--nys-space-100);
+  }
+
+  li::marker {
+    color: var(--nys-color-theme-primary, #000000);
+  }
+
+  /* --- Links --- */
+
+  a {
+    color: var(--nys-color-link);
+  }
+
+  a:hover,
+  a:focus {
+    color: var(--nys-color-link-strong);
+  }
+
+  a:active {
+    color: var(--nys-color-link-strongest);
+  }
 }

--- a/packages/styles/src/core/typography.scss
+++ b/packages/styles/src/core/typography.scss
@@ -8,72 +8,74 @@
 
 /* --- Body --- */
 
-$body-sizes: (xs, sm, md);
+@layer nysds.base {
+  $body-sizes: (xs, sm, md);
 
-@each $size in $body-sizes {
-  .nys-font-body-#{$size} {
-    font: var(--nys-font-size-#{$size}) /
-      var(--nys-font-lineheight-#{$size})
-      var(--nys-font-family-body);
+  @each $size in $body-sizes {
+    .nys-font-body-#{$size} {
+      font: var(--nys-font-size-#{$size}) /
+        var(--nys-font-lineheight-#{$size})
+        var(--nys-font-family-body);
+    }
   }
-}
 
-/* --- Heading --- */
+  /* --- Heading --- */
 
-@for $i from 1 through 6 {
-  .nys-font-h#{$i} {
-    font: normal
-      normal
-      var(--nys-font-weight-h#{$i}, bold)
-      var(--nys-font-size-h#{$i}) /
-      var(--nys-font-lineheight-h#{$i})
-      var(--nys-font-family-heading);
+  @for $i from 1 through 6 {
+    .nys-font-h#{$i} {
+      font: normal
+        normal
+        var(--nys-font-weight-h#{$i}, bold)
+        var(--nys-font-size-h#{$i}) /
+        var(--nys-font-lineheight-h#{$i})
+        var(--nys-font-family-heading);
+    }
   }
-}
 
-/* --- UI --- */
+  /* --- UI --- */
 
-$ui-sizes: (xs, sm, md, lg, xl);
+  $ui-sizes: (xs, sm, md, lg, xl);
 
-@each $size in $ui-sizes {
-  .nys-font-ui-#{$size} {
-    font: var(--nys-font-size-ui-#{$size}) /
-      var(--nys-font-lineheight-ui-#{$size})
-      var(--nys-font-family-ui);
+  @each $size in $ui-sizes {
+    .nys-font-ui-#{$size} {
+      font: var(--nys-font-size-ui-#{$size}) /
+        var(--nys-font-lineheight-ui-#{$size})
+        var(--nys-font-family-ui);
+    }
   }
-}
 
-/* --- Display --- */
+  /* --- Display --- */
 
-$display-sizes: (sm, md, lg, xl);
+  $display-sizes: (sm, md, lg, xl);
 
-@each $size in $display-sizes {
-  .nys-font-display-#{$size} {
-    font: var(--nys-font-size-display-#{$size}) /
-      var(--nys-font-lineheight-display-#{$size})
-      var(--nys-font-family-display);
+  @each $size in $display-sizes {
+    .nys-font-display-#{$size} {
+      font: var(--nys-font-size-display-#{$size}) /
+        var(--nys-font-lineheight-display-#{$size})
+        var(--nys-font-family-display);
+    }
   }
-}
 
-/* --- Agency/Application Title --- */
+  /* --- Agency/Application Title --- */
 
-.nys-font-agency {
-  font: var(--nys-font-size-agency-xl) / var(--nys-font-lineheight-h1)
-    var(--nys-font-family-agency);
-}
+  .nys-font-agency {
+    font: var(--nys-font-size-agency-xl) / var(--nys-font-lineheight-h1)
+      var(--nys-font-family-agency);
+  }
 
-/* --- Font Family Attribute Selectors --- */
+  /* --- Font Family Attribute Selectors --- */
 
-/* These set font-family for any class matching the pattern */
+  /* These set font-family for any class matching the pattern */
 
-[class*="nys-font-mono-"] {
-  font-family: var(--nys-font-family-monospace), monospace;
-}
+  [class*="nys-font-mono-"] {
+    font-family: var(--nys-font-family-monospace), monospace;
+  }
 
-[class*="nys-font-sans-"] {
-  font-family: var(--nys-font-family-sans), sans-serif;
-}
+  [class*="nys-font-sans-"] {
+    font-family: var(--nys-font-family-sans), sans-serif;
+  }
 
-[class*="nys-font-serif-"] {
-  font-family: var(--nys-font-family-serif), serif;
+  [class*="nys-font-serif-"] {
+    font-family: var(--nys-font-family-serif), serif;
+  }
 }

--- a/packages/styles/src/nysds-full.scss
+++ b/packages/styles/src/nysds-full.scss
@@ -1,3 +1,9 @@
+/* 
+ * Cascade layer order — later layers have higher priority.
+ * Unlayered consumer CSS always wins over all layers. 
+ */
+@layer nysds.base, nysds.components, nysds.utilities;
+
 /* Include the selective CSS reset  */
 @use "./core/reset";
 
@@ -8,4 +14,6 @@
 @use "./core/typography";
 
 /* Include NYSDS Utility classes */
-@use "./utilities";
+@layer nysds.utilities {
+  @use "./utilities";
+}

--- a/packages/styles/src/nysds-full.scss
+++ b/packages/styles/src/nysds-full.scss
@@ -1,9 +1,3 @@
-/* 
- * Cascade layer order — later layers have higher priority.
- * Unlayered consumer CSS always wins over all layers. 
- */
-@layer nysds.base, nysds.components, nysds.utilities;
-
 /* Include the selective CSS reset  */
 @use "./core/reset";
 
@@ -14,6 +8,10 @@
 @use "./core/typography";
 
 /* Include NYSDS Utility classes */
-@layer nysds.utilities {
-  @use "./utilities";
-}
+@use "./utilities";
+
+/* 
+ * Cascade layer order — later layers have higher priority.
+ * Unlayered consumer CSS always wins over all layers. 
+ */
+@layer nysds.base, nysds.utilities;

--- a/packages/styles/src/nysds.scss
+++ b/packages/styles/src/nysds.scss
@@ -10,17 +10,17 @@
    * Version: 1.19.0
 */
 
+/* Include Design Tokens (variables for colors, spacing, typography) */
+@use "./core/tokens";
+
 /* 
  * Cascade layer order — later layers have higher priority.
  * Unlayered consumer CSS always wins over all layers. 
  */
-@layer nysds.base, nysds.components, nysds.utilities;
-
-/* Include Design Tokens (variables for colors, spacing, typography) */
-@use "./core/tokens";
+@layer nysds.base, nysds.utilities;
 
 /* Include NYSDS component styles (Light DOM) */
-@use "./components";
+// @use "./components";
 
 /* Hide unstyled components until they are fully loaded */
 nys-breadcrumbs:not(:defined),

--- a/packages/styles/src/nysds.scss
+++ b/packages/styles/src/nysds.scss
@@ -10,8 +10,17 @@
    * Version: 1.19.0
 */
 
+/* 
+ * Cascade layer order — later layers have higher priority.
+ * Unlayered consumer CSS always wins over all layers. 
+ */
+@layer nysds.base, nysds.components, nysds.utilities;
+
 /* Include Design Tokens (variables for colors, spacing, typography) */
 @use "./core/tokens";
+
+/* Include NYSDS component styles (Light DOM) */
+@use "./components";
 
 /* Hide unstyled components until they are fully loaded */
 nys-breadcrumbs:not(:defined),
@@ -47,6 +56,7 @@ nys-textinput:not(:defined),
 nys-toggle:not(:defined),
 nys-tooltip:not(:defined),
 nys-unavheader:not(:defined),
-nys-unavfooter:not(:defined) {
+nys-unavfooter:not(:defined),
+nys-verticalnav:not(:defined) {
   visibility: hidden;
 }

--- a/packages/styles/src/utilities/_clearfix.scss
+++ b/packages/styles/src/utilities/_clearfix.scss
@@ -3,8 +3,10 @@
 // Clearfix for floated content
 // ============================================
 
-.nys-clearfix::after {
-  clear: both;
-  content: "";
-  display: block;
+@layer nysds.utilities {
+  .nys-clearfix::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
 }

--- a/packages/styles/src/utilities/_config.scss
+++ b/packages/styles/src/utilities/_config.scss
@@ -3,130 +3,132 @@
 // Shared configuration maps for all utilities
 // ============================================
 
-// Breakpoints (mobile-first)
-$breakpoints: (
-  "mobile-lg": 30em,
-  "tablet": 40em,
-  "desktop": 64em,
-  "widescreen": 87.5em,
-);
+@layer nysds.utilities {
+  // Breakpoints (mobile-first)
+  $breakpoints: (
+    "mobile-lg": 30em,
+    "tablet": 40em,
+    "desktop": 64em,
+    "widescreen": 87.5em,
+  );
 
-// Grid containers (USWDS scale in rem)
-$grid-containers: (
-  "": 64rem,
-  "-card": 10rem,
-  "-card-lg": 15rem,
-  "-mobile": 20rem,
-  "-mobile-lg": 30rem,
-  "-tablet": 40rem,
-  "-tablet-lg": 55rem,
-  "-desktop": 64rem,
-  "-desktop-lg": 75rem,
-  "-widescreen": 87.5rem,
-  /* NYS-custom scale in ems*/ "-nys-mobile-lg": 30rem,
-  "-nys-tablet": 40rem,
-  "-nys-desktop": 64rem,
-  "-nys-widescreen": 87.5rem,
-);
+  // Grid containers (USWDS scale in rem)
+  $grid-containers: (
+    "": 64rem,
+    "-card": 10rem,
+    "-card-lg": 15rem,
+    "-mobile": 20rem,
+    "-mobile-lg": 30rem,
+    "-tablet": 40rem,
+    "-tablet-lg": 55rem,
+    "-desktop": 64rem,
+    "-desktop-lg": 75rem,
+    "-widescreen": 87.5rem,
+    /* NYS-custom scale in ems*/ "-nys-mobile-lg": 30rem,
+    "-nys-tablet": 40rem,
+    "-nys-desktop": 64rem,
+    "-nys-widescreen": 87.5rem,
+  );
 
-// Spacing scale (matches published CSS utility classes)
-$spacing: (
-  "1px": 1px,
-  "2px": 2px,
-  "50": 4px,
-  "100": 8px,
-  "150": 12px,
-  "200": 16px,
-  "250": 20px,
-  "300": 24px,
-  "400": 32px,
-  "500": 40px,
-  "600": 48px,
-  "700": 56px,
-  "800": 64px,
-  "1200": 96px,
-);
+  // Spacing scale (matches published CSS utility classes)
+  $spacing: (
+    "1px": 1px,
+    "2px": 2px,
+    "50": 4px,
+    "100": 8px,
+    "150": 12px,
+    "200": 16px,
+    "250": 20px,
+    "300": 24px,
+    "400": 32px,
+    "500": 40px,
+    "600": 48px,
+    "700": 56px,
+    "800": 64px,
+    "1200": 96px,
+  );
 
-// Display values
-$display-values: (
-  block,
-  flex,
-  none,
-  inline,
-  inline-block,
-  inline-flex,
-  table,
-  table-cell,
-  table-row
-);
+  // Display values
+  $display-values: (
+    block,
+    flex,
+    none,
+    inline,
+    inline-block,
+    inline-flex,
+    table,
+    table-cell,
+    table-row
+  );
 
-// Opacity scale
-$opacity-values: (0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100);
+  // Opacity scale
+  $opacity-values: (0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100);
 
-// Z-index scale
-$zindex-values: (
-  "auto": auto,
-  "bottom": -100,
-  "top": 99999,
-  "0": 0,
-  "100": 100,
-  "200": 200,
-  "300": 300,
-  "400": 400,
-  "500": 500,
-);
+  // Z-index scale
+  $zindex-values: (
+    "auto": auto,
+    "bottom": -100,
+    "top": 99999,
+    "0": 0,
+    "100": 100,
+    "200": 200,
+    "300": 300,
+    "400": 400,
+    "500": 500,
+  );
 
-// Flex column values (1-12)
-$flex-columns: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+  // Flex column values (1-12)
+  $flex-columns: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
 
-// Order values
-$order-values: (
-  "first": -1,
-  "last": 999,
-  "initial": 0,
-  "0": 0,
-  "1": 1,
-  "2": 2,
-  "3": 3,
-  "4": 4,
-  "5": 5,
-  "6": 6,
-  "7": 7,
-  "8": 8,
-  "9": 9,
-  "10": 10,
-  "11": 11,
-);
+  // Order values
+  $order-values: (
+    "first": -1,
+    "last": 999,
+    "initial": 0,
+    "0": 0,
+    "1": 1,
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "8": 8,
+    "9": 9,
+    "10": 10,
+    "11": 11,
+  );
 
-// Float values
-$float-values: (left, right, none);
+  // Float values
+  $float-values: (left, right, none);
 
-// Overflow values
-$overflow-values: (auto, hidden, scroll, visible);
+  // Overflow values
+  $overflow-values: (auto, hidden, scroll, visible);
 
-// Position values
-$position-values: (absolute, fixed, relative, static, sticky);
+  // Position values
+  $position-values: (absolute, fixed, relative, static, sticky);
 
-// Spacing direction mappings (used by margin and padding)
-$directions: (
-  "x": (
-    left,
-    right,
-  ),
-  "y": (
-    top,
-    bottom,
-  ),
-  "t": (
-    top,
-  ),
-  "r": (
-    right,
-  ),
-  "b": (
-    bottom,
-  ),
-  "l": (
-    left,
-  ),
-);
+  // Spacing direction mappings (used by margin and padding)
+  $directions: (
+    "x": (
+      left,
+      right,
+    ),
+    "y": (
+      top,
+      bottom,
+    ),
+    "t": (
+      top,
+    ),
+    "r": (
+      right,
+    ),
+    "b": (
+      bottom,
+    ),
+    "l": (
+      left,
+    ),
+  );
+}

--- a/packages/styles/src/utilities/_config.scss
+++ b/packages/styles/src/utilities/_config.scss
@@ -3,132 +3,130 @@
 // Shared configuration maps for all utilities
 // ============================================
 
-@layer nysds.utilities {
-  // Breakpoints (mobile-first)
-  $breakpoints: (
-    "mobile-lg": 30em,
-    "tablet": 40em,
-    "desktop": 64em,
-    "widescreen": 87.5em,
-  );
+// Breakpoints (mobile-first)
+$breakpoints: (
+  "mobile-lg": 30em,
+  "tablet": 40em,
+  "desktop": 64em,
+  "widescreen": 87.5em,
+);
 
-  // Grid containers (USWDS scale in rem)
-  $grid-containers: (
-    "": 64rem,
-    "-card": 10rem,
-    "-card-lg": 15rem,
-    "-mobile": 20rem,
-    "-mobile-lg": 30rem,
-    "-tablet": 40rem,
-    "-tablet-lg": 55rem,
-    "-desktop": 64rem,
-    "-desktop-lg": 75rem,
-    "-widescreen": 87.5rem,
-    /* NYS-custom scale in ems*/ "-nys-mobile-lg": 30rem,
-    "-nys-tablet": 40rem,
-    "-nys-desktop": 64rem,
-    "-nys-widescreen": 87.5rem,
-  );
+// Grid containers (USWDS scale in rem)
+$grid-containers: (
+  "": 64rem,
+  "-card": 10rem,
+  "-card-lg": 15rem,
+  "-mobile": 20rem,
+  "-mobile-lg": 30rem,
+  "-tablet": 40rem,
+  "-tablet-lg": 55rem,
+  "-desktop": 64rem,
+  "-desktop-lg": 75rem,
+  "-widescreen": 87.5rem,
+  /* NYS-custom scale in ems*/ "-nys-mobile-lg": 30rem,
+  "-nys-tablet": 40rem,
+  "-nys-desktop": 64rem,
+  "-nys-widescreen": 87.5rem,
+);
 
-  // Spacing scale (matches published CSS utility classes)
-  $spacing: (
-    "1px": 1px,
-    "2px": 2px,
-    "50": 4px,
-    "100": 8px,
-    "150": 12px,
-    "200": 16px,
-    "250": 20px,
-    "300": 24px,
-    "400": 32px,
-    "500": 40px,
-    "600": 48px,
-    "700": 56px,
-    "800": 64px,
-    "1200": 96px,
-  );
+// Spacing scale (matches published CSS utility classes)
+$spacing: (
+  "1px": 1px,
+  "2px": 2px,
+  "50": 4px,
+  "100": 8px,
+  "150": 12px,
+  "200": 16px,
+  "250": 20px,
+  "300": 24px,
+  "400": 32px,
+  "500": 40px,
+  "600": 48px,
+  "700": 56px,
+  "800": 64px,
+  "1200": 96px,
+);
 
-  // Display values
-  $display-values: (
-    block,
-    flex,
-    none,
-    inline,
-    inline-block,
-    inline-flex,
-    table,
-    table-cell,
-    table-row
-  );
+// Display values
+$display-values: (
+  block,
+  flex,
+  none,
+  inline,
+  inline-block,
+  inline-flex,
+  table,
+  table-cell,
+  table-row
+);
 
-  // Opacity scale
-  $opacity-values: (0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100);
+// Opacity scale
+$opacity-values: (0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100);
 
-  // Z-index scale
-  $zindex-values: (
-    "auto": auto,
-    "bottom": -100,
-    "top": 99999,
-    "0": 0,
-    "100": 100,
-    "200": 200,
-    "300": 300,
-    "400": 400,
-    "500": 500,
-  );
+// Z-index scale
+$zindex-values: (
+  "auto": auto,
+  "bottom": -100,
+  "top": 99999,
+  "0": 0,
+  "100": 100,
+  "200": 200,
+  "300": 300,
+  "400": 400,
+  "500": 500,
+);
 
-  // Flex column values (1-12)
-  $flex-columns: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+// Flex column values (1-12)
+$flex-columns: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
 
-  // Order values
-  $order-values: (
-    "first": -1,
-    "last": 999,
-    "initial": 0,
-    "0": 0,
-    "1": 1,
-    "2": 2,
-    "3": 3,
-    "4": 4,
-    "5": 5,
-    "6": 6,
-    "7": 7,
-    "8": 8,
-    "9": 9,
-    "10": 10,
-    "11": 11,
-  );
+// Order values
+$order-values: (
+  "first": -1,
+  "last": 999,
+  "initial": 0,
+  "0": 0,
+  "1": 1,
+  "2": 2,
+  "3": 3,
+  "4": 4,
+  "5": 5,
+  "6": 6,
+  "7": 7,
+  "8": 8,
+  "9": 9,
+  "10": 10,
+  "11": 11,
+);
 
-  // Float values
-  $float-values: (left, right, none);
+// Float values
+$float-values: (left, right, none);
 
-  // Overflow values
-  $overflow-values: (auto, hidden, scroll, visible);
+// Overflow values
+$overflow-values: (auto, hidden, scroll, visible);
 
-  // Position values
-  $position-values: (absolute, fixed, relative, static, sticky);
+// Position values
+$position-values: (absolute, fixed, relative, static, sticky);
 
-  // Spacing direction mappings (used by margin and padding)
-  $directions: (
-    "x": (
-      left,
-      right,
-    ),
-    "y": (
-      top,
-      bottom,
-    ),
-    "t": (
-      top,
-    ),
-    "r": (
-      right,
-    ),
-    "b": (
-      bottom,
-    ),
-    "l": (
-      left,
-    ),
-  );
-}
+// Spacing direction mappings (used by margin and padding)
+$directions: (
+  "x": (
+    left,
+    right,
+  ),
+  "y": (
+    top,
+    bottom,
+  ),
+  "t": (
+    top,
+  ),
+  "r": (
+    right,
+  ),
+  "b": (
+    bottom,
+  ),
+  "l": (
+    left,
+  ),
+);

--- a/packages/styles/src/utilities/_display.scss
+++ b/packages/styles/src/utilities/_display.scss
@@ -6,17 +6,19 @@
 @use "config" as *;
 @use "mixins" as *;
 
-@each $value in $display-values {
-  @include base-class("nys-display-#{$value}") {
-    display: $value;
+@layer nysds.utilities {
+  @each $value in $display-values {
+    @include base-class("nys-display-#{$value}") {
+      display: $value;
+    }
   }
-}
 
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $value in $display-values {
-      @include responsive-variants($bp-name, "nys-display-#{$value}") {
-        display: $value;
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $value in $display-values {
+        @include responsive-variants($bp-name, "nys-display-#{$value}") {
+          display: $value;
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_flex.scss
+++ b/packages/styles/src/utilities/_flex.scss
@@ -6,226 +6,231 @@
 @use "config" as *;
 @use "mixins" as *;
 
-// ── BASE CLASSES ───────────────────────────────────────
-// Flex column sizes (1-12)
-@each $i in $flex-columns {
-  @include base-class("nys-flex-#{$i}") {
-    flex: $i;
+@layer nysds.utilities {
+  // ── BASE CLASSES ───────────────────────────────────────
+  // Flex column sizes (1-12)
+  @each $i in $flex-columns {
+    @include base-class("nys-flex-#{$i}") {
+      flex: $i;
+    }
   }
-}
 
-// Flex auto and fill
-@include base-class("nys-flex-auto") {
-  flex: auto;
-}
-
-@include base-class("nys-flex-fill") {
-  flex: 1 1 0%;
-}
-
-// Flex direction
-@include base-class("nys-flex-column") {
-  flex-direction: column;
-}
-
-@include base-class("nys-flex-row") {
-  flex-direction: row;
-}
-
-// Flex wrap
-@include base-class("nys-flex-wrap") {
-  flex-wrap: wrap;
-}
-
-@include base-class("nys-flex-no-wrap") {
-  flex-wrap: nowrap;
-}
-
-// Align items
-$flex-align-values: (start, end, center, stretch, baseline);
-
-@each $value in $flex-align-values {
-  @include base-class("nys-flex-align-#{$value}") {
-    align-items: if(
-      sass($value == "start" or $value == "end"): flex-#{$value}; else: $value
-    );
+  // Flex auto and fill
+  @include base-class("nys-flex-auto") {
+    flex: auto;
   }
-}
 
-// Align self
-@each $value in $flex-align-values {
-  @include base-class("nys-flex-align-self-#{$value}") {
-    align-self: if(
-      sass($value == "start" or $value == "end"): flex-#{$value}; else: $value
-    );
+  @include base-class("nys-flex-fill") {
+    flex: 1 1 0%;
   }
-}
 
-// Justify content
-@include base-class("nys-flex-justify-start") {
-  justify-content: flex-start;
-}
-
-@include base-class("nys-flex-justify-center") {
-  justify-content: center;
-}
-
-@include base-class("nys-flex-justify-end") {
-  justify-content: flex-end;
-}
-
-@include base-class("nys-flex-justify-space-between") {
-  justify-content: space-between;
-}
-
-@include base-class("nys-flex-justify-space-around") {
-  justify-content: space-around;
-}
-
-@include base-class("nys-flex-justify-space-evenly") {
-  justify-content: space-evenly;
-}
-
-// Flex gap
-$flex-gap-tokens: (
-  1px,
-  2px,
-  50,
-  100,
-  150,
-  200,
-  250,
-  300,
-  400,
-  500,
-  600,
-  700,
-  800,
-  1200
-);
-
-@each $size in $flex-gap-tokens {
-  @include base-class("nys-flex-gap-#{$size}") {
-    gap: var(--nys-space-#{$size});
+  // Flex direction
+  @include base-class("nys-flex-column") {
+    flex-direction: column;
   }
-}
 
-// Flex gap — row/column splits
-@each $size in $flex-gap-tokens {
-  @include base-class("nys-flex-row-gap-#{$size}") {
-    row-gap: var(--nys-space-#{$size});
+  @include base-class("nys-flex-row") {
+    flex-direction: row;
   }
-}
 
-@each $size in $flex-gap-tokens {
-  @include base-class("nys-flex-column-gap-#{$size}") {
-    column-gap: var(--nys-space-#{$size});
+  // Flex wrap
+  @include base-class("nys-flex-wrap") {
+    flex-wrap: wrap;
   }
-}
 
-// ── RESPONSIVE VARIANTS ────────────────────────────────
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    // Flex column sizes (1-12)
-    @each $i in $flex-columns {
-      @include responsive-variants($bp-name, "nys-flex-#{$i}") {
-        flex: $i;
-      }
+  @include base-class("nys-flex-no-wrap") {
+    flex-wrap: nowrap;
+  }
+
+  // Align items
+  $flex-align-values: (start, end, center, stretch, baseline);
+
+  @each $value in $flex-align-values {
+    @include base-class("nys-flex-align-#{$value}") {
+      align-items: if(
+        sass($value == "start" or $value == "end"): flex-#{$value}; else: $value
+      );
     }
+  }
 
-    // Flex auto and fill
-    @include responsive-variants($bp-name, "nys-flex-auto") {
-      flex: auto;
+  // Align self
+  @each $value in $flex-align-values {
+    @include base-class("nys-flex-align-self-#{$value}") {
+      align-self: if(
+        sass($value == "start" or $value == "end"): flex-#{$value}; else: $value
+      );
     }
+  }
 
-    @include responsive-variants($bp-name, "nys-flex-fill") {
-      flex: 1 1 0%;
+  // Justify content
+  @include base-class("nys-flex-justify-start") {
+    justify-content: flex-start;
+  }
+
+  @include base-class("nys-flex-justify-center") {
+    justify-content: center;
+  }
+
+  @include base-class("nys-flex-justify-end") {
+    justify-content: flex-end;
+  }
+
+  @include base-class("nys-flex-justify-space-between") {
+    justify-content: space-between;
+  }
+
+  @include base-class("nys-flex-justify-space-around") {
+    justify-content: space-around;
+  }
+
+  @include base-class("nys-flex-justify-space-evenly") {
+    justify-content: space-evenly;
+  }
+
+  // Flex gap
+  $flex-gap-tokens: (
+    1px,
+    2px,
+    50,
+    100,
+    150,
+    200,
+    250,
+    300,
+    400,
+    500,
+    600,
+    700,
+    800,
+    1200
+  );
+
+  @each $size in $flex-gap-tokens {
+    @include base-class("nys-flex-gap-#{$size}") {
+      gap: var(--nys-space-#{$size});
     }
+  }
 
-    // Flex direction
-    @include responsive-variants($bp-name, "nys-flex-column") {
-      flex-direction: column;
+  // Flex gap — row/column splits
+  @each $size in $flex-gap-tokens {
+    @include base-class("nys-flex-row-gap-#{$size}") {
+      row-gap: var(--nys-space-#{$size});
     }
+  }
 
-    @include responsive-variants($bp-name, "nys-flex-row") {
-      flex-direction: row;
+  @each $size in $flex-gap-tokens {
+    @include base-class("nys-flex-column-gap-#{$size}") {
+      column-gap: var(--nys-space-#{$size});
     }
+  }
 
-    // Flex wrap
-    @include responsive-variants($bp-name, "nys-flex-wrap") {
-      flex-wrap: wrap;
-    }
-
-    @include responsive-variants($bp-name, "nys-flex-no-wrap") {
-      flex-wrap: nowrap;
-    }
-
-    // Align items
-    @each $value in $flex-align-values {
-      @include responsive-variants($bp-name, "nys-flex-align-#{$value}") {
-        $computed: $value;
-
-        @if $value == "start" or $value == "end" {
-          $computed: flex-#{$value};
+  // ── RESPONSIVE VARIANTS ────────────────────────────────
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      // Flex column sizes (1-12)
+      @each $i in $flex-columns {
+        @include responsive-variants($bp-name, "nys-flex-#{$i}") {
+          flex: $i;
         }
-        align-items: $computed;
       }
-    }
 
-    // Align self
-    @each $value in $flex-align-values {
-      @include responsive-variants($bp-name, "nys-flex-align-self-#{$value}") {
-        $computed: $value;
+      // Flex auto and fill
+      @include responsive-variants($bp-name, "nys-flex-auto") {
+        flex: auto;
+      }
 
-        @if $value == "start" or $value == "end" {
-          $computed: flex-#{$value};
+      @include responsive-variants($bp-name, "nys-flex-fill") {
+        flex: 1 1 0%;
+      }
+
+      // Flex direction
+      @include responsive-variants($bp-name, "nys-flex-column") {
+        flex-direction: column;
+      }
+
+      @include responsive-variants($bp-name, "nys-flex-row") {
+        flex-direction: row;
+      }
+
+      // Flex wrap
+      @include responsive-variants($bp-name, "nys-flex-wrap") {
+        flex-wrap: wrap;
+      }
+
+      @include responsive-variants($bp-name, "nys-flex-no-wrap") {
+        flex-wrap: nowrap;
+      }
+
+      // Align items
+      @each $value in $flex-align-values {
+        @include responsive-variants($bp-name, "nys-flex-align-#{$value}") {
+          $computed: $value;
+
+          @if $value == "start" or $value == "end" {
+            $computed: flex-#{$value};
+          }
+          align-items: $computed;
         }
-        align-self: $computed;
       }
-    }
 
-    // Justify content
-    @include responsive-variants($bp-name, "nys-flex-justify-start") {
-      justify-content: flex-start;
-    }
+      // Align self
+      @each $value in $flex-align-values {
+        @include responsive-variants(
+          $bp-name,
+          "nys-flex-align-self-#{$value}"
+        ) {
+          $computed: $value;
 
-    @include responsive-variants($bp-name, "nys-flex-justify-center") {
-      justify-content: center;
-    }
-
-    @include responsive-variants($bp-name, "nys-flex-justify-end") {
-      justify-content: flex-end;
-    }
-
-    @include responsive-variants($bp-name, "nys-flex-justify-space-between") {
-      justify-content: space-between;
-    }
-
-    @include responsive-variants($bp-name, "nys-flex-justify-space-around") {
-      justify-content: space-around;
-    }
-
-    @include responsive-variants($bp-name, "nys-flex-justify-space-evenly") {
-      justify-content: space-evenly;
-    }
-
-    // Flex gap
-    @each $size in $flex-gap-tokens {
-      @include responsive-variants($bp-name, "nys-flex-gap-#{$size}") {
-        gap: var(--nys-space-#{$size});
+          @if $value == "start" or $value == "end" {
+            $computed: flex-#{$value};
+          }
+          align-self: $computed;
+        }
       }
-    }
 
-    // Flex gap — row/column splits
-    @each $size in $flex-gap-tokens {
-      @include responsive-variants($bp-name, "nys-flex-row-gap-#{$size}") {
-        row-gap: var(--nys-space-#{$size});
+      // Justify content
+      @include responsive-variants($bp-name, "nys-flex-justify-start") {
+        justify-content: flex-start;
       }
-    }
 
-    @each $size in $flex-gap-tokens {
-      @include responsive-variants($bp-name, "nys-flex-column-gap-#{$size}") {
-        column-gap: var(--nys-space-#{$size});
+      @include responsive-variants($bp-name, "nys-flex-justify-center") {
+        justify-content: center;
+      }
+
+      @include responsive-variants($bp-name, "nys-flex-justify-end") {
+        justify-content: flex-end;
+      }
+
+      @include responsive-variants($bp-name, "nys-flex-justify-space-between") {
+        justify-content: space-between;
+      }
+
+      @include responsive-variants($bp-name, "nys-flex-justify-space-around") {
+        justify-content: space-around;
+      }
+
+      @include responsive-variants($bp-name, "nys-flex-justify-space-evenly") {
+        justify-content: space-evenly;
+      }
+
+      // Flex gap
+      @each $size in $flex-gap-tokens {
+        @include responsive-variants($bp-name, "nys-flex-gap-#{$size}") {
+          gap: var(--nys-space-#{$size});
+        }
+      }
+
+      // Flex gap — row/column splits
+      @each $size in $flex-gap-tokens {
+        @include responsive-variants($bp-name, "nys-flex-row-gap-#{$size}") {
+          row-gap: var(--nys-space-#{$size});
+        }
+      }
+
+      @each $size in $flex-gap-tokens {
+        @include responsive-variants($bp-name, "nys-flex-column-gap-#{$size}") {
+          column-gap: var(--nys-space-#{$size});
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_float.scss
+++ b/packages/styles/src/utilities/_float.scss
@@ -6,17 +6,19 @@
 @use "config" as *;
 @use "mixins" as *;
 
-@each $value in $float-values {
-  @include base-class("nys-float-#{$value}") {
-    float: $value;
+@layer nysds.utilities {
+  @each $value in $float-values {
+    @include base-class("nys-float-#{$value}") {
+      float: $value;
+    }
   }
-}
 
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $value in $float-values {
-      @include responsive-variants($bp-name, "nys-float-#{$value}") {
-        float: $value;
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $value in $float-values {
+        @include responsive-variants($bp-name, "nys-float-#{$value}") {
+          float: $value;
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_layout-grid.scss
+++ b/packages/styles/src/utilities/_layout-grid.scss
@@ -6,159 +6,97 @@
 @use "sass:math";
 @use "config" as *;
 
-// ============================================
-// BASE COLUMN STYLES (attribute selector)
-// ============================================
-[class*="nys-grid-col"] {
-  position: relative;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-// ============================================
-// GRID CONTAINERS
-// ============================================
-@each $suffix, $max-width in $grid-containers {
-  .nys-grid-container#{$suffix} {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: $max-width;
-    padding-left: 1rem;
-    padding-right: 1rem;
-
-    @media all and (width >= 64em) {
-      padding-left: 2rem;
-      padding-right: 2rem;
-    }
-  }
-}
-
-// Responsive container variants (with nested media queries for padding)
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $suffix, $max-width in $grid-containers {
-      .nys-#{$bp-name}\:nys-grid-container#{$suffix} {
-        margin-left: auto;
-        margin-right: auto;
-        max-width: $max-width;
-        padding-left: 1rem;
-        padding-right: 1rem;
-      }
-    }
+@layer nysds.utilities {
+  // ============================================
+  // BASE COLUMN STYLES (attribute selector)
+  // ============================================
+  [class*="nys-grid-col"] {
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
   }
 
-  // Nested media query for desktop+ padding
-  @media all and (min-width: #{$bp-value}) and (width >= 64em) {
-    @each $suffix, $max-width in $grid-containers {
-      .nys-#{$bp-name}\:nys-grid-container#{$suffix} {
+  // ============================================
+  // GRID CONTAINERS
+  // ============================================
+  @each $suffix, $max-width in $grid-containers {
+    .nys-grid-container#{$suffix} {
+      margin-left: auto;
+      margin-right: auto;
+      max-width: $max-width;
+      padding-left: 1rem;
+      padding-right: 1rem;
+
+      @media all and (width >= 64em) {
         padding-left: 2rem;
         padding-right: 2rem;
       }
     }
   }
-}
 
-// ============================================
-// GRID ROW
-// ============================================
-.nys-grid-row {
-  display: flex;
-  flex-wrap: wrap;
-}
+  // Responsive container variants (with nested media queries for padding)
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $suffix, $max-width in $grid-containers {
+        .nys-#{$bp-name}\:nys-grid-container#{$suffix} {
+          margin-left: auto;
+          margin-right: auto;
+          max-width: $max-width;
+          padding-left: 1rem;
+          padding-right: 1rem;
+        }
+      }
+    }
 
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    .nys-#{$bp-name}\:nys-grid-row {
-      display: flex;
-      flex-wrap: wrap;
+    // Nested media query for desktop+ padding
+    @media all and (min-width: #{$bp-value}) and (width >= 64em) {
+      @each $suffix, $max-width in $grid-containers {
+        .nys-#{$bp-name}\:nys-grid-container#{$suffix} {
+          padding-left: 2rem;
+          padding-right: 2rem;
+        }
+      }
     }
   }
-}
 
-// ============================================
-// GRID GAPS
-// Both horizontal and vertical gaps use the negative-margin + child-padding pattern.
-// Horizontal: negative left/right margin on row + left/right padding on children.
-// Vertical: negative top margin on row + top padding on children.
-// This avoids native gap properties which interfere with flex column width math.
-// ============================================
-
-// Default gap (responsive: 0.5rem base, 1rem at 64em+)
-
-// Horizontal only
-.nys-grid-row.nys-grid-gap-x {
-  margin-left: -0.5rem;
-  margin-right: -0.5rem;
-
-  > * {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+  // ============================================
+  // GRID ROW
+  // ============================================
+  .nys-grid-row {
+    display: flex;
+    flex-wrap: wrap;
   }
 
-  @media all and (width >= 64em) {
-    margin-left: -1rem;
-    margin-right: -1rem;
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      .nys-#{$bp-name}\:nys-grid-row {
+        display: flex;
+        flex-wrap: wrap;
+      }
+    }
+  }
+
+  // ============================================
+  // GRID GAPS
+  // Both horizontal and vertical gaps use the negative-margin + child-padding pattern.
+  // Horizontal: negative left/right margin on row + left/right padding on children.
+  // Vertical: negative top margin on row + top padding on children.
+  // This avoids native gap properties which interfere with flex column width math.
+  // ============================================
+
+  // Default gap (responsive: 0.5rem base, 1rem at 64em+)
+
+  // Horizontal only
+  .nys-grid-row.nys-grid-gap-x {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
 
     > * {
-      padding-left: 1rem;
-      padding-right: 1rem;
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
     }
-  }
-}
 
-// Vertical only
-.nys-grid-row.nys-grid-gap-y {
-  margin-top: -0.5rem;
-  margin-bottom: -0.5rem;
-
-  > * {
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-  }
-
-  @media all and (width >= 64em) {
-    margin-top: -1rem;
-    margin-bottom: -1rem;
-
-    > * {
-      padding-top: 1rem;
-      padding-bottom: 1rem;
-    }
-  }
-}
-
-// Both horizontal + vertical
-.nys-grid-row.nys-grid-gap {
-  margin: -0.5rem;
-
-  > * {
-    padding: 0.5rem;
-  }
-
-  @media all and (width >= 64em) {
-    margin: -1rem;
-
-    > * {
-      padding: 1rem;
-    }
-  }
-}
-
-// Sized gaps (compound selectors)
-// Horizontal gap values are halved: negative margin on row + padding on children.
-// Gaps 400+ exceed small-viewport container padding (1rem), so horizontal is capped below 64em.
-// Vertical gaps are also capped at 2rem on small screens for consistent sizing.
-$responsive-gap-suffixes: ("400", "500", "600", "700", "800", "1200");
-
-@each $suffix, $value in $spacing {
-  $half: if(sass($value == 0): 0; else: math.div($value, 2));
-  $needs-responsive: index($responsive-gap-suffixes, $suffix) != null;
-
-  @if $needs-responsive {
-    // On small screens: cap horizontal at -1rem (matches container padding, prevents overflow).
-    // On small screens: cap vertical at 2rem for proportional sizing.
-    // On large screens (64em+): use full values.
-    .nys-grid-row.nys-grid-gap-x-#{$suffix} {
+    @media all and (width >= 64em) {
       margin-left: -1rem;
       margin-right: -1rem;
 
@@ -166,19 +104,20 @@ $responsive-gap-suffixes: ("400", "500", "600", "700", "800", "1200");
         padding-left: 1rem;
         padding-right: 1rem;
       }
+    }
+  }
 
-      @media all and (width >= 64em) {
-        margin-left: -$half;
-        margin-right: -$half;
+  // Vertical only
+  .nys-grid-row.nys-grid-gap-y {
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem;
 
-        > * {
-          padding-left: $half;
-          padding-right: $half;
-        }
-      }
+    > * {
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
     }
 
-    .nys-grid-row.nys-grid-gap-y-#{$suffix} {
+    @media all and (width >= 64em) {
       margin-top: -1rem;
       margin-bottom: -1rem;
 
@@ -186,129 +125,50 @@ $responsive-gap-suffixes: ("400", "500", "600", "700", "800", "1200");
         padding-top: 1rem;
         padding-bottom: 1rem;
       }
+    }
+  }
 
-      @media all and (width >= 64em) {
-        margin-top: -$half;
-        margin-bottom: -$half;
+  // Both horizontal + vertical
+  .nys-grid-row.nys-grid-gap {
+    margin: -0.5rem;
 
-        > * {
-          padding-top: $half;
-          padding-bottom: $half;
-        }
-      }
+    > * {
+      padding: 0.5rem;
     }
 
-    .nys-grid-row.nys-grid-gap-#{$suffix} {
+    @media all and (width >= 64em) {
       margin: -1rem;
 
       > * {
         padding: 1rem;
       }
-
-      @media all and (width >= 64em) {
-        margin: -$half;
-
-        > * {
-          padding: $half;
-        }
-      }
-    }
-  } @else {
-    .nys-grid-row.nys-grid-gap-x-#{$suffix} {
-      margin-left: -$half;
-      margin-right: -$half;
-
-      > * {
-        padding-left: $half;
-        padding-right: $half;
-      }
-    }
-
-    .nys-grid-row.nys-grid-gap-y-#{$suffix} {
-      margin-top: -$half;
-      margin-bottom: -$half;
-
-      > * {
-        padding-top: $half;
-        padding-bottom: $half;
-      }
-    }
-
-    .nys-grid-row.nys-grid-gap-#{$suffix} {
-      margin: -$half;
-
-      > * {
-        padding: $half;
-      }
     }
   }
-}
 
-// Responsive gap variants
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $suffix, $value in $spacing {
-      $half: if(sass($value == 0): 0; else: math.div($value, 2));
-      $needs-responsive: index($responsive-gap-suffixes, $suffix) != null;
+  // Sized gaps (compound selectors)
+  // Horizontal gap values are halved: negative margin on row + padding on children.
+  // Gaps 400+ exceed small-viewport container padding (1rem), so horizontal is capped below 64em.
+  // Vertical gaps are also capped at 2rem on small screens for consistent sizing.
+  $responsive-gap-suffixes: ("400", "500", "600", "700", "800", "1200");
 
-      @if $needs-responsive {
-        .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-x-#{$suffix} {
-          margin-left: -1rem;
-          margin-right: -1rem;
+  @each $suffix, $value in $spacing {
+    $half: if(sass($value == 0): 0; else: math.div($value, 2));
+    $needs-responsive: index($responsive-gap-suffixes, $suffix) != null;
 
-          > * {
-            padding-left: 1rem;
-            padding-right: 1rem;
-          }
+    @if $needs-responsive {
+      // On small screens: cap horizontal at -1rem (matches container padding, prevents overflow).
+      // On small screens: cap vertical at 2rem for proportional sizing.
+      // On large screens (64em+): use full values.
+      .nys-grid-row.nys-grid-gap-x-#{$suffix} {
+        margin-left: -1rem;
+        margin-right: -1rem;
 
-          @media all and (width >= 64em) {
-            margin-left: -$half;
-            margin-right: -$half;
-
-            > * {
-              padding-left: $half;
-              padding-right: $half;
-            }
-          }
+        > * {
+          padding-left: 1rem;
+          padding-right: 1rem;
         }
 
-        .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-y-#{$suffix} {
-          margin-top: -1rem;
-          margin-bottom: -1rem;
-
-          > * {
-            padding-top: 1rem;
-            padding-bottom: 1rem;
-          }
-
-          @media all and (width >= 64em) {
-            margin-top: -$half;
-            margin-bottom: -$half;
-
-            > * {
-              padding-top: $half;
-              padding-bottom: $half;
-            }
-          }
-        }
-
-        .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-#{$suffix} {
-          margin: -1rem;
-
-          > * {
-            padding: 1rem;
-          }
-
-          @media all and (width >= 64em) {
-            margin: -$half;
-
-            > * {
-              padding: $half;
-            }
-          }
-        }
-      } @else {
-        .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-x-#{$suffix} {
+        @media all and (width >= 64em) {
           margin-left: -$half;
           margin-right: -$half;
 
@@ -317,8 +177,18 @@ $responsive-gap-suffixes: ("400", "500", "600", "700", "800", "1200");
             padding-right: $half;
           }
         }
+      }
 
-        .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-y-#{$suffix} {
+      .nys-grid-row.nys-grid-gap-y-#{$suffix} {
+        margin-top: -1rem;
+        margin-bottom: -1rem;
+
+        > * {
+          padding-top: 1rem;
+          padding-bottom: 1rem;
+        }
+
+        @media all and (width >= 64em) {
           margin-top: -$half;
           margin-bottom: -$half;
 
@@ -327,8 +197,16 @@ $responsive-gap-suffixes: ("400", "500", "600", "700", "800", "1200");
             padding-bottom: $half;
           }
         }
+      }
 
-        .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-#{$suffix} {
+      .nys-grid-row.nys-grid-gap-#{$suffix} {
+        margin: -1rem;
+
+        > * {
+          padding: 1rem;
+        }
+
+        @media all and (width >= 64em) {
           margin: -$half;
 
           > * {
@@ -336,98 +214,222 @@ $responsive-gap-suffixes: ("400", "500", "600", "700", "800", "1200");
           }
         }
       }
-    }
-  }
-}
+    } @else {
+      .nys-grid-row.nys-grid-gap-x-#{$suffix} {
+        margin-left: -$half;
+        margin-right: -$half;
 
-// ============================================
-// GRID COLUMNS
-// ============================================
+        > * {
+          padding-left: $half;
+          padding-right: $half;
+        }
+      }
 
-// Numbered columns (1-12) - use math.percentage for exact parity
-@for $i from 1 through 12 {
-  .nys-grid-col-#{$i} {
-    flex: 0 1 auto;
-    width: math.percentage(math.div($i, 12));
-  }
-}
+      .nys-grid-row.nys-grid-gap-y-#{$suffix} {
+        margin-top: -$half;
+        margin-bottom: -$half;
 
-.nys-grid-col {
-  flex: 1 1 0%;
-  width: auto;
-  max-width: 100%;
-  min-width: 1px;
-}
+        > * {
+          padding-top: $half;
+          padding-bottom: $half;
+        }
+      }
 
-.nys-grid-col-auto {
-  flex: 0 1 auto;
-  width: auto;
-  max-width: 100%;
-}
+      .nys-grid-row.nys-grid-gap-#{$suffix} {
+        margin: -$half;
 
-.nys-grid-col-fill {
-  flex: 1 1 0%;
-  width: auto;
-  max-width: 100%;
-  min-width: 1px;
-}
-
-// Responsive column variants
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @for $i from 1 through 12 {
-      .nys-#{$bp-name}\:nys-grid-col-#{$i} {
-        flex: 0 1 auto;
-        width: math.percentage(math.div($i, 12));
+        > * {
+          padding: $half;
+        }
       }
     }
+  }
 
-    .nys-#{$bp-name}\:nys-grid-col {
-      flex: 1 1 0%;
-      width: auto;
-      max-width: 100%;
-      min-width: 1px;
+  // Responsive gap variants
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $suffix, $value in $spacing {
+        $half: if(sass($value == 0): 0; else: math.div($value, 2));
+        $needs-responsive: index($responsive-gap-suffixes, $suffix) != null;
+
+        @if $needs-responsive {
+          .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-x-#{$suffix} {
+            margin-left: -1rem;
+            margin-right: -1rem;
+
+            > * {
+              padding-left: 1rem;
+              padding-right: 1rem;
+            }
+
+            @media all and (width >= 64em) {
+              margin-left: -$half;
+              margin-right: -$half;
+
+              > * {
+                padding-left: $half;
+                padding-right: $half;
+              }
+            }
+          }
+
+          .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-y-#{$suffix} {
+            margin-top: -1rem;
+            margin-bottom: -1rem;
+
+            > * {
+              padding-top: 1rem;
+              padding-bottom: 1rem;
+            }
+
+            @media all and (width >= 64em) {
+              margin-top: -$half;
+              margin-bottom: -$half;
+
+              > * {
+                padding-top: $half;
+                padding-bottom: $half;
+              }
+            }
+          }
+
+          .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-#{$suffix} {
+            margin: -1rem;
+
+            > * {
+              padding: 1rem;
+            }
+
+            @media all and (width >= 64em) {
+              margin: -$half;
+
+              > * {
+                padding: $half;
+              }
+            }
+          }
+        } @else {
+          .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-x-#{$suffix} {
+            margin-left: -$half;
+            margin-right: -$half;
+
+            > * {
+              padding-left: $half;
+              padding-right: $half;
+            }
+          }
+
+          .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-y-#{$suffix} {
+            margin-top: -$half;
+            margin-bottom: -$half;
+
+            > * {
+              padding-top: $half;
+              padding-bottom: $half;
+            }
+          }
+
+          .nys-grid-row.nys-#{$bp-name}\:nys-grid-gap-#{$suffix} {
+            margin: -$half;
+
+            > * {
+              padding: $half;
+            }
+          }
+        }
+      }
     }
+  }
 
-    .nys-#{$bp-name}\:nys-grid-col-auto {
+  // ============================================
+  // GRID COLUMNS
+  // ============================================
+
+  // Numbered columns (1-12) - use math.percentage for exact parity
+  @for $i from 1 through 12 {
+    .nys-grid-col-#{$i} {
       flex: 0 1 auto;
-      width: auto;
-      max-width: 100%;
-    }
-
-    .nys-#{$bp-name}\:nys-grid-col-fill {
-      flex: 1 1 0%;
-      width: auto;
-      max-width: 100%;
-      min-width: 1px;
+      width: math.percentage(math.div($i, 12));
     }
   }
-}
 
-// ============================================
-// GRID OFFSETS
-// ============================================
-@for $i from 1 through 12 {
-  .nys-grid-offset-#{$i} {
-    margin-left: math.percentage(math.div($i, 12));
+  .nys-grid-col {
+    flex: 1 1 0%;
+    width: auto;
+    max-width: 100%;
+    min-width: 1px;
   }
-}
 
-.nys-grid-offset-none {
-  margin-left: 0;
-}
+  .nys-grid-col-auto {
+    flex: 0 1 auto;
+    width: auto;
+    max-width: 100%;
+  }
 
-// Responsive offset variants
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @for $i from 1 through 12 {
-      .nys-#{$bp-name}\:nys-grid-offset-#{$i} {
-        margin-left: math.percentage(math.div($i, 12));
+  .nys-grid-col-fill {
+    flex: 1 1 0%;
+    width: auto;
+    max-width: 100%;
+    min-width: 1px;
+  }
+
+  // Responsive column variants
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @for $i from 1 through 12 {
+        .nys-#{$bp-name}\:nys-grid-col-#{$i} {
+          flex: 0 1 auto;
+          width: math.percentage(math.div($i, 12));
+        }
+      }
+
+      .nys-#{$bp-name}\:nys-grid-col {
+        flex: 1 1 0%;
+        width: auto;
+        max-width: 100%;
+        min-width: 1px;
+      }
+
+      .nys-#{$bp-name}\:nys-grid-col-auto {
+        flex: 0 1 auto;
+        width: auto;
+        max-width: 100%;
+      }
+
+      .nys-#{$bp-name}\:nys-grid-col-fill {
+        flex: 1 1 0%;
+        width: auto;
+        max-width: 100%;
+        min-width: 1px;
       }
     }
+  }
 
-    .nys-#{$bp-name}\:nys-grid-offset-none {
-      margin-left: 0;
+  // ============================================
+  // GRID OFFSETS
+  // ============================================
+  @for $i from 1 through 12 {
+    .nys-grid-offset-#{$i} {
+      margin-left: math.percentage(math.div($i, 12));
+    }
+  }
+
+  .nys-grid-offset-none {
+    margin-left: 0;
+  }
+
+  // Responsive offset variants
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @for $i from 1 through 12 {
+        .nys-#{$bp-name}\:nys-grid-offset-#{$i} {
+          margin-left: math.percentage(math.div($i, 12));
+        }
+      }
+
+      .nys-#{$bp-name}\:nys-grid-offset-none {
+        margin-left: 0;
+      }
     }
   }
 }

--- a/packages/styles/src/utilities/_margin.scss
+++ b/packages/styles/src/utilities/_margin.scss
@@ -5,19 +5,21 @@
 
 @use "config" as *;
 
-// Uniform margins
-@each $name, $value in $spacing {
-  .nys-margin-#{$name} {
-    margin: $value;
+@layer nysds.utilities {
+  // Uniform margins
+  @each $name, $value in $spacing {
+    .nys-margin-#{$name} {
+      margin: $value;
+    }
   }
-}
 
-// Directional margins
-@each $name, $value in $spacing {
-  @each $dir-name, $props in $directions {
-    .nys-margin-#{$dir-name}-#{$name} {
-      @each $prop in $props {
-        margin-#{$prop}: $value;
+  // Directional margins
+  @each $name, $value in $spacing {
+    @each $dir-name, $props in $directions {
+      .nys-margin-#{$dir-name}-#{$name} {
+        @each $prop in $props {
+          margin-#{$prop}: $value;
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_opacity.scss
+++ b/packages/styles/src/utilities/_opacity.scss
@@ -7,19 +7,21 @@
 @use "config" as *;
 @use "mixins" as *;
 
-@each $value in $opacity-values {
-  @include base-class("nys-opacity-#{$value}") {
-    // stylelint-disable-next-line alpha-value-notation
-    opacity: math.div($value, 100);
+@layer nysds.utilities {
+  @each $value in $opacity-values {
+    @include base-class("nys-opacity-#{$value}") {
+      // stylelint-disable-next-line alpha-value-notation
+      opacity: math.div($value, 100);
+    }
   }
-}
 
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $value in $opacity-values {
-      @include responsive-variants($bp-name, "nys-opacity-#{$value}") {
-        // stylelint-disable-next-line alpha-value-notation
-        opacity: math.div($value, 100);
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $value in $opacity-values {
+        @include responsive-variants($bp-name, "nys-opacity-#{$value}") {
+          // stylelint-disable-next-line alpha-value-notation
+          opacity: math.div($value, 100);
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_order.scss
+++ b/packages/styles/src/utilities/_order.scss
@@ -6,17 +6,19 @@
 @use "config" as *;
 @use "mixins" as *;
 
-@each $name, $value in $order-values {
-  @include base-class("nys-order-#{$name}") {
-    order: $value;
+@layer nysds.utilities {
+  @each $name, $value in $order-values {
+    @include base-class("nys-order-#{$name}") {
+      order: $value;
+    }
   }
-}
 
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $name, $value in $order-values {
-      @include responsive-variants($bp-name, "nys-order-#{$name}") {
-        order: $value;
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $name, $value in $order-values {
+        @include responsive-variants($bp-name, "nys-order-#{$name}") {
+          order: $value;
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_overflow.scss
+++ b/packages/styles/src/utilities/_overflow.scss
@@ -6,44 +6,46 @@
 @use "config" as *;
 @use "mixins" as *;
 
-// Base overflow (all directions)
-@each $value in $overflow-values {
-  @include base-class("nys-overflow-#{$value}") {
-    overflow: $value;
-  }
-}
-
-// Overflow X
-@each $value in $overflow-values {
-  @include base-class("nys-overflow-x-#{$value}") {
-    overflow-x: $value;
-  }
-}
-
-// Overflow Y
-@each $value in $overflow-values {
-  @include base-class("nys-overflow-y-#{$value}") {
-    overflow-y: $value;
-  }
-}
-
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $value in $overflow-values {
-      @include responsive-variants($bp-name, "nys-overflow-#{$value}") {
-        overflow: $value;
-      }
+@layer nysds.utilities {
+  // Base overflow (all directions)
+  @each $value in $overflow-values {
+    @include base-class("nys-overflow-#{$value}") {
+      overflow: $value;
     }
+  }
 
-    @each $value in $overflow-values {
-      @include responsive-variants($bp-name, "nys-overflow-x-#{$value}") {
-        overflow-x: $value;
-      }
+  // Overflow X
+  @each $value in $overflow-values {
+    @include base-class("nys-overflow-x-#{$value}") {
+      overflow-x: $value;
     }
+  }
 
-    @each $value in $overflow-values {
-      @include responsive-variants($bp-name, "nys-overflow-y-#{$value}") {
-        overflow-y: $value;
+  // Overflow Y
+  @each $value in $overflow-values {
+    @include base-class("nys-overflow-y-#{$value}") {
+      overflow-y: $value;
+    }
+  }
+
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $value in $overflow-values {
+        @include responsive-variants($bp-name, "nys-overflow-#{$value}") {
+          overflow: $value;
+        }
+      }
+
+      @each $value in $overflow-values {
+        @include responsive-variants($bp-name, "nys-overflow-x-#{$value}") {
+          overflow-x: $value;
+        }
+      }
+
+      @each $value in $overflow-values {
+        @include responsive-variants($bp-name, "nys-overflow-y-#{$value}") {
+          overflow-y: $value;
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_padding.scss
+++ b/packages/styles/src/utilities/_padding.scss
@@ -5,19 +5,21 @@
 
 @use "config" as *;
 
-// Uniform padding
-@each $name, $value in $spacing {
-  .nys-padding-#{$name} {
-    padding: $value;
+@layer nysds.utilities {
+  // Uniform padding
+  @each $name, $value in $spacing {
+    .nys-padding-#{$name} {
+      padding: $value;
+    }
   }
-}
 
-// Directional padding
-@each $name, $value in $spacing {
-  @each $dir-name, $props in $directions {
-    .nys-padding-#{$dir-name}-#{$name} {
-      @each $prop in $props {
-        padding-#{$prop}: $value;
+  // Directional padding
+  @each $name, $value in $spacing {
+    @each $dir-name, $props in $directions {
+      .nys-padding-#{$dir-name}-#{$name} {
+        @each $prop in $props {
+          padding-#{$prop}: $value;
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_position.scss
+++ b/packages/styles/src/utilities/_position.scss
@@ -6,17 +6,19 @@
 @use "config" as *;
 @use "mixins" as *;
 
-@each $value in $position-values {
-  @include base-class("nys-position-#{$value}") {
-    position: $value;
+@layer nysds.utilities {
+  @each $value in $position-values {
+    @include base-class("nys-position-#{$value}") {
+      position: $value;
+    }
   }
-}
 
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $value in $position-values {
-      @include responsive-variants($bp-name, "nys-position-#{$value}") {
-        position: $value;
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $value in $position-values {
+        @include responsive-variants($bp-name, "nys-position-#{$value}") {
+          position: $value;
+        }
       }
     }
   }

--- a/packages/styles/src/utilities/_zindex.scss
+++ b/packages/styles/src/utilities/_zindex.scss
@@ -1,17 +1,19 @@
 @use "config" as *;
 @use "mixins" as *;
 
-@each $name, $value in $zindex-values {
-  @include base-class("nys-z-#{$name}") {
-    z-index: $value;
+@layer nysds.utilities {
+  @each $name, $value in $zindex-values {
+    @include base-class("nys-z-#{$name}") {
+      z-index: $value;
+    }
   }
-}
 
-@each $bp-name, $bp-value in $breakpoints {
-  @media all and (min-width: #{$bp-value}) {
-    @each $name, $value in $zindex-values {
-      @include responsive-variants($bp-name, "nys-z-#{$name}") {
-        z-index: $value;
+  @each $bp-name, $bp-value in $breakpoints {
+    @media all and (min-width: #{$bp-value}) {
+      @each $name, $value in $zindex-values {
+        @include responsive-variants($bp-name, "nys-z-#{$name}") {
+          z-index: $value;
+        }
       }
     }
   }


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
Add `@layer` cascade hierarchy to global stylesheets so that component-level styles can reliably override base styles without specificity battles or relying on source order.

## Breaking change
Marked as potentially breaking because adding cascade layers changes how styles override each other. App developers may now be able to override reset and base styles by controlling layer order instead of relying on specificity or file order.

**Initial testing did not show issues, but it needs a closer look for edge cases in existing apps.**

:warning: This is **potentially** a breaking change.

<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1616 🎟️
