### PR TITLE
Fix: Checkbox and toggle label weight parity

### DIFF
--- a/packages/nys-checkbox/src/nys-checkbox.scss
+++ b/packages/nys-checkbox/src/nys-checkbox.scss
@@ -29,6 +29,7 @@
   );
   --_nys-checkbox-font-size: var(--nys-font-size-ui-md, 16px);
   --_nys-checkbox-font-weight: var(--nys-font-weight-regular, 400);
+  --_nys-checkbox-font-weight--standalone: var(--nys-font-weight-semibold, 600);
   --_nys-checkbox-line-height: var(--nys-font-lineheight-ui-md, 24px);
 
   /* Global Checkbox Colors */
@@ -372,6 +373,10 @@
 
 :host(:not([tile])) .nys-checkbox__main-container > nys-label {
   --_nys-label-font-weight: var(--_nys-checkbox-font-weight);
+}
+
+:host(:not([tile])) .nys-checkbox__main-container > nys-label.standalone {
+  --_nys-label-font-weight: var(--_nys-checkbox-font-weight--standalone);
 }
 
 :host([tile]) .nys-checkbox__main-container > nys-label {

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -296,6 +296,10 @@ export class NysCheckbox extends LitElement {
     return !!this.description || !!slot;
   }
 
+  get _isStandalone() {
+    return this.parentElement?.tagName.toLowerCase() !== "nys-checkboxgroup";
+  }
+
   /**
    * Event Handlers
    * --------------------------------------------------------------------------
@@ -495,6 +499,7 @@ export class NysCheckbox extends LitElement {
               label="${this.label || (this.other ? "Other" : "")}"
               description=${ifDefined(this.description || undefined)}
               flag=${ifDefined(this.required ? "required" : undefined)}
+              class=${this._isStandalone ? "standalone" : ""}
             >
               <slot name="description" slot="description"
                 >${this.description}</slot

--- a/packages/nys-toggle/src/nys-toggle.scss
+++ b/packages/nys-toggle/src/nys-toggle.scss
@@ -54,7 +54,7 @@
   gap: var(--_nys-toggle-gap);
 
   nys-label {
-    --_nys-label-font-weight: var(--nys-font-weight-regular, 400);
+    --_nys-label-font-weight: var(--nys-font-weight-semibold, 600);
   }
 
   &:has(input:disabled) {


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
Fix parity with the rest of the components: `nys-checkbox` single checkbox label and the `nys-toggle` main label is now set to heavier font weight 600.
<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change


This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes 
## Screenshot
<img width="552" height="149" alt="Screenshot 2026-07-01 at 12 45 11 PM" src="https://github.com/user-attachments/assets/c654d6d8-b68c-4cef-b1ae-24a64797555f" />
<img width="377" height="74" alt="Screenshot 2026-07-01 at 12 45 15 PM" src="https://github.com/user-attachments/assets/4da8cc72-7087-4a29-9986-8f6dc6e25660" />
