### PR TITLE
Native dark mode: token layer, on-color companions, component remediation

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -57,12 +57,33 @@ const preview: Preview = {
         ],
       },
     },
+    mode: {
+      name: "Mode",
+      description: "Light or dark appearance",
+      defaultValue: "light",
+      toolbar: {
+        icon: "contrast",
+        items: [
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+        ],
+        dynamicTitle: true,
+      },
+    },
   },
   decorators: [
     (Story, context) => {
       // Load the theme based on Storybook's global context
       const theme = context.globals.theme;
       loadTheme(theme);
+      // Light/dark appearance via the [data-mode] token layer. Also mirror the
+      // theme onto [data-theme] so dark×theme composes — themes are otherwise
+      // applied via the loadTheme :root stylesheet, which dark can't compose with.
+      const docEl = document.documentElement;
+      if (context.globals.mode === "dark") docEl.setAttribute("data-mode", "dark");
+      else docEl.removeAttribute("data-mode");
+      if (theme && theme !== "default") docEl.setAttribute("data-theme", theme);
+      else docEl.removeAttribute("data-theme");
       setTimeout(() => {
         const skipnav = document.querySelector("nys-skipnav");
         const link = skipnav?.shadowRoot?.querySelector("a");

--- a/packages/nys-accordion/src/nys-accordion.scss
+++ b/packages/nys-accordion/src/nys-accordion.scss
@@ -15,11 +15,11 @@
   /* Header & Text container */
   --_nys-accordion-background-color--header: var(
     --nys-accordion-background-color--header,
-    var(--nys-color-neutral-50, #ededed)
+    var(--nys-color-surface-sunken, #ededed)
   );
   --_nys-accordion-background-color--header--hover: var(
     --nys-accordion-background-color--header--hover,
-    var(--nys-color-neutral-100, #d0d0ce)
+    var(--nys-color-surface-sunken-strong, #d0d0ce)
   );
   --_nys-accordionitem-gap: var(--nys-space-200, 16px);
   --_nys-accordionitem-background-color: var(--nys-color-surface, #ffffff);

--- a/packages/nys-accordion/src/nys-accordion.scss
+++ b/packages/nys-accordion/src/nys-accordion.scss
@@ -4,7 +4,7 @@
   /* Global Accordion Styles */
   --_nys-accordion-border-radius: var(--nys-radius-md, 4px);
   --_nys-accordion-border-width: var(--nys-border-width-md, 2px);
-  --_nys-accordion-border-color: var(--nys-color-neutral-50, #ededed);
+  --_nys-accordion-border-color: var(--nys-color-base-weak, #ededed);
   --_nys-accordion-padding--x: var(--nys-space-250, 20px);
   --_nys-accordion-padding--y: var(--nys-space-200, 16px);
   --_nys-accordion-outline-width: var(--nys-border-width-md, 2px);
@@ -22,7 +22,7 @@
     var(--nys-color-neutral-100, #d0d0ce)
   );
   --_nys-accordionitem-gap: var(--nys-space-200, 16px);
-  --_nys-accordionitem-background-color: var(--nys-color-ink-reverse, #ffffff);
+  --_nys-accordionitem-background-color: var(--nys-color-surface, #ffffff);
   --_nys-accordionitem-padding: var(--nys-space-200, 16px)
     var(--local-xx-spacing-205, 20px);
   --_nys-accordion-content-max-width: var(

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -50,8 +50,8 @@
 }
 
 :host([intent="error"]) {
-  --_nys-badge-background-color: var(--nys-color-error-weak, #f7eaea);
-  --_nys-badge-border-color: var(--nys-color-error-strong, #721c1c);
+  --_nys-badge-background-color: var(--nys-color-danger-weak, #f7eaea);
+  --_nys-badge-border-color: var(--nys-color-danger-strong, #721c1c);
   --_nys-badge-color-on: var(--nys-color-danger-on, #ffffff);
 }
 

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -8,6 +8,10 @@
   --_nys-badge-padding: var(--nys-space-2-px, 2px) var(--nys-space-100, 8px);
   --_nys-badge-gap: var(--nys-space-50, 4px);
   --_nys-badge-color: var(--nys-color-ink, #000000);
+  /* Foreground (text + icon) when the intent fill is painted (strong variant).
+     Keyed to the fill via the --<intent>-on companion: light on dark fills,
+     always-dark on the light warning fill — correct in both light and dark. */
+  --_nys-badge-color-on: var(--nys-color-text-reverse, #ffffff);
   --_nys-badge-background-color: var(--nys-color-base-weak, #f6f6f6);
   --_nys-badge-border-color: var(--nys-color-base, #62666a);
   --_nys-badge-border-width: var(--nys-border-width-sm, 1px);
@@ -42,30 +46,34 @@
 :host([intent="neutral"]) {
   --_nys-badge-background-color: var(--nys-color-base-weak, #f6f6f6);
   --_nys-badge-border-color: var(--nys-color-base, #62666a);
+  --_nys-badge-color-on: var(--nys-color-text-reverse, #ffffff);
 }
 
 :host([intent="error"]) {
   --_nys-badge-background-color: var(--nys-color-error-weak, #f7eaea);
   --_nys-badge-border-color: var(--nys-color-error-strong, #721c1c);
+  --_nys-badge-color-on: var(--nys-color-danger-on, #ffffff);
 }
 
 :host([intent="success"]) {
   --_nys-badge-background-color: var(--nys-color-success-weak, #e8f1ea);
   --_nys-badge-border-color: var(--nys-color-success-strong, #0f3d18);
+  --_nys-badge-color-on: var(--nys-color-success-on, #ffffff);
 }
 
 :host([intent="warning"]) {
   --_nys-badge-background-color: var(--nys-color-warning-weak, #fefae5);
   --_nys-badge-border-color: var(--nys-color-warning-strong, #6a5700);
+  --_nys-badge-color-on: var(--nys-color-warning-on, #000000);
 }
 
 /* Variant */
 :host([variant="strong"]) {
   --_nys-badge-background-color: var(--_nys-badge-border-color);
-  --_nys-badge-color: var(--nys-color-white, #ffffff);
+  --_nys-badge-color: var(--_nys-badge-color-on);
 
   .nys-badge {
-    --nys-icon-color: var(--nys-color-white, #ffffff);
+    --nys-icon-color: var(--_nys-badge-color-on);
   }
 }
 
@@ -74,12 +82,10 @@
 }
 
 :host([variant="strong"][intent="warning"]) {
+  /* Fill switches to the light main warning; the always-dark foreground comes
+     from --_nys-badge-color-on (= --nys-color-warning-on), so the previous
+     per-component dark-ink carve-out is no longer needed. */
   --_nys-badge-border-color: var(--nys-color-warning, #face00);
-  --_nys-badge-color: var(--nys-color-ink, #000000);
-
-  .nys-badge {
-    --nys-icon-color: var(--nys-color-ink, #000000);
-  }
 }
 
 .nys-badge {

--- a/packages/nys-button/src/nys-button.scss
+++ b/packages/nys-button/src/nys-button.scss
@@ -56,7 +56,7 @@
     var(--nys-color-transparent, #ffffff00)
   );
   --_nys-button-background-color--disabled: var(
-    --nys-color-neutral-10,
+    --nys-color-surface-raised,
     #f6f6f6
   );
   --_nys-button-color--disabled: var(--nys-color-text-disabled, #bec0c1);
@@ -164,7 +164,7 @@
 
   /* Filled - Disabled */
   --_nys-button-background-color--disabled: var(
-    --nys-color-neutral-10,
+    --nys-color-surface-raised,
     #f6f6f6
   );
   --_nys-button-color--disabled: var(--nys-color-text-disabled, #bec0c1);

--- a/packages/nys-select/src/nys-select.scss
+++ b/packages/nys-select/src/nys-select.scss
@@ -27,7 +27,7 @@
     --nys-color-danger,
     var(--nys-color-red-600, #b52c2c)
   );
-  --_nys-select-background-color: var(--nys-color-ink-reverse, #ffffff);
+  --_nys-select-background-color: var(--nys-color-surface, #ffffff);
   --_nys-select-background-color--disabled: var(
     --nys-color-neutral-10,
     #f6f6f6
@@ -37,7 +37,7 @@
   /* Select Outline & Border States */
   --_nys-select-border-width: var(--nys-border-width-sm, 1px);
   --_nys-select-border-color: var(--nys-color-neutral-400, #909395);
-  --_nys-select-border-color--hover: var(--nys-color-neutral-900, #1b1b1b);
+  --_nys-select-border-color--hover: var(--nys-color-text, #1b1b1b);
   --_nys-select-border-color--focus: var(--nys-color-focus, #004dd1);
   --_nys-select-border-color--disabled: var(--nys-color-neutral-200, #bec0c1);
   --_nys-select-border-default: var(--nys-border-width-sm, 1px) solid

--- a/packages/nys-stepper/src/nys-stepper.scss
+++ b/packages/nys-stepper/src/nys-stepper.scss
@@ -264,7 +264,7 @@
   .nys-step__number {
     border-radius: 0;
     border: none;
-    background-color: var(--nys-color-neutral-200, #bec0c1);
+    background-color: var(--nys-color-surface-sunken-strong, #bec0c1);
     height: var(--nys-size-100, 8px);
     min-height: var(--nys-size-100, 8px);
     max-height: var(--nys-size-100, 8px);
@@ -276,7 +276,7 @@
 
   :host([previous]) .nys-step__number,
   :host([current]) .nys-step__number {
-    background-color: var(--nys-color-neutral-900, #1b1b1b);
+    background-color: var(--nys-color-text, #1b1b1b);
     color: transparent;
   }
 

--- a/packages/nys-textinput/src/nys-textinput.scss
+++ b/packages/nys-textinput/src/nys-textinput.scss
@@ -18,12 +18,12 @@
   --_nys-textinput-padding: var(--nys-space-100, 8px);
   --_nys-textinput-gap: var(--nys-space-50, 4px);
   --_nys-textinput-background-color: var(
-    --nys-color-ink-reverse,
+    --nys-color-surface,
     var(--nys-color-white, #ffffff)
   );
 
   /* Hovered */
-  --_nys-textinput-outline-color--hover: var(--nys-color-neutral-900, #1b1b1b);
+  --_nys-textinput-outline-color--hover: var(--nys-color-text, #1b1b1b);
   --_nys-textinput-outline-width: var(--nys-border-width-sm, 1px);
 
   /* Focused */
@@ -31,7 +31,7 @@
 
   /* Disabled */
   --_nys-textinput-background-color--disabled: var(
-    --nys-color-neutral-10,
+    --nys-color-base-weak,
     #f6f6f6
   );
   --_nys-textinput-border-color--disabled: var(

--- a/packages/nys-unavheader/src/nys-unavheader.scss
+++ b/packages/nys-unavheader/src/nys-unavheader.scss
@@ -60,7 +60,7 @@
 }
 
 .nys-unavheader__trustbar.wrapper {
-  background-color: var(--nys-color-neutral-100, #d0d0ce);
+  background-color: var(--nys-color-surface-sunken-strong, #d0d0ce);
   padding-top: var(--nys-space-100, 8px);
   padding-bottom: var(--nys-space-100, 8px);
 }

--- a/packages/styles/src/core/reset.scss
+++ b/packages/styles/src/core/reset.scss
@@ -47,6 +47,13 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Dark mode: opt the document into the dark UA color scheme so native form
+   controls, scrollbars, and the default canvas background render dark. The
+   applied color tokens are re-pointed by the [data-mode="dark"] token layer. */
+html[data-mode="dark"] {
+  color-scheme: dark;
+}
+
 body {
   margin: 0;
   font: var(--nys-font-size-md) / var(--nys-font-lineheight-md)

--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -550,7 +550,15 @@
             "health": "{primitive.color.health-purple.10}",
             "local": "{primitive.color.local-brown.10}",
             "safety": "{primitive.color.safety-gray.10}",
-            "transportation": "{primitive.color.transportation-blue.10}"
+            "transportation": "{primitive.color.transportation-blue.10}",
+            "dark": "{primitive.color.state-blue.900}",
+            "admin-dark": "{primitive.color.admin-orange.900}",
+            "business-dark": "{primitive.color.business-teal.900}",
+            "environment-dark": "{primitive.color.environment-green.900}",
+            "health-dark": "{primitive.color.health-purple.900}",
+            "local-dark": "{primitive.color.local-brown.900}",
+            "safety-dark": "{primitive.color.safety-gray.900}",
+            "transportation-dark": "{primitive.color.transportation-blue.900}"
           }
         },
         "$description": "Faintest theme tint. USE for subtle backgrounds and hover states."
@@ -565,7 +573,15 @@
             "health": "{primitive.color.health-purple.50}",
             "local": "{primitive.color.local-brown.50}",
             "safety": "{primitive.color.safety-gray.50}",
-            "transportation": "{primitive.color.transportation-blue.50}"
+            "transportation": "{primitive.color.transportation-blue.50}",
+            "dark": "{primitive.color.state-blue.800}",
+            "admin-dark": "{primitive.color.admin-orange.800}",
+            "business-dark": "{primitive.color.business-teal.800}",
+            "environment-dark": "{primitive.color.environment-green.800}",
+            "health-dark": "{primitive.color.health-purple.800}",
+            "local-dark": "{primitive.color.local-brown.800}",
+            "safety-dark": "{primitive.color.safety-gray.800}",
+            "transportation-dark": "{primitive.color.transportation-blue.800}"
           }
         },
         "$description": "Very light theme tint. USE for secondary backgrounds and disabled states."
@@ -580,7 +596,15 @@
             "health": "{primitive.color.health-purple.100}",
             "local": "{primitive.color.local-brown.100}",
             "safety": "{primitive.color.safety-gray.100}",
-            "transportation": "{primitive.color.transportation-blue.100}"
+            "transportation": "{primitive.color.transportation-blue.100}",
+            "dark": "{primitive.color.state-blue.700}",
+            "admin-dark": "{primitive.color.admin-orange.700}",
+            "business-dark": "{primitive.color.business-teal.700}",
+            "environment-dark": "{primitive.color.environment-green.700}",
+            "health-dark": "{primitive.color.health-purple.700}",
+            "local-dark": "{primitive.color.local-brown.700}",
+            "safety-dark": "{primitive.color.safety-gray.700}",
+            "transportation-dark": "{primitive.color.transportation-blue.700}"
           }
         },
         "$description": "Light theme tint. USE for borders and light accent backgrounds."
@@ -595,7 +619,15 @@
             "health": "{primitive.color.health-purple.500}",
             "local": "{primitive.color.local-brown.500}",
             "safety": "{primitive.color.safety-gray.500}",
-            "transportation": "{primitive.color.transportation-blue.500}"
+            "transportation": "{primitive.color.transportation-blue.500}",
+            "dark": "{primitive.color.state-blue.400}",
+            "admin-dark": "{primitive.color.admin-orange.400}",
+            "business-dark": "{primitive.color.business-teal.400}",
+            "environment-dark": "{primitive.color.environment-green.400}",
+            "health-dark": "{primitive.color.health-purple.400}",
+            "local-dark": "{primitive.color.local-brown.400}",
+            "safety-dark": "{primitive.color.safety-gray.400}",
+            "transportation-dark": "{primitive.color.transportation-blue.400}"
           }
         },
         "$description": "Mid-range theme color. USE for secondary buttons and active states."
@@ -610,7 +642,15 @@
             "health": "{primitive.color.health-purple.700}",
             "local": "{primitive.color.local-brown.700}",
             "safety": "{primitive.color.safety-gray.700}",
-            "transportation": "{primitive.color.transportation-blue.700}"
+            "transportation": "{primitive.color.transportation-blue.700}",
+            "dark": "{primitive.color.state-blue.600}",
+            "admin-dark": "{primitive.color.admin-orange.600}",
+            "business-dark": "{primitive.color.business-teal.600}",
+            "environment-dark": "{primitive.color.environment-green.600}",
+            "health-dark": "{primitive.color.health-purple.600}",
+            "local-dark": "{primitive.color.local-brown.600}",
+            "safety-dark": "{primitive.color.safety-gray.600}",
+            "transportation-dark": "{primitive.color.transportation-blue.600}"
           }
         },
         "$description": "Primary theme color. USE for primary buttons, links, and key UI accents."
@@ -625,7 +665,15 @@
             "health": "{primitive.color.health-purple.800}",
             "local": "{primitive.color.local-brown.800}",
             "safety": "{primitive.color.safety-gray.800}",
-            "transportation": "{primitive.color.transportation-blue.800}"
+            "transportation": "{primitive.color.transportation-blue.800}",
+            "dark": "{primitive.color.state-blue.700}",
+            "admin-dark": "{primitive.color.admin-orange.700}",
+            "business-dark": "{primitive.color.business-teal.700}",
+            "environment-dark": "{primitive.color.environment-green.700}",
+            "health-dark": "{primitive.color.health-purple.700}",
+            "local-dark": "{primitive.color.local-brown.700}",
+            "safety-dark": "{primitive.color.safety-gray.700}",
+            "transportation-dark": "{primitive.color.transportation-blue.700}"
           }
         },
         "$description": "Dark theme variant. USE for hover states on primary elements."
@@ -640,10 +688,23 @@
             "health": "{primitive.color.health-purple.900}",
             "local": "{primitive.color.local-brown.900}",
             "safety": "{primitive.color.safety-gray.900}",
-            "transportation": "{primitive.color.transportation-blue.900}"
+            "transportation": "{primitive.color.transportation-blue.900}",
+            "dark": "{primitive.color.state-blue.800}",
+            "admin-dark": "{primitive.color.admin-orange.800}",
+            "business-dark": "{primitive.color.business-teal.800}",
+            "environment-dark": "{primitive.color.environment-green.800}",
+            "health-dark": "{primitive.color.health-purple.800}",
+            "local-dark": "{primitive.color.local-brown.800}",
+            "safety-dark": "{primitive.color.safety-gray.800}",
+            "transportation-dark": "{primitive.color.transportation-blue.800}"
           }
         },
         "$description": "Darkest theme variant. USE for active/pressed states on primary elements."
+      },
+      "on": {
+        "$type": "color",
+        "$value": "{applied.color.text.reverse}",
+        "$description": "Foreground (text + icons) on the matching intent fill. USE for label/icon color when painting on this fill."
       }
     }
   },
@@ -653,88 +714,203 @@
       "$type": "color",
       "accent": {
         "$value": "{primitive.color.yellow.400}",
-        "$description": "Accent color for highlights and emphasis. USE sparingly for visual interest."
+        "$description": "Accent color for highlights and emphasis. USE sparingly for visual interest.",
+        "$extensions": {
+          "mode": {
+            "dark": "{primitive.color.yellow.400}"
+          }
+        }
       },
       "base": {
         "default": {
           "$value": "{primitive.color.neutral.600}",
-          "$description": "Default base color for UI elements. USE for borders and dividers."
+          "$description": "Default base color for UI elements. USE for borders and dividers.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.500}"
+            }
+          }
         },
         "weak": {
           "$value": "{primitive.color.neutral.10}",
-          "$description": "Subtle base color. USE for hover states and subtle backgrounds."
+          "$description": "Subtle base color. USE for hover states and subtle backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.700}"
+            }
+          }
         }
       },
       "success": {
         "default": {
           "$value": "{primitive.color.green.600}",
-          "$description": "Success state indicator. USE for confirmations and positive feedback. MUST pair with success icon."
+          "$description": "Success state indicator. USE for confirmations and positive feedback. MUST pair with success icon.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.green.600}"
+            }
+          }
         },
         "strong": {
           "$value": "{primitive.color.green.800}",
-          "$description": "Strong success emphasis. USE for success text on light backgrounds."
+          "$description": "Strong success emphasis. USE for success text on light backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.green.300}"
+            }
+          }
         },
         "weak": {
           "$value": "{primitive.color.green.50}",
-          "$description": "Success background tint. USE for success alert backgrounds."
+          "$description": "Success background tint. USE for success alert backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.green.900}"
+            }
+          }
+        },
+        "on": {
+          "$type": "color",
+          "$value": "{applied.color.text.reverse}",
+          "$description": "Foreground (text + icons) on the matching intent fill. USE for label/icon color when painting on this fill."
         }
       },
       "info": {
         "default": {
           "$value": "{primitive.color.blue.600}",
-          "$description": "Informational state. USE for neutral notifications and tips."
+          "$description": "Informational state. USE for neutral notifications and tips.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.blue.600}"
+            }
+          }
         },
         "strong": {
           "$value": "{primitive.color.blue.800}",
-          "$description": "Strong info emphasis. USE for info text on light backgrounds."
+          "$description": "Strong info emphasis. USE for info text on light backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.blue.300}"
+            }
+          }
         },
         "weak": {
           "$value": "{primitive.color.blue.50}",
-          "$description": "Info background tint. USE for info alert backgrounds."
+          "$description": "Info background tint. USE for info alert backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.blue.900}"
+            }
+          }
+        },
+        "on": {
+          "$type": "color",
+          "$value": "{applied.color.text.reverse}",
+          "$description": "Foreground (text + icons) on the matching intent fill. USE for label/icon color when painting on this fill."
         }
       },
       "warning": {
         "default": {
           "$value": "{primitive.color.yellow.400}",
-          "$description": "Warning state. USE for cautions that need attention. SHOULD pair with warning icon."
+          "$description": "Warning state. USE for cautions that need attention. SHOULD pair with warning icon.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.yellow.400}"
+            }
+          }
         },
         "strong": {
           "$value": "{primitive.color.yellow.800}",
-          "$description": "Strong warning emphasis. USE for warning text on light backgrounds."
+          "$description": "Strong warning emphasis. USE for warning text on light backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.yellow.300}"
+            }
+          }
         },
         "weak": {
           "$value": "{primitive.color.yellow.50}",
-          "$description": "Warning background tint. USE for warning alert backgrounds."
+          "$description": "Warning background tint. USE for warning alert backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.yellow.900}"
+            }
+          }
+        },
+        "on": {
+          "$type": "color",
+          "$value": "{primitive.color.neutral.900}",
+          "$description": "Foreground (text + icons) on the matching intent fill. USE for label/icon color when painting on this fill."
         }
       },
       "danger": {
         "default": {
           "$value": "{primitive.color.red.600}",
-          "$description": "Danger/error state. USE for errors and destructive actions. MUST pair with error message."
+          "$description": "Danger/error state. USE for errors and destructive actions. MUST pair with error message.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.red.600}"
+            }
+          }
         },
         "strong": {
           "$value": "{primitive.color.red.800}",
-          "$description": "Strong danger emphasis. USE for error text on light backgrounds."
+          "$description": "Strong danger emphasis. USE for error text on light backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.red.300}"
+            }
+          }
         },
         "weak": {
           "$value": "{primitive.color.red.50}",
-          "$description": "Danger background tint. USE for error alert backgrounds."
+          "$description": "Danger background tint. USE for error alert backgrounds.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.red.900}"
+            }
+          }
+        },
+        "on": {
+          "$type": "color",
+          "$value": "{applied.color.text.reverse}",
+          "$description": "Foreground (text + icons) on the matching intent fill. USE for label/icon color when painting on this fill."
         }
       },
       "emergency": {
         "default": {
           "$value": "{primitive.color.red.800}",
-          "$description": "Emergency banner color. USE only for critical system-wide alerts."
+          "$description": "Emergency banner color. USE only for critical system-wide alerts.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.red.700}"
+            }
+          }
         },
         "weak": {
           "$value": "{primitive.color.red.300}",
-          "$description": "Emergency accent. USE for emergency banner highlights."
+          "$description": "Emergency accent. USE for emergency banner highlights.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.red.800}"
+            }
+          }
+        },
+        "on": {
+          "$type": "color",
+          "$value": "{applied.color.text.reverse}",
+          "$description": "Foreground (text + icons) on the matching intent fill. USE for label/icon color when painting on this fill."
         }
       },
       "ink": {
         "default": {
           "$value": "{primitive.color.neutral.900}",
-          "$description": "Primary ink color. USE for icons and graphic elements."
+          "$description": "Primary ink color. USE for icons and graphic elements.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.50}"
+            }
+          }
         },
         "reverse": {
           "$value": "{primitive.color.white}",
@@ -744,23 +920,48 @@
       "text": {
         "default": {
           "$value": "{primitive.color.neutral.900}",
-          "$description": "Primary text color. USE for body copy and headings. MUST meet WCAG 4.5:1 contrast."
+          "$description": "Primary text color. USE for body copy and headings. MUST meet WCAG 4.5:1 contrast.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.50}"
+            }
+          }
         },
         "weak": {
           "$value": "{primitive.color.neutral.700}",
-          "$description": "Secondary text. USE for metadata, captions, and supporting content."
+          "$description": "Secondary text. USE for metadata, captions, and supporting content.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.200}"
+            }
+          }
         },
         "weaker": {
           "$value": "{primitive.color.neutral.500}",
-          "$description": "Tertiary text. USE for placeholder text and subtle labels. AVOID for important content."
+          "$description": "Tertiary text. USE for placeholder text and subtle labels. AVOID for important content.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.300}"
+            }
+          }
         },
         "weakest": {
           "$value": "{primitive.color.neutral.200}",
-          "$description": "Decorative text only. AVOID for readable content - insufficient contrast."
+          "$description": "Decorative text only. AVOID for readable content - insufficient contrast.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.500}"
+            }
+          }
         },
         "disabled": {
           "$value": "{primitive.color.neutral.200}",
-          "$description": "Disabled text state. USE only for disabled form elements."
+          "$description": "Disabled text state. USE only for disabled form elements.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.600}"
+            }
+          }
         },
         "reverse": {
           "$value": "{primitive.color.white}",
@@ -782,19 +983,39 @@
       "link": {
         "default": {
           "$value": "{primitive.color.blue.600}",
-          "$description": "Default link color. MUST be distinguishable from body text. USE for inline links."
+          "$description": "Default link color. MUST be distinguishable from body text. USE for inline links.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.blue.300}"
+            }
+          }
         },
         "strong": {
           "$value": "{primitive.color.blue.700}",
-          "$description": "Visited or hover link state. USE for :visited and :hover states."
+          "$description": "Visited or hover link state. USE for :visited and :hover states.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.blue.200}"
+            }
+          }
         },
         "strongest": {
           "$value": "{primitive.color.blue.800}",
-          "$description": "Active link state. USE for :active state on links."
+          "$description": "Active link state. USE for :active state on links.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.blue.100}"
+            }
+          }
         },
         "neutral": {
           "$value": "{primitive.color.neutral.900}",
-          "$description": "Neutral link style. USE when link styling should match body text color."
+          "$description": "Neutral link style. USE when link styling should match body text color.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.50}"
+            }
+          }
         },
         "reverse": {
           "$value": "{primitive.color.neutral.300}",
@@ -816,24 +1037,49 @@
       "surface": {
         "default": {
           "$value": "{primitive.color.white}",
-          "$description": "Default page background. USE for main content areas and cards."
+          "$description": "Default page background. USE for main content areas and cards.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.900}"
+            }
+          }
         },
         "reverse": {
           "$value": "{primitive.color.neutral.900}",
-          "$description": "Dark surface background. USE for dark mode sections and footers."
+          "$description": "Dark surface background. USE for dark mode sections and footers.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.800}"
+            }
+          }
         },
         "raised": {
           "$value": "{primitive.color.neutral.10}",
-          "$description": "Elevated surface background. USE for cards and raised elements."
+          "$description": "Elevated surface background. USE for cards and raised elements.",
+          "$extensions": {
+            "mode": {
+              "dark": "{primitive.color.neutral.800}"
+            }
+          }
         }
       },
       "focus": {
         "$value": "{primitive.color.blue.600}",
-        "$description": "Focus ring color. MUST be visible on all backgrounds. USE for :focus-visible outlines."
+        "$description": "Focus ring color. MUST be visible on all backgrounds. USE for :focus-visible outlines.",
+        "$extensions": {
+          "mode": {
+            "dark": "{primitive.color.blue.300}"
+          }
+        }
       },
       "focus-reverse": {
         "$value": "{primitive.color.blue.300}",
         "$description": "Focus ring color on dark backgrounds. USE for :focus-visible outlines on dark surfaces."
+      },
+      "accent-on": {
+        "$type": "color",
+        "$value": "{primitive.color.neutral.900}",
+        "$description": "Foreground (text + icons) on the matching intent fill. USE for label/icon color when painting on this fill."
       }
     }
   },
