### PR TITLE
chore: auto-enable nys-cdo Claude Code plugin marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "extraKnownMarketplaces": {
+    "nys-cdo": {
+      "source": { "source": "github", "repo": "nys-cdo/ops-claude-plugins" },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "nysds-dev@nys-cdo": true,
+    "cdo-common@nys-cdo": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.claude/settings.json` so that cloning + trusting this repo automatically registers the private `nys-cdo` Claude Code plugin marketplace (`nys-cdo/ops-claude-plugins`) and enables two plugins for anyone working here:

- **`nysds-dev`** — worktree/springboard workflow, component scaffolding, preflight, release prep, the NYSDS specialist subagents, and the NYSDS MCP server
- **`cdo-common`** — CDO engineering conventions (WCAG/branching/PR), repo naming, GitHub team/access model

Result: zero-touch setup — teammates get the standard tooling without running any `/plugin` commands.

## Notes

- `.claude/` is gitignored in this repo, so the file is **force-added** — following the existing precedent of the force-tracked `.claude/agents/` and `.claude/CLAUDE.md`.
- Plugins `autoUpdate` from the marketplace, so future improvements roll out on `/reload-plugins`.
- Requires read access to `nys-cdo/ops-claude-plugins` (private).

## Breaking changes

None. Purely additive editor configuration; no code or build impact.

Closes #1688