### PR TITLE
NYSDS – Chore: remove dead private CSS custom properties

### DIFF
--- a/packages/nys-avatar/src/nys-avatar.scss
+++ b/packages/nys-avatar/src/nys-avatar.scss
@@ -3,7 +3,6 @@
 
   --_nys-avatar-border-radius: var(--nys-radius-round, 1776px);
   --_nys-avatar-size: var(--nys-avatar-size, var(--nys-font-size-6xl, 36px));
-  --_nys-avatar-shape: var(--nys-radius-round, 1776px);
   --_nys-avatar-border-color: var(--nys-color-ink-reverse, #ffffff);
   --_nys-avatar-border-size: var(--nys-border-width-sm, 1px);
   --_nys-avatar-width: var(--nys-font-size-6xl, 36px);

--- a/packages/nys-backtotop/src/nys-backtotop.scss
+++ b/packages/nys-backtotop/src/nys-backtotop.scss
@@ -1,8 +1,6 @@
 .nys-backtotop {
   /* These props ARE NOT publicly overridable */
   --_nys-button-border-radius: var(--nys-radius-round, 1776px);
-  --_nys-button-padding--y: var(--nys-space-100, 8px);
-  --_nys-button-padding--x: var(--nys-space-200, 16px);
 
   position: fixed;
   bottom: 1rem;

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -2,8 +2,6 @@
   /* Anything that can be overridden should be defined here */
 
   /* Global Badge Styles */
-  --_nys-badge-width: fit-content;
-  --_nys-badge-height: var(--nys-size-600, 48px);
   --_nys-badge-radius: var(--nys-radius-round, 1776px);
   --_nys-badge-padding: var(--nys-space-2-px, 2px) var(--nys-space-100, 8px);
   --_nys-badge-gap: var(--nys-space-50, 4px);

--- a/packages/nys-button/src/nys-button.scss
+++ b/packages/nys-button/src/nys-button.scss
@@ -225,10 +225,6 @@
   --_nys-button-padding--x: 0;
   --_nys-button-border-width: 0px;
   --_nys-button-text-decoration: underline;
-  --_nys-button-text-decoration-thickness: var(
-    --nys-font-decoration-thickness-regular,
-    7%
-  );
   --_nys-button-text-decoration-thickness--hover: var(
     --nys-font-decoration-thickness-strong,
     14%

--- a/packages/nys-checkbox/src/nys-checkbox.scss
+++ b/packages/nys-checkbox/src/nys-checkbox.scss
@@ -28,15 +28,9 @@
     )
   );
   --_nys-checkbox-font-size: var(--nys-font-size-ui-md, 16px);
-  --_nys-checkbox-font-weight: var(--nys-font-weight-regular, 400);
-  --_nys-checkbox-font-weight--standalone: var(--nys-font-weight-semibold, 600);
   --_nys-checkbox-line-height: var(--nys-font-lineheight-ui-md, 24px);
 
   /* Global Checkbox Colors */
-  --_nys-checkbox-color: var(
-    --nys-color-ink,
-    var(--nys-color-neutral-900, #1b1b1b)
-  );
 
   /* Default (Empty) */
   --_nys-checkbox-background-color: var(--nys-color-ink-reverse, #ffffff);
@@ -172,10 +166,6 @@
   --_nys-checkbox-border-color--tile--checked: var(--nys-color-danger, #b52c2c);
 }
 
-.single-error-message {
-  --_nys-errormessage-margin-top: var(--nys-space-50, 4px);
-}
-
 .nys-checkboxgroup {
   display: flex;
   flex-direction: column;
@@ -293,9 +283,6 @@
 .nys-checkbox:has(.nys-checkbox__checkbox:disabled) * {
   color: var(--_nys-checkbox-color--disabled);
   cursor: not-allowed;
-
-  --_nys-label-cursor: not-allowed;
-  --_nys-label-color: var(--_nys-checkbox-color--disabled);
 }
 
 :host([tile]) .nys-checkbox:has(.nys-checkbox__checkbox:disabled) {
@@ -369,18 +356,6 @@
   outline: solid var(--_nys-checkbox-border-width--tile)
     var(--_nys-checkbox-outline-color) !important;
   border-color: var(--_nys-checkbox-outline-color) !important;
-}
-
-:host(:not([tile])) .nys-checkbox__main-container > nys-label {
-  --_nys-label-font-weight: var(--_nys-checkbox-font-weight);
-}
-
-:host(:not([tile])) .nys-checkbox__main-container > nys-label.standalone {
-  --_nys-label-font-weight: var(--_nys-checkbox-font-weight--standalone);
-}
-
-:host([tile]) .nys-checkbox__main-container > nys-label {
-  --_nys-description-font-style: normal;
 }
 
 /* Required */

--- a/packages/nys-combobox/src/nys-combobox.scss
+++ b/packages/nys-combobox/src/nys-combobox.scss
@@ -206,13 +206,6 @@
   right: var(--nys-space-150, 12px);
   gap: var(--nys-space-150, 12px);
 
-  nys-button {
-    --_nys-button-padding--y: var(--nys-space-50, 4px);
-    --_nys-button-padding--x: var(--nys-space-50, 4px);
-    --_nys-button-height: var(--nys-size-300, 32px);
-    --_nys-button-width: var(--nys-size-400, 32px);
-  }
-
   .nys-combobox__chevron {
     border-inline-start: solid var(--nys-color-neutral-200, #bec0c1)
       var(--nys-border-width-sm, 1px);

--- a/packages/nys-datepicker/src/nys-datepicker.scss
+++ b/packages/nys-datepicker/src/nys-datepicker.scss
@@ -1,10 +1,6 @@
 :host {
   /* Global Datepicker Styles */
-  --_nys-datepicker-width: fit-content;
   --_nys-datepicker-width--input: var(--nys-form-width-md, 200px);
-  --_nys-datepicker-gap: var(--nys-space-100, 8px);
-  --_nys-datepicker-height: var(--nys-size-600, 48px);
-  --_nys-datepicker-radius: var(--nys-radius-xl, 12px);
   --_nys-datepicker-color: var(
     --nys-color-text,
     var(--nys-color-neutral-900, #1b1b1b)

--- a/packages/nys-fileinput/src/nys-fileinput.scss
+++ b/packages/nys-fileinput/src/nys-fileinput.scss
@@ -27,10 +27,6 @@
     --nys-color-neutral-10,
     #f6f6f6
   );
-  --_nys-fileinput-background-color--dropzone--active: var(
-    --nys-color-theme-faint,
-    #f7fafd
-  );
   --_nys-fileinput-border-radius--dropzone: var(
     --nys-radius-lg,
     var(--nys-space-100, 8px)

--- a/packages/nys-globalfooter/src/nys-globalfooter.scss
+++ b/packages/nys-globalfooter/src/nys-globalfooter.scss
@@ -61,7 +61,6 @@
   --_nys-globalfooter-text-decoration-thickness: var(--nys-size-2px, 2px);
 
   /* Divider */
-  --_nys-globalfooter-background--divider: var(--nys-color-theme, #154973);
   --_nys-globalfooter-margin--divider: var(--nys-space-50, 4px);
 }
 

--- a/packages/nys-globalheader/src/nys-globalheader.scss
+++ b/packages/nys-globalheader/src/nys-globalheader.scss
@@ -4,10 +4,6 @@
     --nys-color-text-reverse,
     var(--nys-color-white, #ffffff)
   );
-  --_nys-globalheader-link-color: var(
-    --nys-color-link-reverse-neutral,
-    var(--nys-color-white, #ffffff)
-  );
   --_nys-globalheader-background-color: var(
     --nys-color-theme,
     var(--nys-color-state-blue-700, #154973)
@@ -110,11 +106,6 @@ a {
   display: flex;
   align-items: center;
   margin-inline-start: auto;
-
-  --_nys-button-outline-color: var(
-    --nys-color-ink-reverse,
-    var(--nys-color-white, #ffffff)
-  );
 }
 
 .nys-globalheader {

--- a/packages/nys-modal/src/nys-modal.scss
+++ b/packages/nys-modal/src/nys-modal.scss
@@ -1,7 +1,6 @@
 :host {
   /* Global Modal Styles */
   --_nys-modal-width: 439px;
-  --_nys-modal-min-width: 320px;
   --_nys-modal-border-radius: var(--nys-radius-lg, 8px);
   --_nys-modal-border-color: var(--nys-color-neutral-200, #bec0c1);
   --_nys-modal-border-width: 1px;

--- a/packages/nys-pagination/src/nys-pagination.scss
+++ b/packages/nys-pagination/src/nys-pagination.scss
@@ -39,11 +39,6 @@
 }
 
 nys-button {
-  --_nys-button-height: var(--_nys-pagination-height);
-  --_nys-button-border-width: var(--nys-border-width-sm, 1px);
-  --_nys-button-border-radius: var(--nys-radius-md, 4px);
-  --_nys-button-padding--x: var(--nys-space-200, 16px);
-
   &[variant="outline"] {
     --nys-button-background-color: var(--nys-color-ink-reverse, #ffffff);
     --nys-button-background-color--hover: var(--nys-color-neutral-10, #f6f6f6);
@@ -78,7 +73,6 @@ nys-button {
     --nys-button-color: var(--nys-color-text, #1b1b1b);
     --nys-button-color--hover: var(--nys-color-text, #1b1b1b);
     --nys-button-color--active: var(--nys-color-text, #1b1b1b);
-    --_nys-button-padding--x: var(--nys-space-150, 12px);
   }
 
   &#previous--mobile,

--- a/packages/nys-radiobutton/src/nys-radiobutton.light.scss
+++ b/packages/nys-radiobutton/src/nys-radiobutton.light.scss
@@ -1,7 +1,6 @@
 nys-radiobutton {
   /* Global Radiobutton Styles */
   --_nys-radiobutton-size: var(--nys-size-400, 32px);
-  --_nys-radiobutton-border-radius: var(--nys-radius-md, 4px);
   --_nys-radiobutton-border-width: var(--nys-border-width-md, 2px);
   --_nys-radiobutton-outline-color: var(--nys-color-focus, #004dd1);
   --_nys-radiobutton-outline-width: var(--nys-border-width-md, 2px);
@@ -26,14 +25,9 @@ nys-radiobutton {
     )
   );
   --_nys-radiobutton-font-size: var(--nys-font-size-ui-md, 16px);
-  --_nys-radiobutton-font-weight--label: var(--nys-font-weight-regular, 400);
   --_nys-radiobutton-line-height: var(--nys-font-lineheight-ui-md, 24px);
 
   /* Global Radio Button Colors */
-  --_nys-radiobutton-color: var(
-    --nys-color-text,
-    var(--nys-color-neutral-900, #1b1b1b)
-  );
 
   /* Default (Empty) */
   --_nys-radiobutton-background-color: var(--nys-color-ink-reverse, #ffffff);
@@ -81,7 +75,6 @@ nys-radiobutton {
 /* Small Variant */
 nys-radiobutton[size="sm"] {
   --_nys-radiobutton-size: var(--nys-size-300, 24px);
-  --_nys-radiobutton-border-radius: var(--nys-radius-sm, 2px);
   --_nys-radiogroup-gap: var(--nys-space-100, 8px);
   --_nys-radiobutton-gap: var(--nys-space-100, 8px);
 }
@@ -89,14 +82,12 @@ nys-radiobutton[size="sm"] {
 /* Medium Variant */
 nys-radiobutton[size="md"] {
   --_nys-radiobutton-size: var(--nys-size-400, 32px);
-  --_nys-radiobutton-border-radius: var(--nys-radius-md, 4px);
   --_nys-radiogroup-gap: var(--nys-space-200, 16px);
   --_nys-radiobutton-gap: var(--nys-space-150, 12px);
 }
 
 /* Tile Variant */
 nys-radiobutton[tile] {
-  --_nys-radiobutton-font-weight--label: var(--nys-font-weight-semibold, 600);
   --_nys-radiobutton-border-width--tile: var(--nys-border-width-sm, 1px);
   --_nys-radiobutton-border-radius--tile: var(--nys-radius-md, 4px);
   --_nys-radiobutton-border-color--tile: var(--nys-color-neutral-100, #d0d0ce);
@@ -314,14 +305,8 @@ nys-radiobutton:focus-visible .nys-radiobutton__radio {
 }
 
 .nys-radiobutton__main-container > nys-label {
-  --_nys-label-font-weight: var(--_nys-radiobutton-font-weight--label);
-
   display: flex;
   padding-inline-start: var(--_nys-radiobutton-gap);
-}
-
-nys-radiobutton[tile] .nys-radiobutton__main-container > nys-label {
-  --_nys-description-font-style: normal;
 }
 
 .nys-radiobutton:has(.nys-radiobutton__radio:disabled)
@@ -332,10 +317,5 @@ nys-radiobutton[tile] .nys-radiobutton__main-container > nys-label {
   > nys-label
   * {
   cursor: not-allowed;
-
-  --_nys-label-cursor: not-allowed;
-  --_nys-label-color: var(--_nys-radiobutton-color--disabled);
-  --_nys-description-color: var(--_nys-radiobutton-color--disabled);
-
   color: var(--_nys-radiobutton-color--disabled);
 }

--- a/packages/nys-radiobutton/src/nys-radiobutton.scss
+++ b/packages/nys-radiobutton/src/nys-radiobutton.scss
@@ -1,7 +1,6 @@
 :host {
   /* Global Radiobutton Styles */
   --_nys-radiobutton-size: var(--nys-size-400, 32px);
-  --_nys-radiobutton-border-radius: var(--nys-radius-md, 4px);
   --_nys-radiobutton-border-width: var(--nys-border-width-md, 2px);
   --_nys-radiobutton-outline-color: var(--nys-color-focus, #004dd1);
   --_nys-radiobutton-outline-width: var(--nys-border-width-md, 2px);
@@ -26,14 +25,9 @@
     )
   );
   --_nys-radiobutton-font-size: var(--nys-font-size-ui-md, 16px);
-  --_nys-radiobutton-font-weight--label: var(--nys-font-weight-regular, 400);
   --_nys-radiobutton-line-height: var(--nys-font-lineheight-ui-md, 24px);
 
   /* Global Radio Button Colors */
-  --_nys-radiobutton-color: var(
-    --nys-color-text,
-    var(--nys-color-neutral-900, #1b1b1b)
-  );
 
   /* Default (Empty) */
   --_nys-radiobutton-background-color: var(--nys-color-ink-reverse, #ffffff);
@@ -81,7 +75,6 @@
 /* Small Variant */
 :host([size="sm"]) {
   --_nys-radiobutton-size: var(--nys-size-300, 24px);
-  --_nys-radiobutton-border-radius: var(--nys-radius-sm, 2px);
   --_nys-radiogroup-gap: var(--nys-space-100, 8px);
   --_nys-radiobutton-gap: var(--nys-space-100, 8px);
 }
@@ -89,14 +82,12 @@
 /* Medium Variant */
 :host([size="md"]) {
   --_nys-radiobutton-size: var(--nys-size-400, 32px);
-  --_nys-radiobutton-border-radius: var(--nys-radius-md, 4px);
   --_nys-radiogroup-gap: var(--nys-space-200, 16px);
   --_nys-radiobutton-gap: var(--nys-space-150, 12px);
 }
 
 /* Tile Variant */
 :host([tile]) {
-  --_nys-radiobutton-font-weight--label: var(--nys-font-weight-semibold, 600);
   --_nys-radiobutton-border-width--tile: var(--nys-border-width-sm, 1px);
   --_nys-radiobutton-border-radius--tile: var(--nys-radius-md, 4px);
   --_nys-radiobutton-border-color--tile: var(--nys-color-neutral-100, #d0d0ce);
@@ -333,14 +324,8 @@
 }
 
 .nys-radiobutton__main-container > nys-label {
-  --_nys-label-font-weight: var(--_nys-radiobutton-font-weight--label);
-
   display: flex;
   padding-inline-start: var(--_nys-radiobutton-gap);
-}
-
-:host([tile]) .nys-radiobutton__main-container > nys-label {
-  --_nys-description-font-style: normal;
 }
 
 .nys-radiobutton:has(.nys-radiobutton__radio:disabled)
@@ -351,11 +336,6 @@
   > nys-label
   * {
   cursor: not-allowed;
-
-  --_nys-label-cursor: not-allowed;
-  --_nys-label-color: var(--_nys-radiobutton-color--disabled);
-  --_nys-description-color: var(--_nys-radiobutton-color--disabled);
-
   color: var(--_nys-radiobutton-color--disabled);
 }
 

--- a/packages/nys-select/src/nys-select.scss
+++ b/packages/nys-select/src/nys-select.scss
@@ -15,7 +15,6 @@
   );
   --_nys-select-font-size: var(--nys-font-size-ui-md, 16px);
   --_nys-select-font-weight: var(--nys-font-weight-regular, 400);
-  --_nys-select-line-height: var(--nys-font-lineheight-ui-md, 24px);
   --_nys-select-gap: var(--nys-space-50, 4px);
   --_nys-select-border-radius: var(--nys-radius-md, 4px);
   --_nys-select-padding: var(--nys-space-100, 8px) var(--nys-space-400, 32px)
@@ -23,10 +22,6 @@
 
   /* Global Select Colors */
   --_nys-select-color: var(--nys-color-text, #1b1b1b);
-  --_nys-select-color--error: var(
-    --nys-color-danger,
-    var(--nys-color-red-600, #b52c2c)
-  );
   --_nys-select-background-color: var(--nys-color-ink-reverse, #ffffff);
   --_nys-select-background-color--disabled: var(
     --nys-color-neutral-10,
@@ -40,8 +35,6 @@
   --_nys-select-border-color--hover: var(--nys-color-neutral-900, #1b1b1b);
   --_nys-select-border-color--focus: var(--nys-color-focus, #004dd1);
   --_nys-select-border-color--disabled: var(--nys-color-neutral-200, #bec0c1);
-  --_nys-select-border-default: var(--nys-border-width-sm, 1px) solid
-    var(--nys-color-neutral-400, #909395);
 }
 
 :host([inverted]) {
@@ -131,9 +124,4 @@
 
 .nys-select__select:disabled ~ .nys-select__icon {
   color: var(--_nys-select-color--disabled);
-}
-
-:host([showError]) {
-  --_nys-select-border-default: var(--nys-border-width-sm, 1px) solid
-    var(--_nys-select-color--error);
 }

--- a/packages/nys-table/src/nys-table.light.scss
+++ b/packages/nys-table/src/nys-table.light.scss
@@ -67,12 +67,6 @@ nys-table th {
     width: -webkit-fill-available;
     width: fill-available;
     justify-content: space-between;
-
-    --_nys-button-border-width: 0;
-    --_nys-button-border-radius: 0;
-    --_nys-button-padding--x: var(--_nys-table-padding--cell--x);
-    --_nys-button-justify-content: space-between;
-    --_nys-button-outline-offset: -2px;
   }
 }
 

--- a/packages/nys-table/src/nys-table.scss
+++ b/packages/nys-table/src/nys-table.scss
@@ -8,8 +8,6 @@
 
 :host {
   --_nys-table-width: 100%;
-  --_nys-table-radius: var(--nys-radius-xl, 12px);
-  --_nys-table-padding: var(--nys-space-100, 8px);
   --_nys-table-border-color: transparent;
   --_nys-table-border-width: 0;
   --_nys-table-font-family: var(

--- a/packages/nys-textinput/src/nys-textinput.scss
+++ b/packages/nys-textinput/src/nys-textinput.scss
@@ -174,29 +174,8 @@
 }
 
 ::slotted(nys-button) {
-  /* These props ARE NOT publicly overridable */
-  --_nys-button-height: var(--_nys-textinput-height);
-  --_nys-button-border-radius: var(--_nys-textinput-border-radius);
-  --_nys-button-background-color--disabled: var(
-    --_nys-textinput-background-color--disabled
-  );
-  --_nys-button-border-color--disabled: var(--_nys-textinput-color--disabled);
-  --_nys-button-color--disabled: var(--_nys-textinput-color--disabled);
-  --_nys-button-border-width: var(--_nys-textinput-border-width);
-
-  z-index: 1;
-
   /* to make sure the button outline renders on top of the input */
-}
-
-.nys-textinput__buttoncontainer.has-start-button ::slotted(nys-button) {
-  --_nys-button-border-radius: var(--_nys-textinput-border-radius) 0 0
-    var(--_nys-textinput-border-radius);
-}
-
-.nys-textinput__buttoncontainer.has-end-button ::slotted(nys-button) {
-  --_nys-button-border-radius: 0 var(--_nys-textinput-border-radius)
-    var(--_nys-textinput-border-radius) 0;
+  z-index: 1;
 }
 
 .inline-icon {
@@ -211,15 +190,6 @@
   --nys-button-background-color: var(--_nys-textinput-background-color);
   --nys-button-background-color--hover: var(--_nys-textinput-background-color);
   --nys-button-background-color--active: var(--_nys-textinput-background-color);
-
-  /* These props ARE NOT publicly overridable */
-  --_nys-button-outline-focus: calc(var(--_nys-button-outline-width) * -1);
-
-  /* Needs to be negative of the offset width */
-  --_nys-button-padding--y: var(--nys-space-50, 4px);
-  --_nys-button-padding--x: var(--nys-space-50, 4px);
-  --_nys-button-height: var(--nys-size-300, 32px);
-  --_nys-button-width: var(--nys-size-400, 32px);
 }
 
 /* Hovered */

--- a/packages/nys-toggle/src/nys-toggle.scss
+++ b/packages/nys-toggle/src/nys-toggle.scss
@@ -41,7 +41,6 @@
     #081b2b
   );
   --_nys-toggle-color-ink-reverse: var(--nys-color-ink-reverse, #ffffff);
-  --_nys-toggle-color--disabled: var(--nys-color-neutral-500, #797c7f);
 }
 
 :host([inverted]) {
@@ -53,14 +52,8 @@
   display: flex;
   gap: var(--_nys-toggle-gap);
 
-  nys-label {
-    --_nys-label-font-weight: var(--nys-font-weight-semibold, 600);
-  }
-
   &:has(input:disabled) {
     nys-label {
-      --_nys-label-color: var(--_nys-toggle-color--disabled);
-
       cursor: not-allowed;
     }
   }

--- a/packages/nys-unavfooter/src/nys-unavfooter.scss
+++ b/packages/nys-unavfooter/src/nys-unavfooter.scss
@@ -139,7 +139,6 @@ a:active {
   :host {
     --_nys-unavfooter-padding--gutter: var(--nys-gutter-lg, 32px);
     --_nys-unavfooter-column-gap: var(--nys-space-600, 48px);
-    --_nys-unavfooter-gap-spacing: var(--nys-space-800, 64px);
   }
 }
 

--- a/packages/nys-unavheader/src/nys-unavheader.scss
+++ b/packages/nys-unavheader/src/nys-unavheader.scss
@@ -5,10 +5,6 @@
     --nys-color-surface,
     var(--nys-color-white, #ffffff)
   );
-  --_nys-unavheader-color: var(
-    --nys-color-text,
-    var(--nys-color-neutral-900, #1b1b1b)
-  );
   --_nys-unavheader-max-width--content: var(
     --nys-unavheader-max-width--content,
     1280px
@@ -58,34 +54,18 @@
      band and the alert can't drift apart. */
   &[data-type="info"] {
     --_nys-unavheader-alert-background-color: var(--nys-color-info, #004dd1);
-    --_nys-alert-color: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--hover: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--active: var(--nys-color-ink-reverse, #ffffff);
   }
 
   &[data-type="success"] {
     --_nys-unavheader-alert-background-color: var(--nys-color-success, #1e752e);
-    --_nys-alert-color: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--hover: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--active: var(--nys-color-ink-reverse, #ffffff);
   }
 
   &[data-type="warning"] {
     --_nys-unavheader-alert-background-color: var(--nys-color-warning, #face00);
-    --_nys-alert-color: var(--nys-color-ink, #1b1b1b);
-    --_nys-alert-color--link: var(--nys-color-ink, #1b1b1b);
-    --_nys-alert-color--link--hover: var(--nys-color-ink, #1b1b1b);
-    --_nys-alert-color--link--active: var(--nys-color-ink, #1b1b1b);
   }
 
   &[data-type="danger"] {
     --_nys-unavheader-alert-background-color: var(--nys-color-danger, #b52c2c);
-    --_nys-alert-color: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--hover: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--active: var(--nys-color-ink-reverse, #ffffff);
   }
 
   &[data-type="emergency"] {
@@ -93,18 +73,10 @@
       --nys-color-emergency,
       #721c1c
     );
-    --_nys-alert-color: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--hover: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--active: var(--nys-color-ink-reverse, #ffffff);
   }
 
   &[data-type="base"] {
     --_nys-unavheader-alert-background-color: var(--nys-color-base, #62666a);
-    --_nys-alert-color: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--hover: var(--nys-color-ink-reverse, #ffffff);
-    --_nys-alert-color--link--active: var(--nys-color-ink-reverse, #ffffff);
   }
 
   /* The alert sits flush against the header, so square off its corners */
@@ -112,9 +84,6 @@
     --_nys-alert-background-color: var(
       --_nys-unavheader-alert-background-color
     );
-    --_nys-alert-border-radius: 0;
-    --_nys-alert-border-width: 0;
-    --_nys-alert-padding: var(--nys-space-250, 20px) 0;
 
     /* nys-alert's :host is inline by default; blockify so max-width/auto margins apply */
     display: block;
@@ -206,29 +175,6 @@ a#nys-unavheader__logolink {
   align-items: center;
   cursor: pointer;
   gap: var(--nys-space-50, 4px);
-
-  /* These props ARE NOT publicly overridable */
-  --_nys-button-padding--x: var(--nys-space-50, 4px);
-  --_nys-button-padding--y: var(--nys-space-2px, 2px);
-  --_nys-button-height: var(--nys-font-lineheight-ui-xs, 20px);
-  --_nys-button-border-radius: var(--nys-radius-md, 4px);
-  --_nys-button-border-width: 0px;
-
-  /* typography */
-  --_nys-button-font-size: var(--nys-font-size-ui-xs, 12px);
-  --_nys-button-font-weight: var(--nys-font-weight-regular, 400);
-  --_nys-button-line-height: var(--nys-font-lineheight-ui-xs, 20px);
-  --_nys-button-font-family: var(
-    --nys-font-family-ui,
-    var(
-      --nys-font-family-sans,
-      "Proxima Nova",
-      "Helvetica Neue",
-      "Helvetica",
-      "Arial",
-      sans-serif
-    )
-  );
 }
 
 .hide {
@@ -284,8 +230,6 @@ a#nys-unavheader__logolink {
 .nys-unavheader__search {
   max-width: var(--nys-form-width-md, 200px);
   transition: max-width 0.5s ease;
-
-  --_nys-textinput-gap: 0px;
 }
 
 /* Grow size on focus */
@@ -301,15 +245,6 @@ a#nys-unavheader__logolink {
   --nys-button-color: var(--nys-color-state-blue-700, #154973);
   --nys-button-color--hover: var(--nys-color-state-blue-700, #154973);
   --nys-button-color--active: var(--nys-color-state-blue-700, #154973);
-  --_nys-button-border-width: 0px;
-}
-
-.nys-unavheader__iconbutton {
-  /* These props ARE NOT publicly overridable */
-  --_nys-button-width: var(--nys-size-400, 32px);
-  --_nys-button-height: var(--nys-size-400, 32px);
-  --_nys-button-padding--y: 0;
-  --_nys-button-padding--x: 0;
 }
 
 .nys-unavheader__translatewrapper {
@@ -330,19 +265,9 @@ a#nys-unavheader__logolink {
 }
 
 .nys-unavheader__languagelink {
-  --_nys-button-padding: var(--nys-space-200, 16px) var(--nys-space-250, 20px);
   --nys-button-color: var(--nys-color-state-blue-700, #154973);
   --nys-button-color--hover: var(--nys-color-state-blue-700, #154973);
   --nys-button-color--active: var(--nys-color-state-blue-700, #154973);
-  --_nys-button-border-radius: 0;
-  --_nys-button-justify-content: start;
-
-  /* Arrow keys move focus between options, so the focus ring is the only thing
-     showing which one is active. The options are full-bleed and stacked with no
-     gap, so an outward ring would be drawn over its neighbors — inset it instead.
-     Width and offset must stay equal and opposite. */
-  --_nys-button-outline-width: var(--nys-border-width-md, 2px);
-  --_nys-button-outline-offset: calc(-1 * var(--nys-border-width-md, 2px));
 }
 
 /* Breakpoints using NYSDS Grid Guidelines */
@@ -350,12 +275,6 @@ a#nys-unavheader__logolink {
   /* Mobile (XS) */
   :host {
     --_nys-unavheader-padding--gutter: var(--nys-gutter-xs, 20px);
-  }
-
-  #nys-unavheader__know {
-    --_nys-button-padding--x: 0px;
-    --_nys-button-padding--y: 0px;
-    --_nys-button-height: var(--nys-space-200, 16px);
   }
 
   .nys-unavheader__trustbar > .content {

--- a/packages/nys-verticalnav/src/nys-verticalnav.scss
+++ b/packages/nys-verticalnav/src/nys-verticalnav.scss
@@ -125,8 +125,6 @@ nys-accordion {
 
   &__items {
     display: none;
-
-    --_nys-verticalnav-link-indent: var(--nys-space-300, 24px);
   }
 }
 

--- a/packages/nys-video/src/nys-video.scss
+++ b/packages/nys-video/src/nys-video.scss
@@ -2,11 +2,7 @@
   /* Anything that can be overridden should be defined here */
 
   /* Global Video Styles */
-  --_nys-video-width: fit-content;
-  --_nys-video-height: var(--nys-size-600, 48px);
   --_nys-video-radius: var(--nys-radius-lg, 8px);
-  --_nys-video-padding: var(--nys-space-100, 8px);
-  --_nys-video-gap: var(--nys-space-100, 8px);
 
   /* Typography */
   --_nys-video-font-size: var(--nys-font-size-ui-md, 16px);


### PR DESCRIPTION
# Summary

Removed private `--_nys-*` CSS custom properties across 23 component packages that were declared but never read anywhere in their own package, left behind by earlier refactors. Cleaned up the now-empty rule blocks and orphaned comments that resulted from those removals.

## Breaking change

This is **not** a breaking change.

## Related issues

Closes #1831

## Related pull requests

None.

## Preview link

None.

## Problem statement

Several components declared private `--_nys-*` custom properties that nothing in the same package ever consumed via `var()`. These add noise to the SCSS, mislead future theming work into thinking they do something, and in a few cases (e.g. `nys-unavheader` setting `--_nys-alert-color--link` on a nested `nys-alert`) look like intentional overrides even though the target component privately redeclares the same variable on its own `:host`, making the "override" a permanent no-op.

## Solution

Cross-referenced every `--_nys-*` declaration in each `packages/nys-*/src/*.scss` against its usages within the same package (private props are not public API, so cross-package usage doesn't count). Removed every declaration with zero readers, then re-ran the check to catch second-order dead code — a few properties (e.g. `--_nys-select-color--error`, `--_nys-checkbox-font-weight`) only became dead once their sole consumer (itself dead) was removed. Iterated until no dead private properties remained. Also removed rule blocks that became fully empty as a result, and comments (e.g. "These props ARE NOT publicly overridable") left describing declarations that no longer exist.

Public (non-underscore) `--nys-*` custom properties were left untouched, per the issue's guard, since they're themable API even when currently unused internally.

## Major changes

- **Modified components**: `nys-avatar`, `nys-backtotop`, `nys-badge`, `nys-button`, `nys-checkbox`, `nys-combobox`, `nys-datepicker`, `nys-fileinput`, `nys-globalfooter`, `nys-globalheader`, `nys-modal`, `nys-pagination`, `nys-radiobutton`, `nys-select`, `nys-table`, `nys-textinput`, `nys-toggle`, `nys-unavfooter`, `nys-unavheader`, `nys-verticalnav`, `nys-video` — dead private CSS custom property declarations removed, no behavioral or visual change.

## Screenshots (if applicable)

Not applicable — this is a no-op style cleanup; removed properties were never read by anything.

## Testing and review

This is a mechanical removal of unused CSS custom property declarations. Since each removed property had zero readers (confirmed via cross-reference within the same package), there is no visual or functional change to any component. Reviewers should confirm that no removed property is actually consumed somewhere the scripted check could have missed (e.g. dynamically via JS `style.setProperty`/`getPropertyValue`).

### Browser testing

Not applicable (no visual/functional change expected).

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] iOS Safari
- [ ] Android Chrome

### Accessibility testing

Not applicable (no markup or behavior changes).

- [ ] Screen reader testing
- [ ] Keyboard navigation
- [ ] Color contrast checks
- [ ] Axe/Lighthouse audit
- [ ] Other: _n/a_

### Unit and integration tests

- [ ] Unit tests updated/added — not needed; no existing tests reference these private, unused custom properties.

## Additional considerations

No new dependencies. Backward-compatible: only private (underscore-prefixed), unreferenced custom properties were removed; public theming API (`--nys-*`) is unchanged.