@@ -1470,7 +1716,6 @@
         "$description": "Letter spacing for h6 text. PAIR WITH --nys-font-size-h6."
       }
     },
-
     "decoration": {
       "thickness": {
         "regular": { "$value": "7%", "$type": "string" },
@@ -1478,14 +1723,12 @@
       }
     }
   },
-
   "decoration": {
     "thickness": {
       "regular": { "$value": "7%", "$type": "string" },
       "strong": { "$value": "14%", "$type": "string" }
     }
   },
-
   "icon": {
     "size": {
       "$type": "dimension",

--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1061,6 +1061,26 @@
               "dark": "{primitive.color.neutral.800}"
             }
           }
+        },
+        "sunken": {
+          "default": {
+            "$value": "{primitive.color.neutral.50}",
+            "$description": "Recessed surface background, one step below the page. USE for inset bars, table stripes, and accordion headers.",
+            "$extensions": {
+              "mode": {
+                "dark": "{primitive.color.neutral.800}"
+              }
+            }
+          },
+          "strong": {
+            "$value": "{primitive.color.neutral.100}",
+            "$description": "More recessed surface, or the hover state of a sunken surface. USE for sunken-area hover and the universal-nav trust bar.",
+            "$extensions": {
+              "mode": {
+                "dark": "{primitive.color.neutral.700}"
+              }
+            }
+          }
         }
       },
       "focus": {

--- a/packages/tokens/terrazzo.config.js
+++ b/packages/tokens/terrazzo.config.js
@@ -44,6 +44,16 @@ export default defineConfig({
         { mode: "local", selectors: ['[data-theme="local"]', ".nys-theme-local"] },
         { mode: "safety", selectors: ['[data-theme="safety"]', ".nys-theme-safety"] },
         { mode: "transportation", selectors: ['[data-theme="transportation"]', ".nys-theme-transportation"] },
+        // Dark mode (appearance axis) — re-points the applied set under [data-mode="dark"].
+        { mode: "dark", selectors: ['[data-mode="dark"]'] },
+        // Dark × agency theme — each agency's theme-* ramp in dark, composing the two axes.
+        { mode: "admin-dark", selectors: ['[data-mode="dark"][data-theme="admin"]'] },
+        { mode: "business-dark", selectors: ['[data-mode="dark"][data-theme="business"]'] },
+        { mode: "environment-dark", selectors: ['[data-mode="dark"][data-theme="environment"]'] },
+        { mode: "health-dark", selectors: ['[data-mode="dark"][data-theme="health"]'] },
+        { mode: "local-dark", selectors: ['[data-mode="dark"][data-theme="local"]'] },
+        { mode: "safety-dark", selectors: ['[data-mode="dark"][data-theme="safety"]'] },
+        { mode: "transportation-dark", selectors: ['[data-mode="dark"][data-theme="transportation"]'] },
       ],
     }),
     // Per-theme files — only the CSS vars that change for that theme


