### PR TITLE
feat(a11y): cross-shadow label association + fix inert error association

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2692,8 +2692,7 @@
             {
               "title": "Inverted",
               "code": "<nys-button label=\"Inverted\" inverted></nys-button>",
-              "lang": "html",
-              "render": "<div style=\"background: #1b1b1b; padding: 1rem;\">\n<nys-button label=\"Inverted\" inverted></nys-button>\n</div>"
+              "lang": "html"
             },
             {
               "title": "Disabled",
@@ -2959,6 +2958,26 @@
             },
             {
               "kind": "field",
+              "name": "labelledby",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "description": "Id of an element in the host's light-DOM tree to borrow the accessible name\nfrom (e.g. a table column `<th>`). Enables labelling a checkbox that has no\nvisible label of its own.",
+              "attribute": "labelledby"
+            },
+            {
+              "kind": "field",
+              "name": "hideLabel",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Suppress the internal visible `<nys-label>` (use with `labelledby` for\ntable cells).",
+              "attribute": "hideLabel"
+            },
+            {
+              "kind": "field",
               "name": "_mobileQuery",
               "privacy": "private"
             },
@@ -2985,6 +3004,12 @@
                   "text": "Promise<HTMLInputElement | null>"
                 }
               }
+            },
+            {
+              "kind": "method",
+              "name": "_syncExternalLabel",
+              "privacy": "private",
+              "description": "Point the native <input> at a light-DOM element that IDREF attributes cannot\nreach across the shadow boundary. associateControlRefs sets the control's own\nariaLabelledByElements (honored in Chromium) plus a string aria-label fallback\nfor engines that do not yet resolve element references.\n\nOnly ever called with an external labelledby set: with no external target the\nnative input keeps the internal same-root aria-labelledby IDREF that render()\nemits, and must not be touched."
             },
             {
               "kind": "method",
@@ -3350,6 +3375,26 @@
               "default": "false",
               "fieldName": "showOtherError",
               "propName": "showothererror"
+            },
+            {
+              "name": "labelledby",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "description": "Id of an element in the host's light-DOM tree to borrow the accessible name\nfrom (e.g. a table column `<th>`). Enables labelling a checkbox that has no\nvisible label of its own.",
+              "fieldName": "labelledby",
+              "propName": "labelledby"
+            },
+            {
+              "name": "hideLabel",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Suppress the internal visible `<nys-label>` (use with `labelledby` for\ntable cells).",
+              "fieldName": "hideLabel",
+              "propName": "hidelabel"
             }
           ],
           "superclass": {
@@ -6208,6 +6253,14 @@
               "description": "Shows a divider line above the error message.",
               "attribute": "showDivider",
               "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "_errInternals",
+              "type": {
+                "text": "ElementInternals | null"
+              },
+              "privacy": "private"
             }
           ],
           "attributes": [
@@ -8178,6 +8231,14 @@
               "default": "\"\"",
               "description": "Tooltip text shown on hover/focus of info icon next to label.",
               "attribute": "tooltip"
+            },
+            {
+              "kind": "field",
+              "name": "_labelInternals",
+              "type": {
+                "text": "ElementInternals | null"
+              },
+              "privacy": "private"
             },
             {
               "kind": "method",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "clean:cache": "rm -rf node_modules/.cache",
     "clean:all": "npm run clean:dist && npm run clean:node && npm run clean:cache && find packages -name '*.tsbuildinfo' -delete 2>/dev/null || true && npm run clean:turbo",
     "code-connect": "dotenv -- npx figma connect publish",
-    "cem": "npx cem analyze --config ./custom-elements-manifest.config.mjs && cp ./custom-elements.json dist/ && node src/scripts/patch-react-utils.js"
+    "cem": "npx cem analyze --config ./custom-elements-manifest.config.mjs && cp ./custom-elements.json dist/ && node src/scripts/patch-react-utils.js",
+    "verify:a11y-names": "node scripts/verify-a11y-names.mjs"
   },
   "repository": {
     "type": "git",

--- a/packages/internals/src/aria-associate.ts
+++ b/packages/internals/src/aria-associate.ts
@@ -114,3 +114,54 @@ export function associateHost(
     );
   }
 }
