### PR TITLE
docs(nys-globalheader): clarify when to enable `nysLogo`

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7330,7 +7330,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Toggles the NYS brand mark",
+              "description": "Displays the NYS brand mark in the header. Off by default.\n\nEnable only for internal, state-employee (back-office) applications that omit\n`nys-unavheader`. Any resident-facing app — even one requiring login — should\nkeep `nys-unavheader` for trust and leave this off.",
               "attribute": "nysLogo"
             },
             {
@@ -7458,7 +7458,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Toggles the NYS brand mark",
+              "description": "Displays the NYS brand mark in the header. Off by default.\n\nEnable only for internal, state-employee (back-office) applications that omit\n`nys-unavheader`. Any resident-facing app — even one requiring login — should\nkeep `nys-unavheader` for trust and leave this off.",
               "fieldName": "nysLogo",
               "propName": "nyslogo"
             }

--- a/packages/nys-globalheader/src/nys-globalheader.mdx
+++ b/packages/nys-globalheader/src/nys-globalheader.mdx
@@ -60,6 +60,10 @@ The `nys-globalheader` component includes a named slot called `user-actions`. Th
 
 ## NYS Brand Mark
 
+Enable the `nysLogo` prop to show the NYS brand mark. It is **off by default**.
+
+<div style={{ display: 'flex', gap: '10px', verticalAlign: 'middle', alignItems: 'center'}}>  <nys-icon name="info" size="xl" style={{margin: '20px 0' }}></nys-icon> Use only for internal, state-employee (back-office) applications that omit `nys-unavheader`. Any resident-facing app — even one requiring login — should keep `nys-unavheader` for trust and leave `nysLogo` off.</div>
+
 <Canvas of={NysGlobalHeaderStories.WithBrandMark} />
 
 ## Usage
@@ -77,12 +81,14 @@ The `nys-globalheader` component includes a named slot called `user-actions`. Th
       ### <nys-icon name="check_circle" color="var(--nys-color-success)" /> Do
       - Use `agencyName` as stand alone if public-facing site and not in the context of a specific application.
       - Use `appName` if an application is for a single agency
+      - Enable `nysLogo` only for internal, state-employee apps that omit `nys-unavheader`
     </div>
   </div>
   <div className="nys-mobile-lg:nys-grid-col">
     <div className="usage-card usage-card--dont">
       ### <nys-icon name="error" color="var(--nys-color-danger)"/> Don't
       - Use `appName` if an application is not for a single agency
+      - Enable `nysLogo` on any resident-facing app — keep `nys-unavheader` instead
       - Add unnecessary or unrelated content
     </div>
   </div>

--- a/packages/nys-globalheader/src/nys-globalheader.ts
+++ b/packages/nys-globalheader/src/nys-globalheader.ts
@@ -35,7 +35,13 @@ export class NysGlobalHeader extends LitElement {
   /** URL for the header title link. If empty, title is not clickable. */
   @property({ type: String }) homepageLink = "";
 
-  /** Toggles the NYS brand mark */
+  /**
+   * Displays the NYS brand mark in the header. Off by default.
+   *
+   * Enable only for internal, state-employee (back-office) applications that omit
+   * `nys-unavheader`. Any resident-facing app — even one requiring login — should
+   * keep `nys-unavheader` for trust and leave this off.
+   */
   @property({ type: Boolean }) nysLogo = false;
 
   /** Internal state to track mobile menu open/closed status. */

--- a/packages/react/NysGlobalHeader.d.ts
+++ b/packages/react/NysGlobalHeader.d.ts
@@ -18,7 +18,11 @@ export interface NysGlobalHeaderProps extends Pick<
   | "onFocus"
   | "onBlur"
 > {
-  /** Toggles the NYS brand mark */
+  /** Displays the NYS brand mark in the header. Off by default.
+
+Enable only for internal, state-employee (back-office) applications that omit
+`nys-unavheader`. Any resident-facing app — even one requiring login — should
+keep `nys-unavheader` for trust and leave this off. */
   nysLogo?: boolean;
 
   /** Application name displayed prominently. */

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -531,7 +531,11 @@ export type NysGlobalHeaderProps = {
   agencyName?: string;
   /** URL for the header title link. If empty, title is not clickable. */
   homepageLink?: string;
-  /** Toggles the NYS brand mark */
+  /** Displays the NYS brand mark in the header. Off by default.
+
+Enable only for internal, state-employee (back-office) applications that omit
+`nys-unavheader`. Any resident-facing app — even one requiring login — should
+keep `nys-unavheader` for trust and leave this off. */
   nysLogo?: boolean;
 };
 


### PR DESCRIPTION
## Summary

The `nys-globalheader` `nysLogo` prop was documented only as *"Toggles the NYS brand mark"* — with no guidance on **when** to use it. Because the prop name actively invites enabling it on "a NYS site," the brand mark was getting turned on in standard page layouts where `nys-unavheader` already provides NYS branding one row above. This surfaced repeatedly through AI-assisted authoring (the MCP server re-serves this description verbatim).

The default was already correct (`false`); the gap was purely documentation.

## What changed

Clarified in three places that flow from a single source (the JSDoc):

- **`nys-globalheader.ts`** — expanded the `nysLogo` JSDoc with intent + default.
- **`nys-globalheader.mdx`** — added a note to the *NYS Brand Mark* section and Do/Don't lists.
- **`custom-elements.json`** + React type wrappers — regenerated via `npm run cem` so the manifest (and the MCP server that reads it) carry the new guidance.

## The rule

`nysLogo` is **off by default**. Enable it **only for internal, state-employee (back-office) apps that omit `nys-unavheader`**. Any resident-facing app — even one requiring login — should keep `nys-unavheader` for trust and leave `nysLogo` off.

## Notes

- Docs-only; no behavior or API change.
- The reference site (`nysds-site`) already documents this correctly, so no companion PR is needed there.