### PR DESCRIPTION
## Summary

Adds **native dark mode** to NYSDS as an attribute-driven appearance axis. Dark mode is a pure assignment-layer change: the applied/semantic `--nys-color-*` tokens are re-pointed under `[data-mode="dark"]`, exactly parallel to the existing `[data-theme="<agency>"]` themes, and the primitive → alias → component cascade carries it to every token-driven component. It composes with the agency themes (dark × each agency).

## Token pipeline (`packages/tokens`)

- `tokens.json`: add the `data-mode="dark"` assignment groups (surfaces, text, base, intents, links, focus, and the dark agency `theme-*` ramps), the seven `--nys-color-<fill>--on` foreground companions, and a new **`surface.sunken` / `surface.sunken-strong`** pair.
- `terrazzo.config.js`: add the `dark` and `dark × agency` mode selectors (`[data-mode="dark"]`, `[data-mode="dark"][data-theme="…"]`).

### `--<fill>--on` companions
A per-fill foreground token (`--nys-color-<fill>--on`) carrying the correct text/icon color for each saturated intent fill: dark-enough fills alias `text-reverse` (light, both modes); the light `warning`/`accent` fills anchor to an always-dark primitive. This resolves the `-reverse` overload and the synthetic `text / warning` dark contrast finding once and for all, as data instead of per-component carve-outs.