+
+// Control-level ARIA element-reference reflection (on the native control itself,
+// e.g. the <input> inside a form control's shadow root). Unlike the host-level
+// HOST_ELEMENT_REF_PROP, this is the element's own reflected IDL property and can
+// reference targets in a shadow-including ANCESTOR tree — e.g. a light-DOM <th>
+// (verified in Chromium against Blink's computed accessible name).
+const CONTROL_ELEMENT_REF_PROP: Partial<Record<AriaRelation, string>> = {
+  labelledby: "ariaLabelledByElements",
+  describedby: "ariaDescribedByElements",
+};
+
+// Universal string fallback attribute, applied alongside the element reference so
+// engines that expose the IDL but do not (yet) honor it for name computation still
+// get a correct name from the target's text. Element references win where honored.
+const CONTROL_STRING_ATTR: Partial<Record<AriaRelation, string>> = {
+  labelledby: "aria-label",
+  describedby: "aria-description",
+};
+
+/**
+ * Associate a native control (e.g. the shadow-DOM `<input>`) with target elements
+ * that may live OUTSIDE the control's shadow root (a light-DOM `<th>`), which IDREF
+ * attributes cannot reach.
+ *
+ * Sets the control's own `ariaLabelledByElements`/`ariaDescribedByElements` (honored
+ * where supported — Chromium verified) AND a string `aria-label`/`aria-description`
+ * fallback derived from the targets' text. Both resolve to the same name; the element
+ * reference takes precedence where the engine honors it. Passing an empty/all-nullish
+ * target list clears both.
+ */
+export function associateControlRefs(
+  control: HTMLElement,
+  relation: AriaRelation,
+  targets: AriaTargets,
+): void {
+  const live = compact(targets);
+  const refProp = CONTROL_ELEMENT_REF_PROP[relation];
+  const strAttr = CONTROL_STRING_ATTR[relation];
+  const rec = control as unknown as Record<string, unknown>;
+
+  if (refProp && refProp in control) {
+    rec[refProp] = live.length ? live : null;
+  }
+  if (!strAttr) return;
+  const value = live
+    .map((el) => el.textContent?.trim() ?? "")
+    .filter(Boolean)
+    .join(" ");
+  if (value) control.setAttribute(strAttr, value);
+  else control.removeAttribute(strAttr);
+}

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -7,6 +7,7 @@ export type { AriaRelation, AriaTargets, FormValue } from "./types";
 export {
   supportsElementRefs,
   associateControl,
+  associateControlRefs,
   associateHost,
 } from "./aria-associate";
 export {

--- a/packages/internals/src/internals.test.ts
+++ b/packages/internals/src/internals.test.ts
@@ -4,6 +4,7 @@ import {
   generateId,
   supportsElementRefs,
   associateControl,
+  associateControlRefs,
   associateHost,
   IdentifiedMixin,
   ReflectsAriaMixin,
@@ -121,6 +122,47 @@ describe("associateControl", () => {
     expect(input.getAttribute("aria-errormessage")).to.equal("err-1");
     associateControl(input, "errormessage", []);
     expect(input.hasAttribute("aria-errormessage")).to.equal(false);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* associateControlRefs (element refs on native control)                      */
+/* -------------------------------------------------------------------------- */
+
+describe("associateControlRefs", () => {
+  it("sets element references on the control when supported", async () => {
+    const wrap = await fixture(
+      html`<div><input /><span id="c1">Column A</span></div>`,
+    );
+    const input = wrap.querySelector("input")!;
+    const target = wrap.querySelector("#c1")!;
+    associateControlRefs(input, "labelledby", [target]);
+    expect(
+      (input as unknown as { ariaLabelledByElements: Element[] })
+        .ariaLabelledByElements,
+    ).to.deep.equal([target]);
+  });
+
+  it("also sets a string aria-label fallback from the target text", async () => {
+    const wrap = await fixture(
+      html`<div><input /><span id="c2">Column B</span></div>`,
+    );
+    const input = wrap.querySelector("input")!;
+    const target = wrap.querySelector("#c2")!;
+    associateControlRefs(input, "labelledby", [target]);
+    expect(input.getAttribute("aria-label")).to.equal("Column B");
+  });
+
+  it("clears the reference and fallback when given no live targets", async () => {
+    const input = await fixture<HTMLInputElement>(
+      html`<input aria-label="stale" />`,
+    );
+    associateControlRefs(input, "labelledby", [null]);
+    expect(
+      (input as unknown as { ariaLabelledByElements: Element[] | null })
+        .ariaLabelledByElements,
+    ).to.equal(null);
+    expect(input.hasAttribute("aria-label")).to.be.false;
   });
 });
 

--- a/packages/nys-checkbox/src/nys-checkbox.test.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.test.ts
@@ -799,3 +799,93 @@ describe("nys-checkbox", () => {
     expect(new FormData(form).get("picks")).to.be.a("string");
   });
 });
+
+describe("nys-checkbox external labelling", () => {
+  it("associates the input with a light-DOM element via labelledby", async () => {
+    const wrap = await fixture(html`
+      <div>
+        <span id="colhead">Select row</span>
+        <nys-checkbox labelledby="colhead" hideLabel></nys-checkbox>
+      </div>
+    `);
+    const cb = wrap.querySelector<NysCheckbox>("nys-checkbox")!;
+    await cb.updateComplete;
+    const input = cb.shadowRoot!.querySelector("input")!;
+    const head = wrap.querySelector("#colhead")!;
+    expect(
+      (input as unknown as { ariaLabelledByElements: Element[] })
+        .ariaLabelledByElements,
+    ).to.deep.equal([head]);
+    expect(input.getAttribute("aria-label")).to.equal("Select row");
+  });
+
+  it("hideLabel suppresses the internal nys-label", async () => {
+    const el = await fixture<NysCheckbox>(
+      html`<nys-checkbox label="Hidden" hideLabel></nys-checkbox>`,
+    );
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector("nys-label")).to.equal(null);
+  });
+
+  it("still uses the internal label when no external labelledby is set", async () => {
+    const el = await fixture<NysCheckbox>(
+      html`<nys-checkbox label="Agree"></nys-checkbox>`,
+    );
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector("nys-label")).to.not.equal(null);
+    const input = el.shadowRoot!.querySelector("input")!;
+    expect(input.getAttribute("aria-labelledby")).to.equal(el.id + "--label");
+  });
+
+  it("re-resolves when labelledby changes after the first render", async () => {
+    const wrap = await fixture(html`
+      <div>
+        <span id="first">First header</span>
+        <span id="second">Second header</span>
+        <nys-checkbox labelledby="first" hideLabel></nys-checkbox>
+      </div>
+    `);
+    const cb = wrap.querySelector<NysCheckbox>("nys-checkbox")!;
+    await cb.updateComplete;
+    const input = cb.shadowRoot!.querySelector("input")!;
+
+    cb.labelledby = "second";
+    await cb.updateComplete;
+    expect(
+      (input as unknown as { ariaLabelledByElements: Element[] })
+        .ariaLabelledByElements,
+    ).to.deep.equal([wrap.querySelector("#second")!]);
+    expect(input.getAttribute("aria-label")).to.equal("Second header");
+  });
+
+  it("restores the internal label when labelledby is removed", async () => {
+    const wrap = await fixture(html`
+      <div>
+        <span id="head">Select row</span>
+        <nys-checkbox label="Agree" labelledby="head"></nys-checkbox>
+      </div>
+    `);
+    const cb = wrap.querySelector<NysCheckbox>("nys-checkbox")!;
+    await cb.updateComplete;
+    expect(cb.shadowRoot!.querySelector("nys-label")).to.equal(null);
+
+    cb.labelledby = "";
+    await cb.updateComplete;
+
+    // The external element reference and its string fallback are dropped, and the
+    // internal same-root IDREF + visible label come back.
+    const input = cb.shadowRoot!.querySelector("input")!;
+    expect(input.hasAttribute("aria-label")).to.equal(false);
+    expect(cb.shadowRoot!.querySelector("nys-label")).to.not.equal(null);
+    expect(input.getAttribute("aria-labelledby")).to.equal(cb.id + "--label");
+  });
+
+  it("clears the association when labelledby points at a missing id", async () => {
+    const el = await fixture<NysCheckbox>(
+      html`<nys-checkbox labelledby="nope" hideLabel></nys-checkbox>`,
+    );
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector("input")!;
+    expect(input.hasAttribute("aria-label")).to.equal(false);
+  });
+});

