### PR TITLE
Fix: read component dependencies from package.json 

### DIFF
--- a/packages/nys-accordion/src/nys-accordion.stories.ts
+++ b/packages/nys-accordion/src/nys-accordion.stories.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-accordion";
 import "./nys-accordionitem";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Accordion",

--- a/packages/nys-alert/src/nys-alert.stories.ts
+++ b/packages/nys-alert/src/nys-alert.stories.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-alert";
 import "@nysds/nys-button";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Alert",

--- a/packages/nys-avatar/src/nys-avatar.stories.ts
+++ b/packages/nys-avatar/src/nys-avatar.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-avatar";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Avatar",

--- a/packages/nys-backtotop/src/nys-backtotop.stories.ts
+++ b/packages/nys-backtotop/src/nys-backtotop.stories.ts
@@ -1,10 +1,11 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-backtotop";
-import "@nysds/nys-unavheader";
-import "@nysds/nys-globalheader";
-import "@nysds/nys-unavfooter";
 import "@nysds/nys-button";
+import "@nysds/nys-globalheader";
+import "@nysds/nys-icon";
+import "@nysds/nys-unavfooter";
+import "@nysds/nys-unavheader";
 
 const meta: Meta = {
   title: "Components/Backtotop",

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-badge";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Badge",

--- a/packages/nys-breadcrumbs/src/nys-breadcrumbs.stories.ts
+++ b/packages/nys-breadcrumbs/src/nys-breadcrumbs.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-breadcrumbs";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Breadcrumbs",

--- a/packages/nys-checkbox/src/nys-checkbox.stories.ts
+++ b/packages/nys-checkbox/src/nys-checkbox.stories.ts
@@ -2,8 +2,9 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-checkbox";
 import "./nys-checkboxgroup";
-import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
+import "@nysds/nys-label";
 import "@nysds/nys-textinput";
 
 const meta: Meta = {

--- a/packages/nys-combobox/src/nys-combobox.stories.ts
+++ b/packages/nys-combobox/src/nys-combobox.stories.ts
@@ -1,8 +1,10 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-combobox";
-import "@nysds/nys-label";
+import "@nysds/nys-button";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
+import "@nysds/nys-label";
 
 const meta: Meta = {
   title: "Components/Combobox",

--- a/packages/nys-datepicker/src/nys-datepicker.stories.ts
+++ b/packages/nys-datepicker/src/nys-datepicker.stories.ts
@@ -1,8 +1,10 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-datepicker";
-import "@nysds/nys-label";
+import "@nysds/nys-button";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
+import "@nysds/nys-label";
 
 const meta: Meta = {
   title: "Components/Datepicker",

--- a/packages/nys-dropdownmenu/src/nys-dropdownmenu.stories.ts
+++ b/packages/nys-dropdownmenu/src/nys-dropdownmenu.stories.ts
@@ -1,8 +1,9 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-dropdownmenu";
-import "@nysds/nys-button";
 import "./nys-dropdownmenuitem";
+import "@nysds/nys-button";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Dropdownmenu",

--- a/packages/nys-errormessage/src/nys-errormessage.stories.ts
+++ b/packages/nys-errormessage/src/nys-errormessage.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-errormessage";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Errormessage",

--- a/packages/nys-fileinput/src/nys-fileinput.stories.ts
+++ b/packages/nys-fileinput/src/nys-fileinput.stories.ts
@@ -1,8 +1,11 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-fileinput";
-import "@nysds/nys-label";
+import "./nys-fileitem";
+import "@nysds/nys-button";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
+import "@nysds/nys-label";
 
 const meta: Meta = {
   title: "Components/Fileinput",

--- a/packages/nys-globalfooter/src/nys-globalfooter.stories.ts
+++ b/packages/nys-globalfooter/src/nys-globalfooter.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-globalfooter";
+import "@nysds/nys-divider";
 
 const meta: Meta = {
   title: "Components/Globalfooter",

--- a/packages/nys-globalheader/src/nys-globalheader.stories.ts
+++ b/packages/nys-globalheader/src/nys-globalheader.stories.ts
@@ -1,9 +1,10 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-globalheader";
-import "@nysds/nys-button";
 import "@nysds/nys-avatar";
+import "@nysds/nys-button";
 import "@nysds/nys-dropdownmenu";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Globalheader",

--- a/packages/nys-label/src/nys-label.stories.ts
+++ b/packages/nys-label/src/nys-label.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-label";
+import "@nysds/nys-icon";
 import "@nysds/nys-tooltip";
 
 const meta: Meta = {

--- a/packages/nys-pagination/src/nys-pagination.stories.ts
+++ b/packages/nys-pagination/src/nys-pagination.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-pagination";
+import "@nysds/nys-button";
 
 const meta: Meta = {
   title: "Components/Pagination",

--- a/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
+++ b/packages/nys-radiobutton/src/nys-radiobutton.stories.ts
@@ -2,8 +2,8 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-radiobutton";
 import "./nys-radiogroup";
-import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-label";
 import "@nysds/nys-textinput";
 
 const meta: Meta = {

--- a/packages/nys-select/src/nys-select.stories.ts
+++ b/packages/nys-select/src/nys-select.stories.ts
@@ -1,8 +1,10 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-select";
-import "@nysds/nys-label";
+import "./nys-option";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
+import "@nysds/nys-label";
 
 const meta: Meta = {
   title: "Components/Select",

--- a/packages/nys-table/src/nys-table.stories.ts
+++ b/packages/nys-table/src/nys-table.stories.ts
@@ -1,6 +1,8 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-table";
+import "@nysds/nys-button";
+import "@nysds/nys-icon";
 
 const meta: Meta = {
   title: "Components/Table",

--- a/packages/nys-textarea/src/nys-textarea.stories.ts
+++ b/packages/nys-textarea/src/nys-textarea.stories.ts
@@ -1,8 +1,9 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-textarea";
-import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
+import "@nysds/nys-label";
 
 const meta: Meta = {
   title: "Components/Textarea",

--- a/packages/nys-textinput/package.json
+++ b/packages/nys-textinput/package.json
@@ -22,6 +22,7 @@
     "lit-analyze": "lit-analyzer '**/*.ts'"
   },
   "dependencies": {
+    "@nysds/nys-button": "^1.19.4",
     "@nysds/nys-icon": "^1.19.4",
     "@nysds/nys-label": "^1.19.4",
     "@nysds/nys-errormessage": "^1.19.4"

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -2,8 +2,9 @@ import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-textinput";
 import "@nysds/nys-button";
-import "@nysds/nys-label";
 import "@nysds/nys-errormessage";
+import "@nysds/nys-icon";
+import "@nysds/nys-label";
 
 const meta: Meta = {
   title: "Components/Textinput",

--- a/packages/nys-toggle/src/nys-toggle.stories.ts
+++ b/packages/nys-toggle/src/nys-toggle.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-toggle";
+import "@nysds/nys-icon";
 import "@nysds/nys-label";
 
 const meta: Meta = {

--- a/packages/nys-unavheader/src/nys-unavheader.stories.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.stories.ts
@@ -1,6 +1,8 @@
 import { html } from "lit";
 import { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./nys-unavheader";
+import "@nysds/nys-button";
+import "@nysds/nys-icon";
 import "@nysds/nys-textinput";
 
 const meta: Meta = {

--- a/src/scripts/generate-stories.mjs
+++ b/src/scripts/generate-stories.mjs
@@ -624,7 +624,8 @@ async function main() {
       while ((m = tagRe.exec(renderCode)) !== null) usedTags.add(m[1]);
     });
 
-    // Also scan source files for internal usage of common components
+    // Also scan source files for any nys-* tag rendered internally (e.g. the
+    // nys-label / nys-errormessage a form control renders in its own template).
     const componentSourceFiles = fs
       .readdirSync(dir)
       .filter(
@@ -632,25 +633,44 @@ async function main() {
       );
     for (const f of componentSourceFiles) {
       const content = fs.readFileSync(path.join(dir, f), "utf8");
-      if (content.includes("<nys-label")) usedTags.add("nys-label");
-      if (content.includes("<nys-errormessage")) usedTags.add("nys-errormessage");
-      if (content.includes("<nys-textinput")) usedTags.add("nys-textinput");
+      const tagRe = /<(nys-[\w-]+)/g;
+      let m;
+      while ((m = tagRe.exec(content)) !== null) usedTags.add(m[1]);
     }
 
-    const siblingImports = [...usedTags]
-      .filter((t) => t !== componentName)
-      .map((t) => {
-        const modPath = tagToModule[t];
-        if (modPath) {
-          if (path.dirname(modPath) === dir) {
-            return `import "./${t}";`;
+    // Every @nysds/nys-* dependency declared in the package's package.json is
+    // needed at runtime, including transitive-only ones that never appear as a
+    // literal tag here (e.g. nys-textinput slots a nys-button whose prefixIcon
+    // renders a nys-icon). Import them all so stories don't silently render
+    // undefined elements.
+    const declaredPackageDeps = new Set();
+    const pkgJsonPath = path.join(path.dirname(dir), "package.json");
+    if (fs.existsSync(pkgJsonPath)) {
+      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+      for (const depName of Object.keys(pkgJson.dependencies || {})) {
+        const match = depName.match(/^@nysds\/(nys-[\w-]+)$/);
+        if (match && match[1] !== componentName) declaredPackageDeps.add(match[1]);
+      }
+    }
+
+    const siblingImports = [
+      ...[...usedTags]
+        .filter((t) => t !== componentName)
+        .map((t) => {
+          const modPath = tagToModule[t];
+          if (modPath) {
+            if (path.dirname(modPath) === dir) {
+              return `import "./${t}";`;
+            }
+            const pkg = tagToPackage[t] ?? t;
+            return `import "@nysds/${pkg}";`;
           }
-          const pkg = tagToPackage[t] ?? t;
-          return `import "@nysds/${pkg}";`;
-        }
-        return `import "@nysds/${t}";`;
-      })
+          return `import "@nysds/${t}";`;
+        }),
+      ...[...declaredPackageDeps].map((pkg) => `import "@nysds/${pkg}";`),
+    ]
       .filter((imp, i, arr) => arr.indexOf(imp) === i)  // dedupe same-package tags
+      .sort()
       .join("\n");
 
     // Hoist all <script data-scope="module"> blocks to module scope, deduped


### PR DESCRIPTION
Before the gen-stories script juct checked what components were used in the examples to figure out what needs to be imported to storybook. Now it also reads the package.json file. This mostly effected icons when they were not directly used in a component but needed to be rendered. In the below example the `nys-button` is read by the gen-stories script and knows to import button but it couldn't tell that icon needed to be imported too since it was used as a prop.

```
<nys-textinput id="search-demo" type="search" placeholder="Search">
  <nys-button
    slot="endButton"
    ariaLabel="Search"
    prefixIcon="search"
    onclick="alert('searching for: ' + document.getElementById('search-demo').value)"
  ></nys-button>
</nys-textinput>
```