### `surface.sunken` (new)
The neutral surface ramp collapsed to two values in light mode (`surface`/`surface-raised` = white / `neutral-10`), so recessed mid-gray surfaces had no semantic token that *flips* in dark without a visible light-mode shift:

| Token | Light | Dark |
|---|---|---|
| `--nys-color-surface-sunken` | `neutral-50` | `neutral-800` |
| `--nys-color-surface-sunken-strong` | `neutral-100` | `neutral-700` |

## Component remediation
Components that hardcoded neutral primitives (opting out of the token cascade) now read the semantic/companion token for the role — **no light-mode visual change**:

- **nys-accordion** — content bg → `surface`, item border → `base-weak`, header bg → `surface-sunken`, header hover → `surface-sunken-strong`.
- **nys-textinput / nys-select** — field bg → `surface`, hover outline → `text`.
- **nys-badge** — `intent="error"` bg/border → `danger-weak`/`danger-strong` (previously referenced non-existent `error-*` tokens), strong-fill text + icon → the `--<fill>--on` companion (deletes the literal `white` and `warning → ink` carve-out).
- **nys-button** — disabled bg → `surface-raised`.
- **nys-stepper** — compact track → `surface-sunken-strong`, compact filled bar → `text` (was `neutral-900`, invisible on dark).
- **nys-unavheader** — trust bar bg → `surface-sunken-strong`.

## Storybook
- `.storybook/preview.ts`: a `data-mode` toolbar global to view each component light/dark across agency themes.
- `packages/styles` reset: `html[data-mode="dark"] { color-scheme: dark; }` so native controls/scrollbars/canvas render dark.

## Still open (deliberately out of scope — design / brand decisions)
- **nys-button** `variant="outline"` label + border: a single native value would change the light appearance (navy → mid-blue); needs a design call (`theme-mid` vs honoring `inverted`).
- **nys-unavheader** logo `<path>` fill (`fill="#457AA5"` attribute) and icon-button icon colors → token-driven; brand/API decision.

## Testing
Full component suite: **825/826** passing. The single failure (`nys-globalfooter` `agencySubheading`) predates this branch and is unrelated. Verified the new tokens resolve correctly in light and `[data-mode="dark"]`.