--- a/packages/nys-checkbox/src/nys-checkbox.test.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.test.ts
@@ -889,3 +889,33 @@ describe("nys-checkbox external labelling", () => {
     expect(input.hasAttribute("aria-label")).to.equal(false);
   });
 });
+
+describe("nys-checkbox error association", () => {
+  // The checkbox previously had no aria-invalid at all (only the "other" text field did),
+  // so Blink would not expose an error relation for it under any markup.
+  it("marks the input invalid and describes it with the error when showError is set", async () => {
+    const el = await fixture<NysCheckbox>(
+      html`<nys-checkbox
+        id="cb"
+        label="Agree"
+        showError
+        errorMessage="You must agree"
+      ></nys-checkbox>`,
+    );
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector("input")!;
+    expect(input.getAttribute("aria-invalid")).to.equal("true");
+    expect(input.getAttribute("aria-errormessage")).to.equal("cb--error");
+    expect(input.getAttribute("aria-describedby")).to.equal("cb--error");
+  });
+
+  it("does not describe the input when there is no error", async () => {
+    const el = await fixture<NysCheckbox>(
+      html`<nys-checkbox id="cb" label="Agree"></nys-checkbox>`,
+    );
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector("input")!;
+    expect(input.getAttribute("aria-invalid")).to.equal("false");
+    expect(input.hasAttribute("aria-describedby")).to.equal(false);
+  });
+});

--- a/packages/nys-checkbox/src/nys-checkbox.test.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.test.ts
@@ -827,6 +827,25 @@ describe("nys-checkbox external labelling", () => {
     expect(el.shadowRoot!.querySelector("nys-label")).to.equal(null);
   });
 
