### PR TITLE
Fix: Overlapping texts in `nys-alert`, `nys-badge`, and `nys-icon`

### DIFF
--- a/packages/nys-alert/src/nys-alert.scss
+++ b/packages/nys-alert/src/nys-alert.scss
@@ -112,7 +112,6 @@ a:active {
 
 /* Handles both header and description text */
 .nys-alert__texts {
-  position: relative;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -83,7 +83,6 @@
 }
 
 .nys-badge {
-  position: relative;
   display: flex;
   width: fit-content;
   align-items: center;

--- a/packages/nys-icon/src/nys-icon.test.ts
+++ b/packages/nys-icon/src/nys-icon.test.ts
@@ -52,7 +52,6 @@ describe("nys-icon", () => {
     expect(svg?.classList.contains("nys-icon--md")).to.be.true;
     expect(svg?.classList.contains("nys-icon--flip-")).to.be.false;
     expect(svg?.style.color).to.equal("currentcolor"); // Default color
-    expect(svg?.style.rotate).to.equal("0deg");
   });
 
   it("applies size class based on size property", async () => {

--- a/packages/nys-icon/src/nys-icon.ts
+++ b/packages/nys-icon/src/nys-icon.ts
@@ -197,7 +197,11 @@ export class NysIcon extends LitElement implements NysIconWatcher {
       svg.removeAttribute("aria-label");
     }
 
-    svg.style.rotate = `${this.rotate}deg`;
+    if (this.rotate && this.rotate !== "0") {
+      svg.style.rotate = `${this.rotate}deg`;
+    } else {
+      svg.style.removeProperty("rotate");
+    }
     svg.style.color = this.color || "currentcolor";
     svg.classList.add(`nys-icon--${this.size}`);
     svg.classList.add(`nys-icon--svg`);


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Fix the issue with overlapping texts in `nys-alert`, `nys-badge`, and `nys-icon`

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change
This is **not** a breaking change.  

<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1662 🎟️