### PR TITLE
FIx: Capitalized the "i" from NysTextinput with NysTextInput

### DIFF
--- a/.vscode/vscode.html-custom-data.json
+++ b/.vscode/vscode.html-custom-data.json
@@ -495,7 +495,7 @@
         { "name": "name", "values": [] },
         {
           "name": "type",
-          "values": [{ "name": "(typeof NysTextinput.VALID_TYPES)[number]" }]
+          "values": [{ "name": "(typeof NysTextInput.VALID_TYPES)[number]" }]
         },
         { "name": "label", "values": [] },
         { "name": "description", "values": [] },
@@ -511,7 +511,7 @@
         { "name": "maxlength", "values": [] },
         {
           "name": "width",
-          "values": [{ "name": "(typeof NysTextinput.VALID_WIDTHS)[number]" }]
+          "values": [{ "name": "(typeof NysTextInput.VALID_WIDTHS)[number]" }]
         },
         { "name": "step", "values": [] },
         { "name": "min", "values": [] },

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -12584,7 +12584,7 @@
         {
           "kind": "class",
           "description": "A text input for collecting short, single-line data. Supports validation, input masking (tel),\npassword visibility toggle, and live error messaging. Form-associated via ElementInternals.\n\nUse for names, emails, passwords, phone numbers. For multi-line input, use `nys-textarea` instead.\nFor predefined options, use `nys-select`, `nys-radiobutton`, or `nys-checkbox`.",
-          "name": "NysTextinput",
+          "name": "NysTextInput",
           "slots": [
             {
               "description": "Custom HTML description content below the label.",
@@ -13347,15 +13347,15 @@
           "kind": "custom-element-definition",
           "name": "nys-textinput",
           "declaration": {
-            "name": "NysTextinput",
+            "name": "NysTextInput",
             "module": "packages/nys-textinput/src/nys-textinput.ts"
           }
         },
         {
           "kind": "js",
-          "name": "NysTextinput",
+          "name": "NysTextInput",
           "declaration": {
-            "name": "NysTextinput",
+            "name": "NysTextInput",
             "module": "packages/nys-textinput/src/nys-textinput.ts"
           }
         }

--- a/packages/nys-pagination/src/nys-pagination.test.ts
+++ b/packages/nys-pagination/src/nys-pagination.test.ts
@@ -4,7 +4,7 @@ import { NysPagination } from "./nys-pagination.js";
 
 // You may need to import other dependencies such as the component's tag name
 // For example:
-// import { NysTextinput } from "./nys-textinput";
+// import { NysTextInput } from "./nys-textinput";
 
 // Below are placeholder examples of test cases for a web component. Add your own tests as needed.
 describe("nys-pagination", () => {

--- a/packages/nys-textinput/src/nys-textinput.mdx
+++ b/packages/nys-textinput/src/nys-textinput.mdx
@@ -1,10 +1,10 @@
 import { Meta, Story, Source, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { html } from 'lit';
-import * as NysTextinputStories from './nys-textinput.stories';
+import * as NysTextInputStories from './nys-textinput.stories';
 import "@nysds/nys-icon";
 import '@nysds/nys-badge';
 
-<Meta of={NysTextinputStories} title="Components/Textinput/Documentation" />
+<Meta of={NysTextInputStories} title="Components/Textinput/Documentation" />
 
 
 # Text Input
@@ -24,7 +24,7 @@ The **`nys-textinput`** is a reusable web component for use in New York State di
 
 ***
 
-<Canvas of={NysTextinputStories.Basic} />
+<Canvas of={NysTextInputStories.Basic} />
 
 <Controls />
 
@@ -34,47 +34,47 @@ The **`nys-textinput`** is a reusable web component for use in New York State di
 If no width is provided, the `nys-textinput` will default to `full`. Supported widths are `sm`, `md`, `lg`, and `full`.\
 Width `full` will take up the full width of the parent container.\
 If an invalid option is assigned to `width`, it will be ignored and default to `full`.
-<Canvas of={NysTextinputStories.Width} />
+<Canvas of={NysTextInputStories.Width} />
 ### Different Input Types
 Note: Accepted types are: `text` `email` `number` `password` `search` `tel` `url`. Any other input defaults to `type="text"`\
 Certain types will apply additional styling onto the input field. For `type="password"` the input will be automatically hidden.
 For `type="tel"` an input mask will appear to style the input properly.
-<Canvas of={NysTextinputStories.Password} />
-<Canvas of={NysTextinputStories.Telephone} />
+<Canvas of={NysTextInputStories.Password} />
+<Canvas of={NysTextInputStories.Telephone} />
 ### Values and Placeholders
-<Canvas of={NysTextinputStories.ValueAndPlaceholder} />
+<Canvas of={NysTextInputStories.ValueAndPlaceholder} />
 ### Disabled and Readonly
-<Canvas of={NysTextinputStories.Disabled} />
-<Canvas of={NysTextinputStories.Readonly} />
+<Canvas of={NysTextInputStories.Disabled} />
+<Canvas of={NysTextInputStories.Readonly} />
 ### Max Min and Step
 Note: `max` `min` `step` only apply when `type="number"`
-<Canvas of={NysTextinputStories.MaxMinAndStep} />
+<Canvas of={NysTextInputStories.MaxMinAndStep} />
 ### Maxlength
-<Canvas of={NysTextinputStories.Maxlength} />
+<Canvas of={NysTextInputStories.Maxlength} />
 ### Pattern
 Note: Takes in valid regex
-<Canvas of={NysTextinputStories.Pattern} />
+<Canvas of={NysTextInputStories.Pattern} />
 ### Required
-<Canvas of={NysTextinputStories.Required} />
+<Canvas of={NysTextInputStories.Required} />
 ### Optional
 Adding the `optional` prop will add an optional flag to the input.
-<Canvas of={NysTextinputStories.Optional} />
+<Canvas of={NysTextInputStories.Optional} />
 ### Description Slot
 You can supply a description via our `description` prop for plain text or by embedding HTML within our component via our slot for higher customization.
-<Canvas of={NysTextinputStories.DescriptionSlot} />
+<Canvas of={NysTextInputStories.DescriptionSlot} />
 ### Slotted Button
 Note: You can add a button to the input by adding a `slot="startButton"` or `slot="endButton"`.
 This will add a button to the left or right of the input respectively.\
 Use a `<nys-button>` for the slotted button. Do not use both `startButton` and `endButton` on the same input.\
 The slotted button will automatically be `size="sm"` and `variant="filled"` and support the disabled state of the input.\
 Use `width="lg"` or `width="full"` on `<nys-textinput>` to give users enough space to enter text when a button is present.
-<Canvas of={NysTextinputStories.SlottedButton} />
+<Canvas of={NysTextInputStories.SlottedButton} />
 ### Error Message
 Note: in order to display an error message, you must pass in `hasError` to the component. Setting `errorMessage` does not display the message by default.
-<Canvas of={NysTextinputStories.ErrorMessage} />
+<Canvas of={NysTextInputStories.ErrorMessage} />
 ## Inverted
 Set the `inverted` when the component is on a dark background.
-<Canvas of={NysTextinputStories.Inverted} />
+<Canvas of={NysTextInputStories.Inverted} />
 
 ## Usage
 

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -7,7 +7,7 @@ import "@nysds/nys-button";
 import "@nysds/nys-icon";
 
 // Define the structure of the args used in the stories
-interface NysTextinputArgs {
+interface NysTextInputArgs {
   id: string;
   name: string;
   type: "number" | "text" | "email" | "password" | "search" | "tel" | "url";
@@ -31,7 +31,7 @@ interface NysTextinputArgs {
   errorMessage: string;
 }
 
-const meta: Meta<NysTextinputArgs> = {
+const meta: Meta<NysTextInputArgs> = {
   title: "Components/Textinput",
   component: "nys-textinput",
   argTypes: {
@@ -74,7 +74,7 @@ const meta: Meta<NysTextinputArgs> = {
 };
 
 export default meta;
-type Story = StoryObj<NysTextinputArgs>;
+type Story = StoryObj<NysTextInputArgs>;
 
 // Define stories without using args
 

--- a/packages/nys-textinput/src/nys-textinput.test.ts
+++ b/packages/nys-textinput/src/nys-textinput.test.ts
@@ -1,5 +1,5 @@
 import { expect, html, fixture, oneEvent } from "@open-wc/testing";
-import { NysTextinput } from "./nys-textinput";
+import { NysTextInput } from "./nys-textinput";
 import "../dist/nys-textinput.js";
 import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
@@ -18,7 +18,7 @@ describe("nys-textinput", () => {
   });
 
   it("generates an id if not provided", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     await el.updateComplete;
@@ -66,7 +66,7 @@ describe("nys-textinput", () => {
   });
 
   it("displays a toggle password icon that changes visibility when property type is password", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput type="password"></nys-textinput>`,
     );
     const input = el.shadowRoot?.querySelector("input");
@@ -85,7 +85,7 @@ describe("nys-textinput", () => {
   });
 
   it("displays an error message when required field is empty", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput required></nys-textinput>`,
     );
     const input = el.shadowRoot?.querySelector("input") as HTMLInputElement;
@@ -100,7 +100,7 @@ describe("nys-textinput", () => {
   });
 
   it("validates pattern mismatch", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput pattern="\\d+"></nys-textinput>`,
     );
     const input = el.shadowRoot?.querySelector("input") as HTMLInputElement;
@@ -116,7 +116,7 @@ describe("nys-textinput", () => {
   });
 
   it("falls back to type text type is unset", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     expect(el.type).to.equal("text");
@@ -125,7 +125,7 @@ describe("nys-textinput", () => {
   });
 
   it("falls back to width full if width is unset", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     await el.updateComplete;
@@ -133,7 +133,7 @@ describe("nys-textinput", () => {
   });
 
   it("runs native checkValidity", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     expect(el.checkValidity()).to.be.true;
@@ -144,7 +144,7 @@ describe("nys-textinput", () => {
     const originalWarn = console.warn;
     console.warn = () => {}; // no-op
 
-    const el = await fixture<NysTextinput>(html`
+    const el = await fixture<NysTextInput>(html`
       <nys-textinput>
         <div slot="startButton">invalid</div>
         <nys-button slot="startButton" label="MyBtn"></nys-button>
@@ -166,7 +166,7 @@ describe("nys-textinput", () => {
   });
 
   it("sets custom validity message and showError flag", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     (el as any)._setValidityMessage("Something is wrong");
@@ -196,7 +196,7 @@ describe("nys-textinput", () => {
   });
 
   it("should not leave trailing dash or formatting characters when backspacing in masked input", async () => {
-    const el = await fixture<NysTextinput>(html`
+    const el = await fixture<NysTextInput>(html`
       <nys-textinput type="tel"></nys-textinput>
     `);
 
@@ -220,7 +220,7 @@ describe("nys-textinput", () => {
   });
 
   it("should dispatch focus and blur events", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput label="FocusMe"></nys-textinput>`,
     );
     const textinput = el.shadowRoot?.querySelector("input")!;
@@ -246,7 +246,7 @@ describe("nys-textinput", () => {
   });
 
   it("should focus on the internal textinput via the delegatesFocus", async () => {
-    const el = await fixture<NysTextinput>(html`
+    const el = await fixture<NysTextInput>(html`
       <nys-textinput label="Test Input"></nys-textinput>
     `);
 
@@ -274,7 +274,7 @@ describe("nys-textinput", () => {
       </form>
     `);
 
-    const el = form.querySelector<NysTextinput>("nys-textinput")!;
+    const el = form.querySelector<NysTextInput>("nys-textinput")!;
     const input = el.shadowRoot?.querySelector<HTMLInputElement>("input")!;
 
     (el as any).showPassword = true; // this is private on the textinput, so need to set it directly here
@@ -306,7 +306,7 @@ describe("nys-textinput", () => {
       </form>
     `);
 
-    const el = form.querySelector<NysTextinput>("nys-textinput")!;
+    const el = form.querySelector<NysTextInput>("nys-textinput")!;
     const input = el.shadowRoot!.querySelector<HTMLInputElement>("input")!;
     const overlay = el.shadowRoot!.querySelector<HTMLElement>(
       ".nys-textinput__mask-overlay",
@@ -341,7 +341,7 @@ describe("nys-textinput", () => {
   // -------------------------------------------------------------------------
 
   it("_handleInvalid prevents default", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput required></nys-textinput>`,
     );
     await el.updateComplete;
@@ -353,7 +353,7 @@ describe("nys-textinput", () => {
   });
 
   it("_handleInvalid sets showError via _validate()", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput required></nys-textinput>`,
     );
     await el.updateComplete;
@@ -366,7 +366,7 @@ describe("nys-textinput", () => {
   });
 
   it("_handleInvalid enables eager validation on subsequent input", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput required></nys-textinput>`,
     );
     await el.updateComplete;
@@ -382,7 +382,7 @@ describe("nys-textinput", () => {
   });
 
   it("_handleInvalid focuses the input when not inside a form", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput required></nys-textinput>`,
     );
     await el.updateComplete;
@@ -405,7 +405,7 @@ describe("nys-textinput", () => {
         <nys-textinput id="only" required></nys-textinput>
       </form>
     `);
-    const el = container.querySelector<NysTextinput>("#only")!;
+    const el = container.querySelector<NysTextInput>("#only")!;
     await el.updateComplete;
 
     const input = el.shadowRoot!.querySelector("input")!;
@@ -427,7 +427,7 @@ describe("nys-textinput", () => {
         <nys-textinput id="second" required></nys-textinput>
       </form>
     `);
-    const second = container.querySelector<NysTextinput>("#second")!;
+    const second = container.querySelector<NysTextInput>("#second")!;
     await second.updateComplete;
 
     const input = second.shadowRoot!.querySelector("input")!;
@@ -443,7 +443,7 @@ describe("nys-textinput", () => {
   });
 
   it("_applyMask generic loop fills digit placeholders with input digits", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     await el.updateComplete;
@@ -457,7 +457,7 @@ describe("nys-textinput", () => {
   });
 
   it("_applyMask generic loop stops when digits run out", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     await el.updateComplete;
@@ -467,7 +467,7 @@ describe("nys-textinput", () => {
   });
 
   it("_applyMask generic loop treats 'd' as a digit placeholder", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     await el.updateComplete;
@@ -477,7 +477,7 @@ describe("nys-textinput", () => {
   });
 
   it("_applyMask generic loop treats '9' as a digit placeholder", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     await el.updateComplete;
@@ -487,7 +487,7 @@ describe("nys-textinput", () => {
   });
 
   it("_applyMask generic loop passes through literal formatting characters", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     await el.updateComplete;
@@ -501,7 +501,7 @@ describe("nys-textinput", () => {
   // More Event Tests
   // -------------------------------------------------------------------------
   it("fires nys-input with correct detail on input", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     await el.updateComplete;
@@ -521,7 +521,7 @@ describe("nys-textinput", () => {
   });
 
   it("fires nys-focus when input gains focus", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     let focused = false;
@@ -535,7 +535,7 @@ describe("nys-textinput", () => {
   });
 
   it("fires nys-blur when input loses focus", async () => {
-    const el = await fixture<NysTextinput>(
+    const el = await fixture<NysTextInput>(
       html`<nys-textinput></nys-textinput>`,
     );
     let blurred = false;
@@ -559,7 +559,7 @@ describe("nys-textinput", () => {
       </form>
     `);
 
-    const el = form.querySelector<NysTextinput>("nys-textinput")!;
+    const el = form.querySelector<NysTextInput>("nys-textinput")!;
     await el.updateComplete;
 
     expect(new FormData(form).get("test-field")).to.equal("stale-value");

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -47,7 +47,7 @@ let textinputIdCounter = 0;
  * ```
  */
 
-export class NysTextinput extends LitElement {
+export class NysTextInput extends LitElement {
   static styles = unsafeCSS(styles);
   static shadowRootOptions = {
     ...LitElement.shadowRootOptions,
@@ -625,5 +625,5 @@ export class NysTextinput extends LitElement {
 }
 
 if (!customElements.get("nys-textinput")) {
-  customElements.define("nys-textinput", NysTextinput);
+  customElements.define("nys-textinput", NysTextInput);
 }

--- a/packages/react/NysTextinput.d.ts
+++ b/packages/react/NysTextinput.d.ts
@@ -1,13 +1,13 @@
 import React from "react";
 import {
-  NysTextinput as NysTextinputElement,
+  NysTextInput as NysTextInputElement,
   CustomEvent,
   Event,
 } from "../../dist/nysds.es.js";
 
-export type { NysTextinputElement, CustomEvent, Event };
+export type { NysTextInputElement, CustomEvent, Event };
 
-export interface NysTextinputProps extends Pick<
+export interface NysTextInputProps extends Pick<
   React.AllHTMLAttributes<HTMLElement>,
   | "children"
   | "dir"
@@ -41,55 +41,55 @@ export interface NysTextinputProps extends Pick<
   showError?: boolean;
 
   /** Unique identifier. Auto-generated if not provided. */
-  id?: NysTextinputElement["id"];
+  id?: NysTextInputElement["id"];
 
   /** Name for form submission. */
-  name?: NysTextinputElement["name"];
+  name?: NysTextInputElement["name"];
 
   /** Input type: `text` (default), `email`, `number`, `password`, `search`, `tel` (auto-masked), `url`. */
-  type?: NysTextinputElement["type"];
+  type?: NysTextInputElement["type"];
 
   /** Visible label text. Required for accessibility. */
-  label?: NysTextinputElement["label"];
+  label?: NysTextInputElement["label"];
 
   /** Helper text below label. Use slot for custom HTML. */
-  description?: NysTextinputElement["description"];
+  description?: NysTextInputElement["description"];
 
   /** Placeholder text. Don't use as label replacement. */
-  placeholder?: NysTextinputElement["placeholder"];
+  placeholder?: NysTextInputElement["placeholder"];
 
   /** Current input value. */
-  value?: NysTextinputElement["value"];
+  value?: NysTextInputElement["value"];
 
   /** Tooltip text shown on hover/focus of info icon. */
-  tooltip?: NysTextinputElement["tooltip"];
+  tooltip?: NysTextInputElement["tooltip"];
 
   /** Form `id` to associate with when input is outside form element. */
-  form?: NysTextinputElement["form"];
+  form?: NysTextInputElement["form"];
 
   /** Regex pattern for validation. Shows error on mismatch. */
-  pattern?: NysTextinputElement["pattern"];
+  pattern?: NysTextInputElement["pattern"];
 
   /** Maximum character length. */
-  maxlength?: NysTextinputElement["maxlength"];
+  maxlength?: NysTextInputElement["maxlength"];
 
   /** Accessible label. When set, assuming "label" isn't provided for private special cases (i.e., <checkbox other>). */
-  ariaLabel?: NysTextinputElement["ariaLabel"];
+  ariaLabel?: NysTextInputElement["ariaLabel"];
 
   /** Input width: `sm` (88px), `md` (200px), `lg` (384px), `full` (100%, default). */
-  width?: NysTextinputElement["width"];
+  width?: NysTextInputElement["width"];
 
   /** Step increment for `type="number"`. */
-  step?: NysTextinputElement["step"];
+  step?: NysTextInputElement["step"];
 
   /** Minimum value for `type="number"`. */
-  min?: NysTextinputElement["min"];
+  min?: NysTextInputElement["min"];
 
   /** Maximum value for `type="number"`. */
-  max?: NysTextinputElement["max"];
+  max?: NysTextInputElement["max"];
 
   /** Error message text. Shown only when `showError` is true. */
-  errorMessage?: NysTextinputElement["errorMessage"];
+  errorMessage?: NysTextInputElement["errorMessage"];
 
   /** A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the class selectors or functions like the method `Document.getElementsByClassName()`. */
   className?: string;
@@ -141,4 +141,4 @@ export interface NysTextinputProps extends Pick<
  * - **startButton** - Button at input start. Use single `nys-button` only.
  * - **endButton** - Button at input end. Use single `nys-button` only.
  */
-export const NysTextinput: React.ForwardRefExoticComponent<NysTextinputProps>;
+export const NysTextInput: React.ForwardRefExoticComponent<NysTextInputProps>;

--- a/packages/react/NysTextinput.js
+++ b/packages/react/NysTextinput.js
@@ -2,7 +2,7 @@ import React, { forwardRef, useRef, useEffect } from "react";
 import "../../dist/nysds.es.js";
 import { useEventListener } from "./react-utils.js";
 
-export const NysTextinput = forwardRef((props, forwardedRef) => {
+export const NysTextInput = forwardRef((props, forwardedRef) => {
   const ref = useRef(null);
   const {
     disabled,

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -27,12 +27,12 @@ The `./react` subpath export is declared in the root `package.json`, pointing at
 ## Usage
 
 ```tsx
-import { NysButton, NysTextinput } from "@nysds/components/react";
+import { NysButton, NysTextInput } from "@nysds/components/react";
 
 function MyForm() {
   return (
     <>
-      <NysTextinput
+      <NysTextInput
         label="First name"
         onNysInput={(e) => console.log(e.detail)}
       />

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -34,7 +34,7 @@ export * from "./NysTabgroup.js";
 export * from "./NysTabpanel.js";
 export * from "./NysTable.js";
 export * from "./NysTextarea.js";
-export * from "./NysTextinput.js";
+export * from "./NysTextInput.js";
 export * from "./NysToggle.js";
 export * from "./NysTooltip.js";
 export * from "./NysUnavFooter.js";

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -34,7 +34,7 @@ export * from "./NysTabgroup.js";
 export * from "./NysTabpanel.js";
 export * from "./NysTable.js";
 export * from "./NysTextarea.js";
-export * from "./NysTextinput.js";
+export * from "./NysTextInput.js";
 export * from "./NysToggle.js";
 export * from "./NysTooltip.js";
 export * from "./NysUnavFooter.js";

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -899,7 +899,7 @@ export type NysTextareaProps = {
   "onnys-selectionchange"?: (e: CustomEvent<CustomEvent>) => void;
 };
 
-export type NysTextinputProps = {
+export type NysTextInputProps = {
   /** Unique identifier. Auto-generated if not provided. */
   id?: string;
   /** Name for form submission. */
@@ -1564,7 +1564,7 @@ export type CustomElements = {
    * - **startButton** - Button at input start. Use single `nys-button` only.
    * - **endButton** - Button at input end. Use single `nys-button` only.
    */
-  "nys-textinput": Partial<NysTextinputProps & BaseProps & BaseEvents>;
+  "nys-textinput": Partial<NysTextInputProps & BaseProps & BaseEvents>;
 
   /**
    * Toggle switch for binary settings with immediate effect.

--- a/src/templates/test.template.hbs
+++ b/src/templates/test.template.hbs
@@ -4,7 +4,7 @@ import { Nys{{capitalize componentName}} } from "./nys-{{componentName}}.js";
 
 // You may need to import other dependencies such as the component's tag name
 // For example:
-// import { NysTextinput } from "./nys-textinput";
+// import { NysTextInput } from "./nys-textinput";
 
 // Below are placeholder examples of test cases for a web component. Add your own tests as needed.
 describe("nys-{{componentName}}", () => {


### PR DESCRIPTION
# Summary

Renamed the `NysTextinput` class to `NysTextInput` to align with standard PascalCase naming conventions. 
We must inform applications importing `NysTextinput` that they must update their imports and references to `NysTextInput`.

```ts
Before:

import { NysTextinput } from "@nysds/components";

After:

import { NysTextInput } from "@nysds/components";
```

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

:warning: This is a **breaking change**.

<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1641 🎫
