### PR TITLE
fix: declare lit as a peerDependency across published packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,5 +136,8 @@
     "dompurify": "^3.4.7",
     "wc-datepicker": "^0.10.0"
   },
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-accordion/package.json
+++ b/packages/nys-accordion/package.json
@@ -40,5 +40,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-alert/package.json
+++ b/packages/nys-alert/package.json
@@ -41,5 +41,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-avatar/package.json
+++ b/packages/nys-avatar/package.json
@@ -41,5 +41,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-backtotop/package.json
+++ b/packages/nys-backtotop/package.json
@@ -42,5 +42,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-badge/package.json
+++ b/packages/nys-badge/package.json
@@ -41,5 +41,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-breadcrumbs/package.json
+++ b/packages/nys-breadcrumbs/package.json
@@ -40,5 +40,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-button/package.json
+++ b/packages/nys-button/package.json
@@ -41,5 +41,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-checkbox/package.json
+++ b/packages/nys-checkbox/package.json
@@ -43,5 +43,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-combobox/package.json
+++ b/packages/nys-combobox/package.json
@@ -38,5 +38,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-datepicker/package.json
+++ b/packages/nys-datepicker/package.json
@@ -45,5 +45,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-divider/package.json
+++ b/packages/nys-divider/package.json
@@ -37,5 +37,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-dropdownmenu/package.json
+++ b/packages/nys-dropdownmenu/package.json
@@ -42,5 +42,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-errormessage/package.json
+++ b/packages/nys-errormessage/package.json
@@ -40,5 +40,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-fileinput/package.json
+++ b/packages/nys-fileinput/package.json
@@ -44,5 +44,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-globalfooter/package.json
+++ b/packages/nys-globalfooter/package.json
@@ -40,5 +40,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-globalheader/package.json
+++ b/packages/nys-globalheader/package.json
@@ -40,5 +40,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-icon/package.json
+++ b/packages/nys-icon/package.json
@@ -37,5 +37,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-label/package.json
+++ b/packages/nys-label/package.json
@@ -41,5 +41,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-modal/package.json
+++ b/packages/nys-modal/package.json
@@ -40,5 +40,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-pagination/package.json
+++ b/packages/nys-pagination/package.json
@@ -41,5 +41,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-radiobutton/package.json
+++ b/packages/nys-radiobutton/package.json
@@ -42,5 +42,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-select/package.json
+++ b/packages/nys-select/package.json
@@ -43,5 +43,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-skipnav/package.json
+++ b/packages/nys-skipnav/package.json
@@ -37,5 +37,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-stepper/package.json
+++ b/packages/nys-stepper/package.json
@@ -41,5 +41,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-tab/package.json
+++ b/packages/nys-tab/package.json
@@ -40,5 +40,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-table/package.json
+++ b/packages/nys-table/package.json
@@ -42,5 +42,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-textarea/package.json
+++ b/packages/nys-textarea/package.json
@@ -43,5 +43,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-textinput/package.json
+++ b/packages/nys-textinput/package.json
@@ -43,5 +43,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-toggle/package.json
+++ b/packages/nys-toggle/package.json
@@ -41,5 +41,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-tooltip/package.json
+++ b/packages/nys-tooltip/package.json
@@ -38,5 +38,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-unavfooter/package.json
+++ b/packages/nys-unavfooter/package.json
@@ -38,5 +38,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-unavheader/package.json
+++ b/packages/nys-unavheader/package.json
@@ -43,5 +43,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }

--- a/packages/nys-video/package.json
+++ b/packages/nys-video/package.json
@@ -37,5 +37,8 @@
   ],
   "author": "New York State Design System Team",
   "license": "MIT",
-  "sideEffects": true
+  "sideEffects": true,
+  "peerDependencies": {
+    "lit": "^3.3.1"
+  }
 }


### PR DESCRIPTION
## What this fixes

Our published ESM builds **externalize** `lit` — the bundler intentionally leaves bare `import ... from "lit"` in the dist output (`vite.config.js` → `externalEs`), so the consumer provides Lit. That's the right call for a component library (avoids duplicate Lit copies). But the manifests only listed `lit` under **`devDependencies`**, which npm does **not** install for consumers. Result: a clean `npm`/ESM install in a project that doesn't already have Lit fails at resolution time:

```
ERR_MODULE_NOT_FOUND — Cannot find package 'lit' imported from
  .../node_modules/@nysds/components/dist/nysds.es.js
```

This restores `lit` to **`peerDependencies`** (keeping the existing `devDependency`) on the root `@nysds/components` package and every published `@nysds/nys-*` component package. **Manifest-only change — no bundle output changes.**

## Why now / how it went unnoticed

Regressed in `b128bc77` ("Upgrade Vite"), which deleted the `peerDependencies` block as collateral while reshuffling dependency sections. First shipped in **v1.11.0** (~8 months ago). It stayed hidden because the common consumption paths all sidestep it:

- **CDN / esm.sh** consumers get Lit resolved automatically by the CDN.
- **UMD / `require`** consumers use the UMD build, which bundles Lit in.
- **Apps that already use Lit** have it hoisted in `node_modules`, so the bare import resolves.

Only a clean **npm + native-ESM** install with no other Lit in the tree hits it. Low-severity but a genuine npm-contract violation (shipped code imports an undeclared package).

## The fix

Each affected `package.json` gains:

```jsonc
"peerDependencies": { "lit": "^3.3.1" }
```

Range mirrors the existing `devDependency`. `lit` stays in `devDependencies` so the repo still builds/tests — this is an *add*, not a move.

## Verification

Packed `@nysds/components` and installed it into a clean project with no Lit present:

**Before:** `npm ls lit` → `└── (empty)` and ESM import throws `ERR_MODULE_NOT_FOUND`.

**After:**
```
└─┬ @nysds/components@…
  └── lit@3.3.3        ← npm auto-installs the peer
```

34 packages updated (root + 33 components); diff is peer-block-only, all valid JSON.

Fixes #1683
