### PR TITLE
Bug/translate icon missing

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2229,6 +2229,15 @@
             },
             {
               "kind": "field",
+              "name": "_hasCircleSlot",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "field",
               "name": "formAssociated",
               "type": {
                 "text": "boolean"
@@ -2259,6 +2268,19 @@
             {
               "kind": "method",
               "name": "_onSuffixSlotChange",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_onCircleSlotChange",
               "privacy": "private",
               "parameters": [
                 {

--- a/packages/nys-button/src/nys-button.test.ts
+++ b/packages/nys-button/src/nys-button.test.ts
@@ -158,16 +158,40 @@ describe("nys-button", () => {
     expect(suffixIcon!.getAttribute("size")).to.equal("16");
   });
 
-  it(" should allow for the icon to be slotted in", async () => {
+  it(" should allow for the prefix icon to be slotted in", async () => {
     const el = await fixture<NysButton>(
       html`<nys-button size="sm">
-        <nys-icon slot="suffix-icon" size="2xl" name="visibility"></nys-icon>
+        <nys-icon slot="prefix-icon" size="2xl" name="visibility"></nys-icon>
       </nys-button>`,
     );
     const prefixIcon = el.querySelector("nys-icon[name='visibility']");
 
     expect(el.prefixIcon).to.exist;
     expect(prefixIcon).to.exist;
+  });
+
+  it(" should allow for the suffix icon to be slotted in", async () => {
+    const el = await fixture<NysButton>(
+      html`<nys-button size="sm">
+        <nys-icon slot="suffix-icon" size="2xl" name="visibility"></nys-icon>
+      </nys-button>`,
+    );
+    const suffixIcon = el.querySelector("nys-icon[name='visibility']");
+
+    expect(el.suffixIcon).to.exist;
+    expect(suffixIcon).to.exist;
+  });
+
+  it(" should allow for the circle icon to be slotted in", async () => {
+    const el = await fixture<NysButton>(
+      html`<nys-button size="sm" circle>
+        <nys-icon slot="circle-icon" size="2xl" name="visibility"></nys-icon>
+      </nys-button>`,
+    );
+    const circleIcon = el.querySelector("nys-icon[name='visibility']");
+
+    expect(el.icon).to.exist;
+    expect(circleIcon).to.exist;
   });
 
   it("renders correct icon sizes for regular and circle buttons", async () => {

--- a/packages/nys-button/src/nys-button.ts
+++ b/packages/nys-button/src/nys-button.ts
@@ -202,6 +202,7 @@ export class NysButton extends LitElement {
 
   @state() private _hasPrefixSlot = false;
   @state() private _hasSuffixSlot = false;
+  @state() private _hasCircleSlot = false;
 
   /**
    * Lifecycle methods
@@ -241,6 +242,11 @@ export class NysButton extends LitElement {
   private _onSuffixSlotChange(e: Event) {
     const slot = e.target as HTMLSlotElement;
     this._hasSuffixSlot = slot.assignedElements({ flatten: true }).length > 0;
+  }
+
+  private _onCircleSlotChange(e: Event) {
+    const slot = e.target as HTMLSlotElement;
+    this._hasCircleSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _manageFormAction() {
@@ -415,18 +421,23 @@ export class NysButton extends LitElement {
                       ></nys-icon>`
                     : ""}
                 </slot>
-                ${this.circle && this.icon
-                  ? html`<slot name="circle-icon"
-                      ><nys-icon
+                <slot
+                  name="circle-icon"
+                  @slotchange=${this._onCircleSlotChange}
+                  ?hidden=${!this.circle ||
+                  (!this.icon && !this._hasCircleSlot)}
+                >
+                  ${this.icon
+                    ? html`<nys-icon
                         size=${this.size === "sm"
                           ? "24"
                           : this.size === "lg"
                             ? "40"
                             : "32"}
                         name=${this.icon}
-                      ></nys-icon
-                    ></slot>`
-                  : ""}
+                      ></nys-icon>`
+                    : ""}
+                </slot>
               </a>
             </div>
           `
@@ -484,18 +495,22 @@ export class NysButton extends LitElement {
                     ></nys-icon>`
                   : ""}
               </slot>
-              ${this.circle && this.icon
-                ? html`<slot name="circle-icon">
-                    <nys-icon
+              <slot
+                name="circle-icon"
+                @slotchange=${this._onCircleSlotChange}
+                ?hidden=${!this.circle || (!this.icon && !this._hasCircleSlot)}
+              >
+                ${this.icon
+                  ? html`<nys-icon
                       size=${this.size === "sm"
                         ? "24"
                         : this.size === "lg"
                           ? "40"
                           : "32"}
                       name=${this.icon}
-                    ></nys-icon>
-                  </slot>`
-                : ""}
+                    ></nys-icon>`
+                  : ""}
+              </slot>
             </button>
           `}
     `;

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -339,7 +339,7 @@ export class NysUnavHeader extends LitElement {
                   <nys-button
                     variant="ghost"
                     circle
-                    icon="translate"
+                    icon="language"
                     ariaLabel="Translate"
                     aria-expanded="${this.languageVisible}"
                     id="nys-unavheader__translate--mobile"

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -339,7 +339,6 @@ export class NysUnavHeader extends LitElement {
                   <nys-button
                     variant="ghost"
                     circle
-                    icon="language"
                     ariaLabel="Translate"
                     aria-expanded="${this.languageVisible}"
                     id="nys-unavheader__translate--mobile"
@@ -391,7 +390,6 @@ export class NysUnavHeader extends LitElement {
                   <nys-button
                     variant="ghost"
                     circle
-                    icon="search"
                     ariaLabel="Search"
                     aria-expanded="${this.searchDropdownVisible}"
                     id="nys-unavheader__searchbutton"

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -339,6 +339,7 @@ export class NysUnavHeader extends LitElement {
                   <nys-button
                     variant="ghost"
                     circle
+                    icon="translate"
                     ariaLabel="Translate"
                     aria-expanded="${this.languageVisible}"
                     id="nys-unavheader__translate--mobile"


### PR DESCRIPTION
Fix missing translate icon appearing on circle button due to logic of how slotted icons on button work. a previous fix updated the prefix and suffix icons for slotted buttons but the fix was missing from circle icon. this fixes that.
<img width="792" height="88" alt="image" src="https://github.com/user-attachments/assets/53d54ff1-22a9-46f7-885c-7104ad692660" />
