### PR TITLE
Fix the customElements.define of nys-fileitem

### DIFF
--- a/packages/nys-fileinput/src/nys-fileitem.ts
+++ b/packages/nys-fileinput/src/nys-fileitem.ts
@@ -128,4 +128,6 @@ export class NysFileItem extends LitElement {
   }
 }
 
-customElements.define("nys-fileitem", NysFileItem);
+if (!customElements.get("nys-fileitem")) {
+  customElements.define("nys-fileitem", NysFileItem);
+}


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to New York State's Design System (NYSDS).
Your contributions are vital to our success, and we are glad you're here.

This pull request (PR) template helps speed up reviews and merging into the public codebase.
Please provide as much detail as possible to help us understand the changes you made.
In other words, we love clear explanations!
-->

<!---
Title format:
NYSDS – [Component]: [Brief statement of what this PR solves]
e.g. "NYSDS – Button: Update hover states"
-->

# Summary
Fixes issue with `Uncaught NotSupportedError: Failed to execute 'define' on 'CustomElementRegistry': the name "nys-fileitem" has already been used with this registry` found on the React Demo

<!--
Write in the past tense and include:
- What was changed
- Why was it changed
- The benefit from the update
-->

## Breaking change

This is **not** a breaking change.  


<!--
Breaking changes can include:
  - Changes to a component’s JavaScript API
  - Changes to required HTML/markup
  - Major design or significant style updates
If applicable, explain the required actions users must take to adapt to the change.
-->

## Related issues

Closes https://github.com/ITS-HCD/nysds/issues/1798 🎟️

## Testing
Tested on the React Demo