### PR TITLE
FIX: unav header how you know focus state

### DIFF
--- a/packages/nys-unavheader/src/nys-unavheader.scss
+++ b/packages/nys-unavheader/src/nys-unavheader.scss
@@ -9,7 +9,10 @@
     --nys-color-text,
     var(--nys-color-neutral-900, #1b1b1b)
   );
-  --_nys-unavheader-max-width--content: var(--nys-unavheader-max-width--content, 1280px);
+  --_nys-unavheader-max-width--content: var(
+    --nys-unavheader-max-width--content,
+    1280px
+  );
 
   /* Trustbar, Search Bar, and Language */
   --_nys-unavheader-background-color--section-raised: var(
@@ -124,22 +127,11 @@ a#nys-unavheader__logolink {
   gap: var(--nys-space-50, 4px);
 
   /* These props ARE NOT publicly overridable */
+  --_nys-button-padding--x: var(--nys-space-50, 4px);
+  --_nys-button-padding--y: var(--nys-space-2px, 2px);
   --_nys-button-height: var(--nys-font-lineheight-ui-xs, 20px);
   --_nys-button-border-radius: var(--nys-radius-md, 4px);
-  --_nys-button-padding--y: var(--nys-space-2px, 2px);
-  --_nys-button-padding--x: var(--nys-space-50, 4px);
   --_nys-button-border-width: 0px;
-  --_nys-button-text-decoration: underline;
-
-  /* These props ARE publicly overridable */
-  --nys-button-color: var(--nys-color-link, #004dd1);
-  --nys-button-color--hover: var(--nys-color-link-strong, #003ba1);
-  --nys-button-color--active: var(--nys-color-link-strongest, #002971);
-  --nys-button-background-color--hover: var(--nys-color-transparent, #ffffff00);
-  --nys-button-background-color--active: var(
-    --nys-color-transparent,
-    #ffffff00
-  );
 
   /* typography */
   --_nys-button-font-size: var(--nys-font-size-ui-xs, 12px);

--- a/packages/nys-unavheader/src/nys-unavheader.ts
+++ b/packages/nys-unavheader/src/nys-unavheader.ts
@@ -288,7 +288,7 @@ export class NysUnavHeader extends LitElement {
             <nys-button
               id="nys-unavheader__know"
               label="Here's how you know"
-              variant="ghost"
+              variant="text"
               size="sm"
               @nys-click="${(e: CustomEvent) => {
                 e.preventDefault();
@@ -367,7 +367,7 @@ export class NysUnavHeader extends LitElement {
                 label="Here's how you know"
                 aria-controls="nys-unavheader__closetrustbar"
                 aria-expanded="${this.trustbarVisible}"
-                variant="ghost"
+                variant="text"
                 size="sm"
                 @nys-click="${() =>
                   this._toggleTrustbar("nys-unavheader__know--inline")}"


### PR DESCRIPTION
The "Here's how you know" trustbar toggle was built as a ghost `nys-button` manually restyled to look like a link — underline, link colors, transparent hover/active backgrounds. Now that `nys-button`'s text variant supports icons, the button can use `variant="text"` directly and drop all the local color/decoration overrides, which restores the button's native focus state.