### PR TITLE
Fix: Change `nys-change` event `files` value

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7056,9 +7056,9 @@
               "privacy": "private",
               "parameters": [
                 {
-                  "name": "changedFile",
+                  "name": "changedFiles",
                   "type": {
-                    "text": "FileWithProgress"
+                    "text": "FileWithProgress[]"
                   }
                 }
               ]
@@ -7158,7 +7158,7 @@
               "type": {
                 "text": "CustomEvent"
               },
-              "description": "Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: \"pending\" | \"processing\" | \"done\" | \"error\", errorMsg?: string }`."
+              "description": "Fired once per user action (file selection, drop, or removal). Detail: `{id, files, changedFiles}`. The `files` is the full current selection Whereas `changedFiles` is the entries this action added or removed. Both `changedFiles` and each entry in `files` are `{ file: File, progress: number, status: \"pending\" | \"processing\" | \"done\" | \"error\", errorMsg?: string }`."
             }
           ],
           "attributes": [

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7143,6 +7143,24 @@
                   }
                 }
               ]
+            },
+            {
+              "kind": "method",
+              "name": "_addFiles",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "Promise<FileWithProgress[]>"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "files",
+                  "type": {
+                    "text": "File[]"
+                  }
+                }
+              ]
             }
           ],
           "events": [

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -7053,7 +7053,15 @@
             {
               "kind": "method",
               "name": "_dispatchChangeEvent",
-              "privacy": "private"
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "changedFile",
+                  "type": {
+                    "text": "FileWithProgress"
+                  }
+                }
+              ]
             },
             {
               "kind": "method",
@@ -7150,7 +7158,7 @@
               "type": {
                 "text": "CustomEvent"
               },
-              "description": "Fired when files are added or removed. Detail: `{id, files}`."
+              "description": "Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: \"pending\" | \"processing\" | \"done\" | \"error\", errorMsg?: string }`."
             }
           ],
           "attributes": [

--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -30,9 +30,10 @@ interface FileWithProgress {
  *
  * @slot description - Custom HTML description content.
  *
- * @fires nys-change - Fired once per file added/removed. Detail: `{id, files, changedFile}`.
- * The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed.
- * Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
+ * @fires nys-change - Fired once per user action (file selection, drop, or removal).
+ * Detail: `{id, files, changedFiles}`. The `files` is the full current selection
+ * Whereas `changedFiles` is the entries this action added or removed.
+ * Both `changedFiles` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
  *
  * @fires nys-blur - Fired when focus leaves the component. Triggers validation.
  *
@@ -544,13 +545,13 @@ export class NysFileinput extends LitElement {
     );
   }
 
-  private _dispatchChangeEvent(changedFile: FileWithProgress) {
+  private _dispatchChangeEvent(changedFiles: FileWithProgress[]) {
     this.dispatchEvent(
       new CustomEvent("nys-change", {
         detail: {
           id: this.id,
           files: this._selectedFiles,
-          changedFile,
+          changedFiles,
         },
         bubbles: true,
         composed: true,
@@ -608,19 +609,22 @@ export class NysFileinput extends LitElement {
     const newFiles = files ? Array.from(files) : []; // changes FileList to array
 
     // Store the uploaded files
-    for (const file of newFiles) {
-      const added = await this._saveSelectedFiles(file);
-      if (added) this._dispatchChangeEvent(added);
-    }
+    const results = await Promise.all(
+      newFiles.map((file) => this._saveSelectedFiles(file)),
+    );
+    const changedFiles = results.filter(
+      (entry): entry is FileWithProgress => entry !== undefined,
+    );
 
     this.requestUpdate();
+    if (changedFiles.length) this._dispatchChangeEvent(changedFiles);
     this._handlePostFileSelectionFocus();
   }
 
   private _handleFileRemove(e: CustomEvent) {
     const fileNameToRemove = e.detail.filename;
 
-    const targetFileToRemove = this._selectedFiles.find(
+    const removed = this._selectedFiles.find(
       (existingFile) => existingFile.file.name === fileNameToRemove,
     );
 
@@ -640,7 +644,7 @@ export class NysFileinput extends LitElement {
     this._validate();
 
     this.requestUpdate();
-    if (targetFileToRemove) this._dispatchChangeEvent(targetFileToRemove);
+    if (removed) this._dispatchChangeEvent([removed]);
   }
 
   private _onDragOver(e: DragEvent) {
@@ -680,12 +684,13 @@ export class NysFileinput extends LitElement {
     const newFiles = Array.from(files);
     const filesToAdd = this.multiple ? newFiles : [newFiles[0]];
 
-    for (const file of filesToAdd) {
-      const added = await this._saveSelectedFiles(file);
-      if (added) this._dispatchChangeEvent(added);
-    }
+    const results = await Promise.all(
+      filesToAdd.map((file) => this._saveSelectedFiles(file)),
+    );
+    const changedFiles = results.filter((entry) => entry !== undefined);
 
     this.requestUpdate();
+    if (changedFiles.length) this._dispatchChangeEvent(changedFiles);
   }
 
   render() {

--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -609,12 +609,7 @@ export class NysFileinput extends LitElement {
     const newFiles = files ? Array.from(files) : []; // changes FileList to array
 
     // Store the uploaded files
-    const results = await Promise.all(
-      newFiles.map((file) => this._saveSelectedFiles(file)),
-    );
-    const changedFiles = results.filter(
-      (entry): entry is FileWithProgress => entry !== undefined,
-    );
+    const changedFiles = await this._addFiles(newFiles);
 
     this.requestUpdate();
     if (changedFiles.length) this._dispatchChangeEvent(changedFiles);
@@ -684,13 +679,19 @@ export class NysFileinput extends LitElement {
     const newFiles = Array.from(files);
     const filesToAdd = this.multiple ? newFiles : [newFiles[0]];
 
-    const results = await Promise.all(
-      filesToAdd.map((file) => this._saveSelectedFiles(file)),
-    );
-    const changedFiles = results.filter((entry) => entry !== undefined);
+    const changedFiles = await this._addFiles(filesToAdd);
 
     this.requestUpdate();
     if (changedFiles.length) this._dispatchChangeEvent(changedFiles);
+  }
+
+  private async _addFiles(files: File[]): Promise<FileWithProgress[]> {
+    const savedEntries = await Promise.all(
+      files.map((file) => this._saveSelectedFiles(file)),
+    );
+    return savedEntries.filter(
+      (entry): entry is FileWithProgress => entry !== undefined,
+    );
   }
 
   render() {

--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -30,7 +30,10 @@ interface FileWithProgress {
  *
  * @slot description - Custom HTML description content.
  *
- * @fires nys-change - Fired when files are added or removed. Detail: `{id, files}`, where `files` is `File[]`.
+ * @fires nys-change - Fired once per file added/removed. Detail: `{id, files, changedFile}`.
+ * The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed.
+ * Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
+ *
  * @fires nys-blur - Fired when focus leaves the component. Triggers validation.
  *
  * @example Basic
@@ -482,6 +485,8 @@ export class NysFileinput extends LitElement {
     // Now that the file is added, update form value and validation
     this._setValue();
     this._validate();
+
+    return entry;
   }
 
   // Read the contents of stored files, this will indicate loading progress of the uploaded files
@@ -539,10 +544,14 @@ export class NysFileinput extends LitElement {
     );
   }
 
-  private _dispatchChangeEvent() {
+  private _dispatchChangeEvent(changedFile: FileWithProgress) {
     this.dispatchEvent(
       new CustomEvent("nys-change", {
-        detail: { id: this.id, files: this._selectedFiles.map((entry) => entry.file) },
+        detail: {
+          id: this.id,
+          files: this._selectedFiles,
+          changedFile,
+        },
         bubbles: true,
         composed: true,
       }),
@@ -593,27 +602,31 @@ export class NysFileinput extends LitElement {
    */
 
   // Access the selected files & add new files to the internal list via the hidden <input type="file">
-  private _handleFileChange(e: Event) {
+  private async _handleFileChange(e: Event) {
     const input = e.target as HTMLInputElement;
     const files = input.files;
     const newFiles = files ? Array.from(files) : []; // changes FileList to array
 
     // Store the uploaded files
-    newFiles.map((file) => {
-      this._saveSelectedFiles(file);
-    });
+    for (const file of newFiles) {
+      const added = await this._saveSelectedFiles(file);
+      if (added) this._dispatchChangeEvent(added);
+    }
 
     this.requestUpdate();
-    this._dispatchChangeEvent();
     this._handlePostFileSelectionFocus();
   }
 
   private _handleFileRemove(e: CustomEvent) {
-    const filenameToRemove = e.detail.filename;
+    const fileNameToRemove = e.detail.filename;
+
+    const targetFileToRemove = this._selectedFiles.find(
+      (existingFile) => existingFile.file.name === fileNameToRemove,
+    );
 
     // Remove selected files
     this._selectedFiles = this._selectedFiles.filter(
-      (existingFile) => existingFile.file.name !== filenameToRemove,
+      (existingFile) => existingFile.file.name !== fileNameToRemove,
     );
 
     if (this._selectedFiles.length === 0) {
@@ -627,7 +640,7 @@ export class NysFileinput extends LitElement {
     this._validate();
 
     this.requestUpdate();
-    this._dispatchChangeEvent();
+    if (targetFileToRemove) this._dispatchChangeEvent(targetFileToRemove);
   }
 
   private _onDragOver(e: DragEvent) {
@@ -654,7 +667,7 @@ export class NysFileinput extends LitElement {
     }
   }
 
-  private _onDrop(e: DragEvent) {
+  private async _onDrop(e: DragEvent) {
     if (this.disabled) return;
 
     e.preventDefault();
@@ -665,17 +678,14 @@ export class NysFileinput extends LitElement {
     if (!files) return;
 
     const newFiles = Array.from(files);
+    const filesToAdd = this.multiple ? newFiles : [newFiles[0]];
 
-    if (this.multiple) {
-      newFiles.forEach((file) => {
-        this._saveSelectedFiles(file);
-      });
-    } else {
-      this._saveSelectedFiles(newFiles[0]);
+    for (const file of filesToAdd) {
+      const added = await this._saveSelectedFiles(file);
+      if (added) this._dispatchChangeEvent(added);
     }
 
     this.requestUpdate();
-    this._dispatchChangeEvent();
   }
 
   render() {

--- a/packages/nys-fileinput/src/nys-fileinput.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.ts
@@ -30,7 +30,7 @@ interface FileWithProgress {
  *
  * @slot description - Custom HTML description content.
  *
- * @fires nys-change - Fired when files are added or removed. Detail: `{id, files}`.
+ * @fires nys-change - Fired when files are added or removed. Detail: `{id, files}`, where `files` is `File[]`.
  * @fires nys-blur - Fired when focus leaves the component. Triggers validation.
  *
  * @example Basic
@@ -542,7 +542,7 @@ export class NysFileinput extends LitElement {
   private _dispatchChangeEvent() {
     this.dispatchEvent(
       new CustomEvent("nys-change", {
-        detail: { id: this.id, files: this._selectedFiles },
+        detail: { id: this.id, files: this._selectedFiles.map((entry) => entry.file) },
         bubbles: true,
         composed: true,
       }),

--- a/packages/react/NysFileinput.d.ts
+++ b/packages/react/NysFileinput.d.ts
@@ -105,7 +105,7 @@ Reads the first selected file (or `null`); setting replaces the selection. */
   /** Fired when focus leaves the component. Triggers validation. */
   onNysBlur?: (event: CustomEvent) => void;
 
-  /** Fired when files are added or removed. Detail: `{id, files}`. */
+  /** Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`. */
   onNysChange?: (event: CustomEvent) => void;
 }
 
@@ -116,7 +116,7 @@ Reads the first selected file (or `null`); setting replaces the selection. */
  *
  * ### **Events:**
  *  - **nys-blur** - Fired when focus leaves the component. Triggers validation.
- * - **nys-change** - Fired when files are added or removed. Detail: `{id, files}`.
+ * - **nys-change** - Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
  *
  * ### **Methods:**
  *  - **setFiles(incoming: _File[]_): _Promise<void>_** - Programmatically set the selection and await async validation/processing.

--- a/packages/react/NysFileinput.d.ts
+++ b/packages/react/NysFileinput.d.ts
@@ -105,7 +105,7 @@ Reads the first selected file (or `null`); setting replaces the selection. */
   /** Fired when focus leaves the component. Triggers validation. */
   onNysBlur?: (event: CustomEvent) => void;
 
-  /** Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`. */
+  /** Fired once per user action (file selection, drop, or removal). Detail: `{id, files, changedFiles}`. The `files` is the full current selection Whereas `changedFiles` is the entries this action added or removed. Both `changedFiles` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`. */
   onNysChange?: (event: CustomEvent) => void;
 }
 
@@ -116,7 +116,7 @@ Reads the first selected file (or `null`); setting replaces the selection. */
  *
  * ### **Events:**
  *  - **nys-blur** - Fired when focus leaves the component. Triggers validation.
- * - **nys-change** - Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
+ * - **nys-change** - Fired once per user action (file selection, drop, or removal). Detail: `{id, files, changedFiles}`. The `files` is the full current selection Whereas `changedFiles` is the entries this action added or removed. Both `changedFiles` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
  *
  * ### **Methods:**
  *  - **setFiles(incoming: _File[]_): _Promise<void>_** - Programmatically set the selection and await async validation/processing.

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -509,7 +509,7 @@ Reads the first selected file (or `null`); setting replaces the selection. */
   value?: File | null;
   /** Fired when focus leaves the component. Triggers validation. */
   "onnys-blur"?: (e: CustomEvent<Event>) => void;
-  /** Fired when files are added or removed. Detail: `{id, files}`. */
+  /** Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`. */
   "onnys-change"?: (e: CustomEvent<CustomEvent>) => void;
 };
 
@@ -1292,7 +1292,7 @@ export type CustomElements = {
    *
    * ### **Events:**
    *  - **nys-blur** - Fired when focus leaves the component. Triggers validation.
-   * - **nys-change** - Fired when files are added or removed. Detail: `{id, files}`.
+   * - **nys-change** - Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
    *
    * ### **Methods:**
    *  - **setFiles(incoming: _File[]_): _Promise<void>_** - Programmatically set the selection and await async validation/processing.

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -509,7 +509,7 @@ Reads the first selected file (or `null`); setting replaces the selection. */
   value?: File | null;
   /** Fired when focus leaves the component. Triggers validation. */
   "onnys-blur"?: (e: CustomEvent<Event>) => void;
-  /** Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`. */
+  /** Fired once per user action (file selection, drop, or removal). Detail: `{id, files, changedFiles}`. The `files` is the full current selection Whereas `changedFiles` is the entries this action added or removed. Both `changedFiles` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`. */
   "onnys-change"?: (e: CustomEvent<CustomEvent>) => void;
 };
 
@@ -1292,7 +1292,7 @@ export type CustomElements = {
    *
    * ### **Events:**
    *  - **nys-blur** - Fired when focus leaves the component. Triggers validation.
-   * - **nys-change** - Fired once per file added/removed. Detail: `{id, files, changedFile}`. The `files` is the full current selection. The `changedFile` is the single entry file the `nys-change` event added or removed. Both `changedFile` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
+   * - **nys-change** - Fired once per user action (file selection, drop, or removal). Detail: `{id, files, changedFiles}`. The `files` is the full current selection Whereas `changedFiles` is the entries this action added or removed. Both `changedFiles` and each entry in `files` are `{ file: File, progress: number, status: "pending" | "processing" | "done" | "error", errorMsg?: string }`.
    *
    * ### **Methods:**
    *  - **setFiles(incoming: _File[]_): _Promise<void>_** - Programmatically set the selection and await async validation/processing.


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary

Adds `changedFile` to `nys-change`'s detail. It documents the changed file entries, whereas `file` shows the overall files. 

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1724 🎟️

## Testing
Done on the [React Demo](https://github.com/ITS-HCD/nysds-react-demo) 