### PR TITLE
Fix/textinput search clear focus

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -13897,6 +13897,11 @@
             },
             {
               "kind": "method",
+              "name": "_clearSearch",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
               "name": "_updateOverlay",
               "privacy": "private",
               "parameters": [

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -14295,6 +14295,11 @@
               "lang": "html"
             },
             {
+              "title": "Password",
+              "code": "<nys-textinput type=\"password\"></nys-textinput>",
+              "lang": "html"
+            },
+            {
               "title": "Max Min Values",
               "code": "<nys-textinput type=\"number\" label=\"Age\" min=\"18\" max=\"99\" width=\"sm\"></nys-textinput>",
               "lang": "html"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test:ssr": "node src/scripts/test-ssr.mjs && npm run audit:dist",
     "audit:dist": "node src/scripts/audit-dist.mjs",
     "test:build": "npm run build:all && npm run test",
+    "test:report": "wtr --node-resolve || true && open coverage/lcov-report/index.html",
     "test:compact": "export NYSDS_TEST_OUTPUT=compact && wtr --node-resolve",
     "test:ai": "export NYSDS_TEST_OUTPUT=ai && wtr --node-resolve",
     "storybook": "cross-env NODE_ENV=production storybook dev -p 6006",

--- a/packages/nys-textinput/src/nys-textinput.scss
+++ b/packages/nys-textinput/src/nys-textinput.scss
@@ -135,6 +135,13 @@
   font: inherit;
 }
 
+/* Hide the browser's native search clear "X" — replaced by the nys-button above */
+.nys-textinput__input[type="search"]::-webkit-search-cancel-button,
+.nys-textinput__input[type="search"]::-webkit-search-decoration {
+  appearance: none;
+  display: none;
+}
+
 .nys-textinput__input::placeholder {
   color: var(--_nys-textinput-color--placeholder);
 }
@@ -192,7 +199,7 @@
     var(--_nys-textinput-border-radius) 0;
 }
 
