### PR TITLE
Fix: Add focus ring on invalid submissions for `nys-radiobutton` and `nys-fileinput`

### DIFF
--- a/packages/nys-button/src/nys-button.scss
+++ b/packages/nys-button/src/nys-button.scss
@@ -617,7 +617,8 @@ a[disabled] {
   pointer-events: none;
 }
 
-.nys-button:focus-visible {
+.nys-button:focus-visible,
+.active-focus {
   outline-offset: var(--_nys-button-outline-offset);
   outline: solid var(--_nys-button-outline-width)
     var(--_nys-button-outline-color);

--- a/packages/nys-radiobutton/src/nys-radiobutton.scss
+++ b/packages/nys-radiobutton/src/nys-radiobutton.scss
@@ -312,7 +312,8 @@
 }
 
 /* When input has focus, show outline on the custom span */
-.nys-radiobutton__radio:focus-visible {
+.nys-radiobutton__radio:focus-visible,
+.nys-radiobutton__radio--invalid-focus {
   outline: solid var(--_nys-radiobutton-outline-width)
     var(--_nys-radiobutton-outline-color);
   outline-offset: var(--_nys-radiobutton-outline-offset);

--- a/packages/nys-radiobutton/src/nys-radiogroup.ts
+++ b/packages/nys-radiobutton/src/nys-radiogroup.ts
@@ -509,9 +509,11 @@ export class NysRadiogroup extends LitElement {
     );
     if (firstEnabledRadio) {
       const focusFirstInput = () => {
-        this.shadowRoot
-          ?.querySelector<HTMLElement>(`#input-${firstEnabledRadio.id}`)
-          ?.focus();
+        const input = this.shadowRoot?.querySelector<HTMLElement>(
+          `#input-${firstEnabledRadio.id}`,
+        );
+        input?.focus();
+        input?.classList.add("nys-radiobutton__radio--invalid-focus");
       };
 
       // Focus only if this is the first invalid element (top-down approach)
@@ -624,6 +626,11 @@ export class NysRadiogroup extends LitElement {
   }
 
   private _handleRadiobtnBlur(radiobtn: NysRadiobutton) {
+    const input = this.shadowRoot?.querySelector<HTMLElement>(
+      `#input-${radiobtn.id}`,
+    );
+    input?.classList.remove("nys-radiobutton__radio--invalid-focus");
+
     radiobtn.dispatchEvent(
       new CustomEvent("nys-blur", { bubbles: true, composed: true }),
     );


### PR DESCRIPTION


<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
> [!NOTE]
> Feel free to ask Robert for a Demo of this

Adds the missing focus ring for required `nys-radiobutton` and `nys-fileinput` components when form submission triggers validation.


## Breaking change

This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1731 🎟️
