### PR TITLE
FIX: card preheading spacing

### DIFF
--- a/packages/nys-card/src/nys-card.scss
+++ b/packages/nys-card/src/nys-card.scss
@@ -14,6 +14,7 @@
   --_nys-card-padding--t: var(--nys-space-200, 16px);
   --_nys-card-padding--x: var(--nys-space-300, 24px);
   --_nys-card-padding--b: var(--nys-space-250, 20px);
+  --_nys-card-padding-bottom--preheading: var(--nys-space-150, 12px);
   --_nys-card-background-color: var(--nys-color-surface, #ffffff);
   --_nys-card-gap: var(--nys-space-150, 12px);
 
@@ -193,6 +194,19 @@
     font-weight: 700;
     line-height: var(--nys-font-lineheight-ui-md, 24px); /* 150% */
     letter-spacing: var(--nys-font-letterspacing-ui-md, 0.044px);
+  }
+
+  /* The slotted counterpart of &__preheading: content supplied through the
+     slot brings its own styling (a badge, for instance), so this only lays it
+     out — none of the text styles above apply to it. */
+  &__preheading-slot {
+    display: flex;
+    flex-direction: row;
+    padding-bottom: var(--_nys-card-padding-bottom--preheading);
+
+    &[hidden] {
+      display: none;
+    }
   }
 
   &__heading {

--- a/packages/nys-card/src/nys-card.scss
+++ b/packages/nys-card/src/nys-card.scss
@@ -10,6 +10,7 @@
 
   --_nys-card-border-radius: var(--nys-radius-xl, 12px);
   --_nys-card-border-radius--media: 0;
+  --_nys-card-border-color: var(--nys-color-neutral-200, #bec0c1);
   --_nys-card-padding--t: var(--nys-space-200, 16px);
   --_nys-card-padding--x: var(--nys-space-300, 24px);
   --_nys-card-padding--b: var(--nys-space-250, 20px);
@@ -96,8 +97,7 @@
   justify-content: center;
 
   border-radius: var(--_nys-card-border-radius);
-  border: var(--nys-border-width-sm, 1px) solid
-    var(--nys-color-neutral-200, #bec0c1);
+  border: var(--nys-border-width-sm, 1px) solid var(--_nys-card-border-color);
   background-color: var(--_nys-card-background-color);
 
   overflow: hidden;

--- a/packages/nys-card/src/nys-card.ts
+++ b/packages/nys-card/src/nys-card.ts
@@ -429,8 +429,12 @@ export class NysCard extends NysElement {
 
   render() {
     const hasMediaAccent = !!(this._accentMonth || this._accentDay);
-    // The preheading block accepts either the property or slotted rich content.
-    const hasPreheading = !!this.preheading || this._hasPreheadingSlot;
+    // Preheading text and slotted preheading content render as separate
+    // elements, so each can be styled on its own: the property gets the styled
+    // <p>, slotted markup (a badge, say) gets the bare slot. Slotted content
+    // still wins over the property, as it did when it was the slot's fallback,
+    // and neither element is rendered when there is nothing to show.
+    const showPreheadingText = !!this.preheading && !this._hasPreheadingSlot;
 
     // The card's inner markup is identical in all three cases; only the element
     // wrapping it changes based on how the card was made interactive.
@@ -454,13 +458,15 @@ export class NysCard extends NysElement {
       </div>
       <div class="nys-card__main-content">
         <div>
-          <p class="nys-card__preheading" ?hidden=${!hasPreheading}>
-            <slot
-              name="preheading"
-              @slotchange=${this.handlePreheadingSlotChange}
-              >${this.preheading}</slot
-            >
-          </p>
+          ${showPreheadingText
+            ? html`<p class="nys-card__preheading">${this.preheading}</p>`
+            : ""}
+          <slot
+            name="preheading"
+            class="nys-card__preheading-slot"
+            ?hidden=${!this._hasPreheadingSlot}
+            @slotchange=${this.handlePreheadingSlotChange}
+          ></slot>
           ${this.renderHeading()}
           ${this.subheading
             ? html`<p class="nys-card__subheading">${this.subheading}</p>`


### PR DESCRIPTION
TODO: add css public override for heading font size

## Before: 
<img width="357" height="183" alt="image" src="https://github.com/user-attachments/assets/918c7740-1e74-45d9-9c84-73d59b993d20" />

## After: 
<img width="359" height="197" alt="image" src="https://github.com/user-attachments/assets/13c8cf7c-8553-4570-8f9e-b7875a322d3b" />

## Additional Changes

Created some css variables that were missed on initial build. Nothing public but need to exist for internal overrides