-.eye-icon {
+.inline-icon {
   position: absolute;
   right: var(--nys-space-50, 4px);
   top: 50%;
@@ -209,7 +216,6 @@
   --_nys-button-outline-focus: calc(var(--_nys-button-outline-width) * -1);
 
   /* Needs to be negative of the offset width */
-
   --_nys-button-padding--y: var(--nys-space-50, 4px);
   --_nys-button-padding--x: var(--nys-space-50, 4px);
   --_nys-button-height: var(--nys-size-300, 32px);

--- a/packages/nys-textinput/src/nys-textinput.stories.ts
+++ b/packages/nys-textinput/src/nys-textinput.stories.ts
@@ -284,6 +284,21 @@ export const Masking: Story = {
   },
 };
 
+export const Password: Story = {
+  render: () => {
+    return html` <nys-textinput type="password"></nys-textinput> `;
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-textinput type="password"></nys-textinput>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
 export const MaxMinValues: Story = {
   render: () => {
     return html`

--- a/packages/nys-textinput/src/nys-textinput.test.ts
+++ b/packages/nys-textinput/src/nys-textinput.test.ts
@@ -84,6 +84,69 @@ describe("nys-textinput", () => {
     expect(input?.type).to.equal("password");
   });
 
+  it("only shows the search clear button when type is search and a value exists", async () => {
+    const el = await fixture<NysTextinput>(
+      html`<nys-textinput type="search"></nys-textinput>`,
+    );
+    expect(el.shadowRoot?.querySelector("#search-clear")).to.not.exist;
+
+    el.value = "albany";
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector("#search-clear")).to.exist;
+
+    // not offered on other types
+    const textEl = await fixture<NysTextinput>(
+      html`<nys-textinput value="albany"></nys-textinput>`,
+    );
+    expect(textEl.shadowRoot?.querySelector("#search-clear")).to.not.exist;
+  });
+
+  it("hides the search clear button when disabled or readonly", async () => {
+    const disabled = await fixture<NysTextinput>(
+      html`<nys-textinput
+        type="search"
+        value="albany"
+        disabled
+      ></nys-textinput>`,
+    );
+    expect(disabled.shadowRoot?.querySelector("#search-clear")).to.not.exist;
+
+    const readonly = await fixture<NysTextinput>(
+      html`<nys-textinput
+        type="search"
+        value="albany"
+        readonly
+      ></nys-textinput>`,
+    );
+    expect(readonly.shadowRoot?.querySelector("#search-clear")).to.not.exist;
+  });
+
+  it("clears the value, refocuses the input, and fires nys-input when the search clear button is clicked", async () => {
+    const el = await fixture<NysTextinput>(
+      html`<nys-textinput type="search" value="albany"></nys-textinput>`,
+    );
+    const input = el.shadowRoot?.querySelector("input") as HTMLInputElement;
+    const clearButton = el.shadowRoot?.querySelector(
+      "#search-clear",
+    ) as HTMLElement;
+    const nativeButton = clearButton.shadowRoot?.querySelector(
+      "button",
+    ) as HTMLButtonElement;
+
+    const listener = oneEvent(el, "nys-input");
+    nativeButton.click();
+    const event = await listener;
+    await el.updateComplete;
+
+    expect(el.value).to.equal("");
+    expect(input.value).to.equal("");
+    expect(event.detail.value).to.equal("");
+    expect(event.detail.id).to.equal(el.id);
+    // focus returns to the input, and the button removes itself once empty
+    expect(el.shadowRoot?.activeElement).to.equal(input);
+    expect(el.shadowRoot?.querySelector("#search-clear")).to.not.exist;
+  });
+
   it("displays an error message when required field is empty", async () => {
     const el = await fixture<NysTextinput>(
       html`<nys-textinput required></nys-textinput>`,

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -441,6 +441,30 @@ export class NysTextinput extends LitElement {
     this.showPassword = !this.showPassword;
   }
 
+  private _clearSearch() {
+    this.value = "";
+
+    const input = this._inputEl;
+    if (input) {
+      input.value = "";
+      input.focus();
+    }
+
+    this._internals.setFormValue("");
+
+    if (this._hasUserInteracted) {
+      this._validate();
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("nys-input", {
+        detail: { id: this.id, value: this.value },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
   private _updateOverlay(value: string, mask: string) {
     const overlay = this.shadowRoot?.querySelector(
       ".nys-textinput__mask-overlay",
@@ -652,18 +676,39 @@ export class NysTextinput extends LitElement {
             />
             ${this.type === "password"
               ? html` <nys-button
-                  class="eye-icon"
+                  class="inline-icon"
                   id="password-toggle"
                   ariaLabel="password toggle"
                   variant="ghost"
+                  circle
                   size="sm"
                   @nys-click=${() =>
                     !this.disabled && this._togglePasswordVisibility()}
                 >
                   <nys-icon
-                    slot="suffix-icon"
+                    slot="circle-icon"
                     size="2xl"
                     name=${this.showPassword ? "visibility_off" : "visibility"}
+                  ></nys-icon>
+                </nys-button>`
+              : ""}
+            ${this.type === "search" &&
+            this.value &&
+            !this.disabled &&
+            !this.readonly
+              ? html` <nys-button
+                  class="inline-icon"
+                  id="search-clear"
+                  ariaLabel="clear search"
+                  variant="ghost"
+                  circle
+                  size="sm"
+                  @nys-click=${() => this._clearSearch()}
+                >
+                  <nys-icon
+                    slot="circle-icon"
+                    size="2xl"
+                    name="close"
                   ></nys-icon>
                 </nys-button>`
               : ""}

--- a/packages/nys-textinput/src/nys-textinput.ts
+++ b/packages/nys-textinput/src/nys-textinput.ts
@@ -83,6 +83,11 @@ let textinputIdCounter = 0;
  * </nys-textinput>
  * ```
  *
+ * @example Password
+ * ```html
+ * <nys-textinput type="password"></nys-textinput>
+ * ```
+ *
  * @example Max Min Values
  * ```html
  * <nys-textinput type="number" label="Age" min="18" max="99" width="sm"></nys-textinput>


### PR DESCRIPTION
## Summary
Added a dedicated clear ("X") button to `nys-textinput` in search mode. When `type="search"` has a value, the component now renders its own `nys-button` clear control that empties the field, resets the form value, re-validates, returns focus to the input, and fires `nys-input`. This replaces the browser's native `::-webkit-search-cancel-button`, which is unstyled, visually inconsistent across browsers, and did not keep focus in the field after clearing. The password-visibility toggle was refactored onto the same shared inline-button pattern for consistency.