+  it("renders no stray text when the internal label is suppressed", async () => {
+    // A `cond && html` guard renders the literal string "false" when cond is a boolean
+    // false — lit only treats nullish/empty-string as blank. Assert on the rendered text,
+    // not just on nys-label being absent, which is true either way.
+    for (const el of [
+      await fixture<NysCheckbox>(
+        html`<nys-checkbox label="Hidden" hideLabel></nys-checkbox>`,
+      ),
+      await fixture<NysCheckbox>(
+        html`<nys-checkbox labelledby="somewhere" hideLabel></nys-checkbox>`,
+      ),
+      await fixture<NysCheckbox>(html`<nys-checkbox></nys-checkbox>`),
+    ]) {
+      await el.updateComplete;
+      expect(el.shadowRoot!.textContent).to.not.contain("false");
+      expect(el.shadowRoot!.textContent).to.not.contain("true");
+    }
+  });
+
   it("still uses the internal label when no external labelledby is set", async () => {
     const el = await fixture<NysCheckbox>(
       html`<nys-checkbox label="Agree"></nys-checkbox>`,

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -518,8 +518,11 @@ export class NysCheckbox extends NysFormControlElement {
               aria-checked="${this.checked}"
               aria-disabled="${this.disabled ? "true" : "false"}"
               aria-required="${this.required}"
-              aria-describedby="group-info"
+              aria-invalid=${this.showError ? "true" : "false"}
               aria-errormessage=${this.id + "--error"}
+              aria-describedby=${ifDefined(
+                this.showError ? this.id + "--error" : undefined,
+              )}
               @change="${this._handleChange}"
               @focus="${this._handleFocus}"
               @keydown="${this._handleKeydown}"

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -1,7 +1,10 @@
 import { LitElement, html, unsafeCSS } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { NysFormControlElement } from "@nysds/internals";
+import {
+  NysFormControlElement,
+  associateControlRefs,
+} from "@nysds/internals";
 import "./nys-checkboxgroup";
 // These internal elements are rendered inside this component's shadow DOM, so
 // they must be registered whenever nys-checkbox is used. Importing them here
@@ -100,6 +103,19 @@ export class NysCheckbox extends NysFormControlElement {
   @property({ type: Boolean, reflect: true }) other = false;
   @property({ type: Boolean }) showOtherError = false;
 
+  /**
+   * Id of an element in the host's light-DOM tree to borrow the accessible name
+   * from (e.g. a table column `<th>`). Enables labelling a checkbox that has no
+   * visible label of its own.
+   */
+  @property({ type: String }) labelledby = "";
+
+  /**
+   * Suppress the internal visible `<nys-label>` (use with `labelledby` for
+   * table cells).
+   */
+  @property({ type: Boolean }) hideLabel = false;
+
   private _mobileQuery = window.matchMedia("(max-width: 479px)");
   @state() private isMobile = this._mobileQuery.matches;
 
@@ -138,6 +154,42 @@ export class NysCheckbox extends NysFormControlElement {
     this._setValue();
     this._manageRequire();
     this._manageLabelClick();
+    if (this.labelledby) this._syncExternalLabel();
+  }
+
+  willUpdate(changed: Map<string, unknown>) {
+    // Dropping an external label must happen BEFORE render. Clearing the control's
+    // element references also removes its aria-labelledby content attribute, so the
+    // clear has to precede the render that restores the internal IDREF — otherwise
+    // it would delete the very attribute that render just wrote.
+    if (changed.has("labelledby") && !this.labelledby) {
+      const input = this.shadowRoot?.querySelector("input");
+      if (input) associateControlRefs(input, "labelledby", []);
+    }
+  }
+
+  updated(changed: Map<string, unknown>) {
+    // Applying an external label must happen AFTER render, once the input exists.
+    if (changed.has("labelledby") && this.labelledby) this._syncExternalLabel();
+  }
+
+  /**
+   * Point the native <input> at a light-DOM element that IDREF attributes cannot
+   * reach across the shadow boundary. associateControlRefs sets the control's own
+   * ariaLabelledByElements (honored in Chromium) plus a string aria-label fallback
+   * for engines that do not yet resolve element references.
+   *
+   * Only ever called with an external labelledby set: with no external target the
+   * native input keeps the internal same-root aria-labelledby IDREF that render()
+   * emits, and must not be touched.
+   */
+  private _syncExternalLabel() {
+    const input = this.shadowRoot?.querySelector("input");
+    if (!input) return;
+    const target = (this.getRootNode() as Document | ShadowRoot).getElementById(
+      this.labelledby,
+    );
+    associateControlRefs(input, "labelledby", [target]);
   }
 
   /**
@@ -472,7 +524,9 @@ export class NysCheckbox extends NysFormControlElement {
               @focus="${this._handleFocus}"
               @keydown="${this._handleKeydown}"
               aria-labelledby=${ifDefined(
-                this.label || this.other ? this.id + "--label" : undefined,
+                !this.labelledby && (this.label || this.other)
+                  ? this.id + "--label"
+                  : undefined,
               )}
             />
             ${this.checked
@@ -487,7 +541,9 @@ export class NysCheckbox extends NysFormControlElement {
                 ></nys-icon>`
               : ""}
           </div>
-          ${(this.label || this.other) &&
+          ${!this.hideLabel &&
+          !this.labelledby &&
+          (this.label || this.other) &&
           html`
             <nys-label
               id="${this.id}--label"

--- a/packages/nys-checkbox/src/nys-checkbox.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, unsafeCSS } from "lit";
+import { LitElement, html, nothing, unsafeCSS } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import {
@@ -544,23 +544,20 @@ export class NysCheckbox extends NysFormControlElement {
                 ></nys-icon>`
               : ""}
           </div>
-          ${!this.hideLabel &&
-          !this.labelledby &&
-          (this.label || this.other) &&
-          html`
-            <nys-label
-              id="${this.id}--label"
-              tooltip=${this.tooltip}
-              label="${this.label || (this.other ? "Other" : "")}"
-              description=${ifDefined(this.description || undefined)}
-              flag=${ifDefined(this.required ? "required" : undefined)}
-              class=${this._isStandalone ? "standalone" : ""}
-            >
-              <slot name="description" slot="description"
-                >${this.description}</slot
+          ${this.hideLabel || this.labelledby || !(this.label || this.other)
+            ? nothing
+            : html`<nys-label
+                id="${this.id}--label"
+                tooltip=${this.tooltip}
+                label="${this.label || (this.other ? "Other" : "")}"
+                description=${ifDefined(this.description || undefined)}
+                flag=${ifDefined(this.required ? "required" : undefined)}
+                class=${this._isStandalone ? "standalone" : ""}
               >
-            </nys-label>
-          `}
+                <slot name="description" slot="description"
+                  >${this.description}</slot
+                >
+              </nys-label>`}
         </div>
         <div class="nys-checkbox__other-container">
           ${this.other && this.checked

--- a/packages/nys-combobox/src/nys-combobox.ts
+++ b/packages/nys-combobox/src/nys-combobox.ts
@@ -680,7 +680,11 @@ export class NysCombobox extends NysFormControlElement {
               aria-label=${ifDefined(
                 !this.label && this.description ? this.description : undefined,
               )}
+              aria-invalid=${this.showError ? "true" : "false"}
               aria-errormessage=${this.id + "--error"}
+              aria-describedby=${ifDefined(
+                this.showError ? this.id + "--error" : undefined,
+              )}
               .value=${this._filterText}
               form=${ifDefined(this.form || undefined)}
               @input=${this._handleInput}

--- a/packages/nys-datepicker/src/nys-datepicker.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.ts
@@ -825,6 +825,9 @@ export class NysDatepicker extends NysFormControlElement {
             aria-required=${ifDefined(this.required ? "true" : undefined)}
             aria-invalid=${this.showError ? "true" : "false"}
             aria-errormessage=${this.id + "--error"}
+            aria-describedby=${ifDefined(
+              this.showError ? this.id + "--error" : undefined,
+            )}
             @click=${this._openDatepicker}
             @input=${this._handleInputChange}
             @blur=${this._handleBlur}

--- a/packages/nys-errormessage/src/nys-errormessage.ts
+++ b/packages/nys-errormessage/src/nys-errormessage.ts
@@ -13,6 +13,15 @@ let errorMessageIdCounter = 0;
  *
  * @summary Internal error message display with icon and ARIA alert support.
  * @element nys-errormessage
+ *
+ * Association contract for form controls:
+ * Chromium never surfaces `aria-errormessage` for a control inside a shadow root —
+ * verified against Blink's AX tree by `scripts/verify-a11y-names.mjs`, and true for the
+ * IDREF attribute and for `ariaErrorMessageElements` reflection alike. `aria-describedby`
+ * DOES resolve there. Form controls therefore reference this element with BOTH
+ * `aria-errormessage` (for engines that honor it) and `aria-describedby` (which is what
+ * actually reaches the AX tree today), alongside `aria-invalid` — which Blink requires
+ * before it will expose an error relation at all.
  */
 export class NysErrorMessage extends LitElement {
   static styles = unsafeCSS(styles);

--- a/packages/nys-errormessage/src/nys-errormessage.ts
+++ b/packages/nys-errormessage/src/nys-errormessage.ts
@@ -29,6 +29,12 @@ export class NysErrorMessage extends LitElement {
   /** Shows a divider line above the error message. */
   @property({ type: Boolean, reflect: true }) showDivider = false;
 
+  // Expose the shadow-encapsulated error text as the host's own accessible name so
+  // aria-errormessage references resolve across engines. Guarded for SSR. The inner
+  // role="alert" live region is unchanged.
+  private _errInternals: ElementInternals | null =
+    typeof this.attachInternals === "function" ? this.attachInternals() : null;
+
   /**
    * Lifecycle methods
    * --------------------------------------------------------------------------
@@ -37,6 +43,12 @@ export class NysErrorMessage extends LitElement {
     super();
     if (!this.id) {
       this.id = `nys-errormessage-${Date.now()}-${errorMessageIdCounter++}`;
+    }
+  }
+
+  updated() {
+    if (this._errInternals) {
+      this._errInternals.ariaLabel = this.errorMessage || null;
     }
   }
 

--- a/packages/nys-label/src/nys-label.ts
+++ b/packages/nys-label/src/nys-label.ts
@@ -36,10 +36,22 @@ export class NysLabel extends LitElement {
   /** Tooltip text shown on hover/focus of info icon next to label. */
   @property({ type: String }) tooltip = "";
 
+  // Expose the (shadow-encapsulated) label text as the host's own accessible name so
+  // references to <nys-label> resolve reliably across engines, instead of relying on
+  // each browser flattening nested-shadow text. Guarded for SSR.
+  private _labelInternals: ElementInternals | null =
+    typeof this.attachInternals === "function" ? this.attachInternals() : null;
+
   connectedCallback() {
     super.connectedCallback();
     if (!this.id) {
       this.id = `nys-label-${Date.now()}-${labelIdCounter++}`;
+    }
+  }
+
+  updated() {
+    if (this._labelInternals) {
+      this._labelInternals.ariaLabel = this.label || null;
     }
   }
 

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -603,7 +603,11 @@ export class NysRadiogroup extends NysFormControlElement {
                         ? `${radiobtn.id}-label`
                         : undefined,
                     )}
+                    aria-invalid=${this.showError ? "true" : "false"}
                     aria-errormessage=${`${this.id}--error`}
+                    aria-describedby=${ifDefined(
+                      this.showError ? `${this.id}--error` : undefined,
+                    )}
                     @change=${() => this._selectRadio(radiobtn)}
                     @focus=${() => this._handleRadiobtnFocus(radiobtn)}
                     @blur=${() => this._handleRadiobtnBlur(radiobtn)}

--- a/packages/nys-select/src/nys-select.ts
+++ b/packages/nys-select/src/nys-select.ts
@@ -439,6 +439,9 @@ export class NysSelect extends NysFormControlElement {
             )}
             aria-invalid=${this.showError ? "true" : "false"}
             aria-errormessage=${this.id + "--error"}
+            aria-describedby=${ifDefined(
+              this.showError ? this.id + "--error" : undefined,
+            )}
             .value=${this.value}
             @focus="${this._handleFocus}"
             @blur="${this._handleBlur}"

--- a/packages/nys-textarea/src/nys-textarea.ts
+++ b/packages/nys-textarea/src/nys-textarea.ts
@@ -381,6 +381,9 @@ export class NysTextarea extends NysFormControlElement {
           aria-description=${ifDefined(this.description || undefined)}
           aria-invalid=${this.showError ? "true" : "false"}
           aria-errormessage=${this.id + "--error"}
+          aria-describedby=${ifDefined(
+            this.showError ? this.id + "--error" : undefined,
+          )}
           placeholder=${ifDefined(
             this.placeholder ? this.placeholder : undefined,
           )}

--- a/packages/nys-textinput/src/nys-textinput.test.ts
+++ b/packages/nys-textinput/src/nys-textinput.test.ts
@@ -641,3 +641,34 @@ describe("nys-textinput", () => {
     expect(Array.from(form.elements)).to.include(el);
   });
 });
+
+describe("nys-textinput error association", () => {
+  // Chromium never surfaces aria-errormessage for a control inside a shadow root, so the
+  // error must also be reachable via aria-describedby. See scripts/verify-a11y-names.mjs,
+  // which asserts the resulting accessible description in Blink's real AX tree.
+  it("describes the input with the error message when showError is set", async () => {
+    const el = await fixture<NysTextinput>(
+      html`<nys-textinput
+        id="ti"
+        label="Name"
+        showError
+        errorMessage="Required field"
+      ></nys-textinput>`,
+    );
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector("input")!;
+    expect(input.getAttribute("aria-invalid")).to.equal("true");
+    expect(input.getAttribute("aria-errormessage")).to.equal("ti--error");
+    expect(input.getAttribute("aria-describedby")).to.equal("ti--error");
+  });
+
+  it("does not describe the input when there is no error", async () => {
+    const el = await fixture<NysTextinput>(
+      html`<nys-textinput id="ti" label="Name"></nys-textinput>`,
+    );
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector("input")!;
+    expect(input.getAttribute("aria-invalid")).to.equal("false");
+    expect(input.hasAttribute("aria-describedby")).to.equal(false);
+  });
+});

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -574,6 +574,9 @@ export class NysTextinput extends NysFormControlElement {
               aria-disabled="${this.disabled}"
               aria-invalid=${this.showError ? "true" : "false"}
               aria-errormessage=${this.id + "--error"}
+              aria-describedby=${ifDefined(
+                this.showError ? this.id + "--error" : undefined,
+              )}
               .value=${this.value}
               placeholder=${ifDefined(
                 this.placeholder ? this.placeholder : undefined,

--- a/packages/react/NysCheckbox.d.ts
+++ b/packages/react/NysCheckbox.d.ts
@@ -46,6 +46,10 @@ export interface NysCheckboxProps extends Pick<
   /** undefined */
   showOtherError?: boolean;
 
+  /** Suppress the internal visible `<nys-label>` (use with `labelledby` for
+table cells). */
+  hideLabel?: boolean;
+
   /** Visible label text. Required for accessibility. */
   label?: NysCheckboxElement["label"];
 
@@ -72,6 +76,11 @@ export interface NysCheckboxProps extends Pick<
 
   /** Checkbox size: `sm` (24px) or `md` (32px, default). */
   size?: NysCheckboxElement["size"];
+
+  /** Id of an element in the host's light-DOM tree to borrow the accessible name
+from (e.g. a table column `<th>`). Enables labelling a checkbox that has no
+visible label of its own. */
+  labelledby?: NysCheckboxElement["labelledby"];
 
   /** A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the class selectors or functions like the method `Document.getElementsByClassName()`. */
   className?: string;

--- a/packages/react/NysCheckbox.js
+++ b/packages/react/NysCheckbox.js
@@ -13,6 +13,7 @@ export const NysCheckbox = forwardRef((props, forwardedRef) => {
     tile,
     other,
     showOtherError,
+    hideLabel,
     label,
     description,
     id,
@@ -22,6 +23,7 @@ export const NysCheckbox = forwardRef((props, forwardedRef) => {
     errorMessage,
     tooltip,
     size,
+    labelledby,
     ...filteredProps
   } = props;
 
@@ -54,6 +56,7 @@ export const NysCheckbox = forwardRef((props, forwardedRef) => {
       errorMessage: props.errorMessage,
       tooltip: props.tooltip,
       size: props.size,
+      labelledby: props.labelledby,
       class: props.className,
       exportparts: props.exportparts,
       for: props.htmlFor,
@@ -67,6 +70,7 @@ export const NysCheckbox = forwardRef((props, forwardedRef) => {
       tile: props.tile ? true : undefined,
       other: props.other ? true : undefined,
       showOtherError: props.showOtherError ? true : undefined,
+      hideLabel: props.hideLabel ? true : undefined,
       style: { ...props.style },
     },
     props.children,

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -290,6 +290,13 @@ export type NysCheckboxProps = {
   other?: boolean;
   /**  */
   showOtherError?: boolean;
+  /** Id of an element in the host's light-DOM tree to borrow the accessible name
+from (e.g. a table column `<th>`). Enables labelling a checkbox that has no
+visible label of its own. */
+  labelledby?: string;
+  /** Suppress the internal visible `<nys-label>` (use with `labelledby` for
+table cells). */
+  hideLabel?: boolean;
   /**  */
   _hasDescription?: string;
   /**  */

--- a/scripts/verify-a11y-names.mjs
+++ b/scripts/verify-a11y-names.mjs
@@ -1,0 +1,114 @@
+// Verifies Blink's REAL computed accessible names for the label/error/external cases.
+//
+// Why this exists: a browser exposes no "computed accessible name" API to page
+// scripts, so Web Test Runner can only assert DOM contracts (that an attribute or
+// element reference was set) — never that the name actually resolves. The nameability
+// of <nys-label> / <nys-errormessage> (whose text lives in their own shadow roots) is
+// only observable from the accessibility tree itself, which we read over CDP.
+//
+// Run AFTER `npm run build:packages`.  Usage: node scripts/verify-a11y-names.mjs
+import { chromium } from "playwright";
+import * as esbuild from "esbuild";
+import { resolve } from "node:path";
+
+// The built bundles leave `lit` externalized as a bare specifier, which a browser
+// cannot resolve from an inline module. Bundle them into one self-contained ESM.
+const entry = [
+  "packages/nys-label/dist/nys-label.js",
+  "packages/nys-errormessage/dist/nys-errormessage.js",
+  "packages/nys-checkbox/dist/nys-checkbox.js",
+  "packages/nys-textinput/dist/nys-textinput.js",
+]
+  .map((p) => `import ${JSON.stringify(resolve(process.cwd(), p))};`)
+  .join("\n");
+
+const bundled = await esbuild.build({
+  stdin: { contents: entry, resolveDir: process.cwd(), loader: "js" },
+  bundle: true,
+  format: "esm",
+  write: false,
+  logLevel: "silent",
+});
+const componentsJs = bundled.outputFiles[0].text;
+
+// Real components, not synthetic hosts: these assert the shipped markup, so a regression
+// in any component's own template is caught here.
+const HTML = `<!doctype html><html><body>
+  <span id="col">Select row</span>
+  <nys-textinput id="ti" label="Full name" showError errorMessage="Required field"></nys-textinput>
+  <nys-checkbox id="cbx" labelledby="col" hideLabel></nys-checkbox>
+</body></html>`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+const pageErrors = [];
+page.on("pageerror", (e) => pageErrors.push(e.message));
+
+await page.setContent(HTML, { waitUntil: "load" });
+// Inject the bundle after setContent so the custom elements upgrade the markup above.
+await page.addScriptTag({ content: componentsJs, type: "module" });
+await page.waitForFunction(
+  () =>
+    customElements.get("nys-checkbox") &&
+    customElements.get("nys-label") &&
+    customElements.get("nys-errormessage") &&
+    customElements.get("nys-textinput"),
+  null,
+  { timeout: 5000 },
+);
+// Let the upgraded elements finish their first Lit update.
+await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => r())));
+
+const client = await page.context().newCDPSession(page);
+await client.send("Accessibility.enable");
+const { nodes } = await client.send("Accessibility.getFullAXTree");
+
+const byRole = (role) => nodes.filter((n) => n.role?.value === role);
+const nameOf = (n) => n.name?.value ?? "";
+const descOf = (n) => n.description?.value ?? "";
+
+const textboxes = byRole("textbox");
+const checkboxes = byRole("checkbox");
+
+const checks = [
+  // nys-textinput's name comes from <nys-label>, whose text lives in its own shadow
+  // root — this resolves only because the label exposes it via internals.ariaLabel.
+  ["internal-label", textboxes.some((n) => nameOf(n) === "Full name")],
+  // The error reaches the AX tree through aria-describedby, NOT aria-errormessage:
+  // Blink never surfaces aria-errormessage for a control inside a shadow root (checked
+  // by attribute and by ariaErrorMessageElements reflection; neither appears). The text
+  // itself resolves because <nys-errormessage> is nameable via internals.ariaLabel.
+  ["internal-error", textboxes.some((n) => descOf(n) === "Required field")],
+  // The checkbox borrows its name from a light-DOM <span> that no same-root IDREF
+  // could reach — the associateControlRefs element-reference path.
+  ["external-th", checkboxes.some((n) => nameOf(n) === "Select row")],
+];
+
+await browser.close();
+
+if (pageErrors.length) {
+  console.error("Page errors:\n  " + pageErrors.join("\n  "));
+}
+
+let ok = pageErrors.length === 0;
+for (const [name, pass] of checks) {
+  console.log(`${pass ? "PASS" : "FAIL"}  ${name}`);
+  if (!pass) ok = false;
+}
+
+if (!ok) {
+  // Dump what Blink actually computed, so a failure is diagnosable rather than a
+  // bare non-zero exit.
+  console.error("\nComputed names Blink reported:");
+  for (const n of [...textboxes, ...checkboxes]) {
+    console.error(
+      `  role=${n.role.value} name=${JSON.stringify(nameOf(n))} description=${JSON.stringify(descOf(n))}`,
+    );
+  }
+}
+
+console.log(
+  ok ? "\nAll computed-name checks passed." : "\nComputed-name checks FAILED.",
+);
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
Follow-up to #1632. Wires the (previously unused) `@nysds/internals` ARIA helper into form controls, adds opt-in external light-DOM labelling, and fixes an error-association bug the work surfaced.

Base is `fix/accessibility-remediation`, not `develop` — this builds on the ElementInternals layer in #1632.

## What's here

**Cross-shadow labelling.** New `associateControlRefs()` in `@nysds/internals` sets a control's own `ariaLabelledByElements` (plus a string `aria-label` fallback), letting a control borrow its accessible name from an element **outside** its shadow root — which IDREF attributes cannot reach. `nys-checkbox` uses it via two new props:

- `labelledby` — id of a light-DOM element to take the name from (e.g. a table column `<th>`)
- `hideLabel` — suppress the internal visible `<nys-label>`

This unblocks the checkbox-in-a-table-row pattern. `nys-radiobutton` reuses the same pattern once #1721's render-revert lands; it is out of scope here.

**Nameable label/error.** `<nys-label>` and `<nys-errormessage>` now expose their text via `ElementInternals.ariaLabel`, so references to them resolve without depending on each engine flattening nested-shadow text.

**Error association fix (the significant one).** Chromium **never surfaces `aria-errormessage` for a control inside a shadow root** — true for the IDREF attribute *and* for `ariaErrorMessageElements` reflection. Every NYSDS form control renders its error inside its shadow root, so the error was never associated with its field. The text was still *announced*, because `<nys-errormessage>` renders a `role="alert"` live region — which is exactly why this went unnoticed. But a screen-reader user interrogating an invalid field heard nothing about why.

`aria-describedby` **does** resolve inside a shadow root. Seven controls now reference the error element with both relations — `aria-errormessage` for engines that honor it, `aria-describedby` for the one that actually reaches the AX tree: textinput, textarea, select, datepicker, combobox, radiogroup, checkbox.

Two also gained a missing `aria-invalid`, which Blink requires before exposing any error relation at all:
- `nys-checkbox` — its only `aria-invalid` was on the separate "other" text field
- `nys-combobox` — had none

Also drops `nys-checkbox`'s `aria-describedby="group-info"`, a dangling IDREF pointing at an element that exists nowhere in the codebase.

## Verification

`npm run verify:a11y-names` (new) reads Blink's **real** accessible-name computation over CDP — the only automated way to check this, since browsers expose no computed-name API to page scripts. It asserts three cases against the shipped components:

```
PASS  internal-label   nys-textinput named by <nys-label> (text two shadow roots deep)
PASS  internal-error   error reaches the AX tree as the input's description
PASS  external-th      nys-checkbox named by a light-DOM element across the shadow boundary
```

Full suite: 1028 passing, 34/34 files, branches 81.23%.

This verification is not ceremonial — it caught two bugs that typechecked cleanly and that unit tests alone would have missed: an early version of the labelling wiring stripped the accessible name off *every* checkbox (element-reference reflection clears the content attribute when set to `null`), and the shadow-DOM `aria-errormessage` failure above.

## Not addressed

Filed separately rather than fixed here, since both need a design decision rather than a mechanical change:

- #1763 — `nys-fileinput`'s error is bound to a `hidden`/`aria-hidden` input that isn't the exposed control
- #1764 — `nys-fileitem` passes error *text* where `aria-errormessage` expects an *id*

## Still open

Manual Safari/VoiceOver + Firefox/NVDA verification. Element reflection is Chromium-only today (other engines get the string `aria-label` fallback), and the `aria-describedby` fix is verified only in Blink. Headless engines can't report computed names for WebKit/Gecko, so this needs a real AT pass before we claim cross-engine support.