### PR TITLE
Fix:  set `nys-datepicker` default width to `full`

### DIFF
--- a/packages/nys-datepicker/src/nys-datepicker.mdx
+++ b/packages/nys-datepicker/src/nys-datepicker.mdx
@@ -65,9 +65,9 @@ Form submission sends:
 ### Width 
 Set the `width` prop to adjust the width of `<nys-datepicker>`\
 Supported widths are:
-- `md`: 200px (_default width_)
+- `md`: 200px
 - `lg`: 384px
-- `full`: will take up the full width of the parent container.
+- `full`: will take up the full width of the parent container (_default width_).
 <Canvas of={NysDatepickerStories.WidthVariants} />
 
 

--- a/packages/nys-datepicker/src/nys-datepicker.stories.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.stories.ts
@@ -68,7 +68,7 @@ export const Basic: Story = {
     id: "my-datepicker",
     name: "my-datepicker",
     value: undefined,
-    width: "md",
+    width: "full",
     disabled: false,
     required: false,
     optional: false,

--- a/packages/nys-datepicker/src/nys-datepicker.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.ts
@@ -73,9 +73,10 @@ export class NysDatepicker extends LitElement {
 
   /**
    * Input width: `md` (200px), `lg` (384px), `full` (100%).
-   * @default "md"
+   * @default "full"
    */
-  @property({ type: String, reflect: true }) width: "md" | "lg" | "full" = "md";
+  @property({ type: String, reflect: true }) width: "md" | "lg" | "full" =
+    "full";
 
   /** Hide the "Today" button in calendar popup. */
   @property({ type: Boolean }) hideTodayButton = false;


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Change `nys-datepicker` default width from `md` to `full`

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

⚠️ This is a **breaking** change.  

<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1614 🎟️