### PR TITLE
ENHANCEMENT: badge intents expanded

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1463,10 +1463,10 @@
               "kind": "field",
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"emergency\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"danger\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`.",
+              "description": "Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`.",
               "attribute": "intent",
               "reflects": true
             },
@@ -1554,7 +1554,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ base: \"info\", emergency: \"emergency_home\", info: \"info\", success: \"check_circle\", warning: \"warning\", }",
+              "default": "{ base: \"info\", danger: \"error\", info: \"info\", success: \"check_circle\", warning: \"warning\", }",
               "description": "Functions\n--------------------------------------------------------------------------"
             },
             {
@@ -1566,7 +1566,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ emergency: \"Emergency\", info: \"Info\", success: \"Success\", warning: \"Warning\", }"
+              "default": "{ danger: \"Danger\", info: \"Info\", success: \"Success\", warning: \"Warning\", }"
             },
             {
               "kind": "method",
@@ -1634,10 +1634,10 @@
             {
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"emergency\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"danger\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`.",
+              "description": "Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`.",
               "fieldName": "intent",
               "propName": "intent"
             },
@@ -1727,8 +1727,8 @@
               "lang": "html"
             },
             {
-              "title": "Emergency Intent",
-              "code": "<nys-badge label=\"Emergency\" intent=\"emergency\" prefixIcon></nys-badge>",
+              "title": "Danger Intent",
+              "code": "<nys-badge label=\"Danger\" intent=\"danger\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
@@ -1752,8 +1752,8 @@
               "lang": "html"
             },
             {
-              "title": "Strong Emergency",
-              "code": "<nys-badge strong label=\"Emergency\" intent=\"emergency\" prefixIcon></nys-badge>",
+              "title": "Strong Danger",
+              "code": "<nys-badge strong label=\"Danger\" intent=\"danger\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1712,18 +1712,8 @@
               "lang": "html"
             },
             {
-              "title": "Error Intent",
-              "code": "<nys-badge label=\"Error\" intent=\"error\" prefixIcon></nys-badge>",
-              "lang": "html"
-            },
-            {
               "title": "Info Intent",
               "code": "<nys-badge label=\"Info\" intent=\"info\" prefixIcon></nys-badge>",
-              "lang": "html"
-            },
-            {
-              "title": "Warning Intent",
-              "code": "<nys-badge label=\"Warning\" intent=\"warning\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
@@ -1732,13 +1722,18 @@
               "lang": "html"
             },
             {
-              "title": "Strong Base",
-              "code": "<nys-badge strong label=\"Base\" prefixIcon></nys-badge>",
+              "title": "Warning Intent",
+              "code": "<nys-badge label=\"Warning\" intent=\"warning\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
-              "title": "Strong Error",
-              "code": "<nys-badge strong label=\"Error\" intent=\"error\" prefixIcon></nys-badge>",
+              "title": "Error Intent",
+              "code": "<nys-badge label=\"Error\" intent=\"error\" prefixIcon></nys-badge>",
+              "lang": "html"
+            },
+            {
+              "title": "Strong Base",
+              "code": "<nys-badge strong label=\"Base\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
@@ -1747,13 +1742,18 @@
               "lang": "html"
             },
             {
+              "title": "Strong Success",
+              "code": "<nys-badge strong label=\"Success\" intent=\"success\" prefixIcon></nys-badge>",
+              "lang": "html"
+            },
+            {
               "title": "Strong Warning",
               "code": "<nys-badge strong label=\"Warning\" intent=\"warning\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
-              "title": "Strong Success",
-              "code": "<nys-badge strong label=\"Success\" intent=\"success\" prefixIcon></nys-badge>",
+              "title": "Strong Error",
+              "code": "<nys-badge strong label=\"Error\" intent=\"error\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1463,10 +1463,10 @@
               "kind": "field",
               "name": "intent",
               "type": {
-                "text": "| \"neutral\"\n    | \"error\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"error\"\n    | \"success\"\n    | \"warning\""
               },
-              "default": "\"neutral\"",
-              "description": "Semantic intent affecting color: `neutral`, `error`, `success`, or `warning`.",
+              "default": "\"base\"",
+              "description": "Semantic intent affecting color: `base`, `error`, `success`, or `warning`.",
               "attribute": "intent",
               "reflects": true
             },
@@ -1553,7 +1553,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ neutral: \"info\", error: \"emergency_home\", success: \"check_circle\", warning: \"warning\", }",
+              "default": "{ base: \"info\", error: \"emergency_home\", success: \"check_circle\", warning: \"warning\", }",
               "description": "Functions\n--------------------------------------------------------------------------"
             },
             {
@@ -1633,10 +1633,10 @@
             {
               "name": "intent",
               "type": {
-                "text": "| \"neutral\"\n    | \"error\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"error\"\n    | \"success\"\n    | \"warning\""
               },
-              "default": "\"neutral\"",
-              "description": "Semantic intent affecting color: `neutral`, `error`, `success`, or `warning`.",
+              "default": "\"base\"",
+              "description": "Semantic intent affecting color: `base`, `error`, `success`, or `warning`.",
               "fieldName": "intent",
               "propName": "intent"
             },
@@ -1725,8 +1725,8 @@
               "lang": "html"
             },
             {
-              "title": "Strong Neutral",
-              "code": "<nys-badge variant=\"strong\" label=\"Neutral\" prefixIcon></nys-badge>",
+              "title": "Strong Base",
+              "code": "<nys-badge variant=\"strong\" label=\"Base\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1463,10 +1463,10 @@
               "kind": "field",
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"error\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"error\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `error`, `success`, or `warning`.",
+              "description": "Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`.",
               "attribute": "intent",
               "reflects": true
             },
@@ -1502,12 +1502,13 @@
             },
             {
               "kind": "field",
-              "name": "variant",
+              "name": "strong",
               "type": {
-                "text": "\"strong\" | \"\""
+                "text": "boolean"
               },
-              "default": "\"\"",
-              "attribute": "variant",
+              "default": "false",
+              "description": "Strong visual intent with bolder text and background.",
+              "attribute": "strong",
               "reflects": true
             },
             {
@@ -1553,7 +1554,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ base: \"info\", error: \"emergency_home\", success: \"check_circle\", warning: \"warning\", }",
+              "default": "{ base: \"info\", error: \"emergency_home\", info: \"info\", success: \"check_circle\", warning: \"warning\", }",
               "description": "Functions\n--------------------------------------------------------------------------"
             },
             {
@@ -1565,7 +1566,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ error: \"Error\", success: \"Success\", warning: \"Warning\", }"
+              "default": "{ error: \"Error\", info: \"Info\", success: \"Success\", warning: \"Warning\", }"
             },
             {
               "kind": "method",
@@ -1633,10 +1634,10 @@
             {
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"error\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"error\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `error`, `success`, or `warning`.",
+              "description": "Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`.",
               "fieldName": "intent",
               "propName": "intent"
             },
@@ -1671,13 +1672,14 @@
               "propName": "srtext"
             },
             {
-              "name": "variant",
+              "name": "strong",
               "type": {
-                "text": "\"strong\" | \"\""
+                "text": "boolean"
               },
-              "default": "\"\"",
-              "fieldName": "variant",
-              "propName": "variant"
+              "default": "false",
+              "description": "Strong visual intent with bolder text and background.",
+              "fieldName": "strong",
+              "propName": "strong"
             },
             {
               "name": "prefixicon",
@@ -1715,6 +1717,11 @@
               "lang": "html"
             },
             {
+              "title": "Info Intent",
+              "code": "<nys-badge label=\"Info\" intent=\"info\" prefixIcon></nys-badge>",
+              "lang": "html"
+            },
+            {
               "title": "Warning Intent",
               "code": "<nys-badge label=\"Warning\" intent=\"warning\" prefixIcon></nys-badge>",
               "lang": "html"
@@ -1726,22 +1733,27 @@
             },
             {
               "title": "Strong Base",
-              "code": "<nys-badge variant=\"strong\" label=\"Base\" prefixIcon></nys-badge>",
+              "code": "<nys-badge strong label=\"Base\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
               "title": "Strong Error",
-              "code": "<nys-badge variant=\"strong\" label=\"Error\" intent=\"error\" prefixIcon></nys-badge>",
+              "code": "<nys-badge strong label=\"Error\" intent=\"error\" prefixIcon></nys-badge>",
+              "lang": "html"
+            },
+            {
+              "title": "Strong Info",
+              "code": "<nys-badge strong label=\"Info\" intent=\"info\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
               "title": "Strong Warning",
-              "code": "<nys-badge variant=\"strong\" label=\"Warning\" intent=\"warning\" prefixIcon></nys-badge>",
+              "code": "<nys-badge strong label=\"Warning\" intent=\"warning\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
               "title": "Strong Success",
-              "code": "<nys-badge variant=\"strong\" label=\"Success\" intent=\"success\" prefixIcon></nys-badge>",
+              "code": "<nys-badge strong label=\"Success\" intent=\"success\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1463,10 +1463,10 @@
               "kind": "field",
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"info\"\n    | \"success\"\n    | \"warning\"\n    | \"danger\"\n    | \"emergency\""
+                "text": "| \"base\"\n    | \"info\"\n    | \"success\"\n    | \"warning\"\n    | \"danger\"\n    | \"error\"\n    | \"emergency\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`.",
+              "description": "Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. `error` has been deprecated and support will be removed in a future release. Use `danger` instead",
               "attribute": "intent",
               "reflects": true
             },
@@ -1554,7 +1554,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ base: \"info\", info: \"info\", success: \"check_circle\", warning: \"warning\", danger: \"error\", emergency: \"emergency_home\", }",
+              "default": "{ base: \"info\", info: \"info\", success: \"check_circle\", warning: \"warning\", danger: \"error\", error: \"error\", emergency: \"emergency_home\", }",
               "description": "Functions\n--------------------------------------------------------------------------"
             },
             {
@@ -1566,7 +1566,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ info: \"Info\", success: \"Success\", warning: \"Warning\", danger: \"Danger\", emergency: \"Emergency\", }"
+              "default": "{ info: \"Info\", success: \"Success\", warning: \"Warning\", danger: \"Danger\", error: \"Danger\", emergency: \"Emergency\", }"
             },
             {
               "kind": "method",
@@ -1634,10 +1634,10 @@
             {
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"info\"\n    | \"success\"\n    | \"warning\"\n    | \"danger\"\n    | \"emergency\""
+                "text": "| \"base\"\n    | \"info\"\n    | \"success\"\n    | \"warning\"\n    | \"danger\"\n    | \"error\"\n    | \"emergency\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`.",
+              "description": "Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. `error` has been deprecated and support will be removed in a future release. Use `danger` instead",
               "fieldName": "intent",
               "propName": "intent"
             },

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1463,10 +1463,10 @@
               "kind": "field",
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"danger\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"info\"\n    | \"success\"\n    | \"warning\"\n    | \"danger\"\n    | \"emergency\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`.",
+              "description": "Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`.",
               "attribute": "intent",
               "reflects": true
             },
@@ -1554,7 +1554,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ base: \"info\", danger: \"error\", info: \"info\", success: \"check_circle\", warning: \"warning\", }",
+              "default": "{ base: \"info\", info: \"info\", success: \"check_circle\", warning: \"warning\", danger: \"error\", emergency: \"emergency_home\", }",
               "description": "Functions\n--------------------------------------------------------------------------"
             },
             {
@@ -1566,7 +1566,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ danger: \"Danger\", info: \"Info\", success: \"Success\", warning: \"Warning\", }"
+              "default": "{ info: \"Info\", success: \"Success\", warning: \"Warning\", danger: \"Danger\", emergency: \"Emergency\", }"
             },
             {
               "kind": "method",
@@ -1634,10 +1634,10 @@
             {
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"danger\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"info\"\n    | \"success\"\n    | \"warning\"\n    | \"danger\"\n    | \"emergency\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`.",
+              "description": "Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`.",
               "fieldName": "intent",
               "propName": "intent"
             },
@@ -1729,6 +1729,11 @@
             {
               "title": "Danger Intent",
               "code": "<nys-badge label=\"Danger\" intent=\"danger\" prefixIcon></nys-badge>",
+              "lang": "html"
+            },
+            {
+              "title": "Emergency Intent",
+              "code": "<nys-badge label=\"Emergency\" intent=\"emergency\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1463,10 +1463,10 @@
               "kind": "field",
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"error\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"emergency\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`.",
+              "description": "Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`.",
               "attribute": "intent",
               "reflects": true
             },
@@ -1554,7 +1554,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ base: \"info\", error: \"emergency_home\", info: \"info\", success: \"check_circle\", warning: \"warning\", }",
+              "default": "{ base: \"info\", emergency: \"emergency_home\", info: \"info\", success: \"check_circle\", warning: \"warning\", }",
               "description": "Functions\n--------------------------------------------------------------------------"
             },
             {
@@ -1566,7 +1566,7 @@
               "privacy": "private",
               "static": true,
               "readonly": true,
-              "default": "{ error: \"Error\", info: \"Info\", success: \"Success\", warning: \"Warning\", }"
+              "default": "{ emergency: \"Emergency\", info: \"Info\", success: \"Success\", warning: \"Warning\", }"
             },
             {
               "kind": "method",
@@ -1634,10 +1634,10 @@
             {
               "name": "intent",
               "type": {
-                "text": "| \"base\"\n    | \"error\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
+                "text": "| \"base\"\n    | \"emergency\"\n    | \"info\"\n    | \"success\"\n    | \"warning\""
               },
               "default": "\"base\"",
-              "description": "Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`.",
+              "description": "Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`.",
               "fieldName": "intent",
               "propName": "intent"
             },
@@ -1727,8 +1727,8 @@
               "lang": "html"
             },
             {
-              "title": "Error Intent",
-              "code": "<nys-badge label=\"Error\" intent=\"error\" prefixIcon></nys-badge>",
+              "title": "Emergency Intent",
+              "code": "<nys-badge label=\"Emergency\" intent=\"emergency\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {
@@ -1752,8 +1752,8 @@
               "lang": "html"
             },
             {
-              "title": "Strong Error",
-              "code": "<nys-badge strong label=\"Error\" intent=\"error\" prefixIcon></nys-badge>",
+              "title": "Strong Emergency",
+              "code": "<nys-badge strong label=\"Emergency\" intent=\"emergency\" prefixIcon></nys-badge>",
               "lang": "html"
             },
             {

--- a/packages/nys-badge/src/nys-badge.figma.ts
+++ b/packages/nys-badge/src/nys-badge.figma.ts
@@ -4,9 +4,10 @@ figma.connect("<FIGMA_BADGE>", {
   props: {
     intent: figma.enum("Intent", {
       "🔘 Base": "base",
+      "🔵 Info": "info",
       "🟢 Success": "success",
       "🟡 Warning": "warning",
-      "🔴 Error": "error",
+      "🔴 Emergency": "emergency",
     }),
     size: figma.enum("Size", {
       sm: "sm",

--- a/packages/nys-badge/src/nys-badge.figma.ts
+++ b/packages/nys-badge/src/nys-badge.figma.ts
@@ -7,7 +7,7 @@ figma.connect("<FIGMA_BADGE>", {
       "🔵 Info": "info",
       "🟢 Success": "success",
       "🟡 Warning": "warning",
-      "🔴 Emergency": "emergency",
+      "🔴 Danger": "danger",
     }),
     size: figma.enum("Size", {
       sm: "sm",

--- a/packages/nys-badge/src/nys-badge.figma.ts
+++ b/packages/nys-badge/src/nys-badge.figma.ts
@@ -3,7 +3,7 @@ import figma, { html } from "@figma/code-connect/html";
 figma.connect("<FIGMA_BADGE>", {
   props: {
     intent: figma.enum("Intent", {
-      "🔘 Neutral": "neutral",
+      "🔘 Base": "base",
       "🟢 Success": "success",
       "🟡 Warning": "warning",
       "🔴 Error": "error",

--- a/packages/nys-badge/src/nys-badge.figma.ts
+++ b/packages/nys-badge/src/nys-badge.figma.ts
@@ -8,10 +8,6 @@ figma.connect("<FIGMA_BADGE>", {
       "🟡 Warning": "warning",
       "🔴 Error": "error",
     }),
-    variant: figma.enum("Variant", {
-      Default: "",
-      Strong: "strong",
-    }),
     size: figma.enum("Size", {
       sm: "sm",
       md: "md",
@@ -28,7 +24,6 @@ figma.connect("<FIGMA_BADGE>", {
     <nys-badge
       label=${props.label}
       intent=${props.intent}
-      variant=${props.variant}
       size=${props.size}
       prefixIcon=${props.prefixIcon}
       suffixIcon=${props.suffixIcon}

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -49,6 +49,16 @@
   --_nys-badge-border-color: var(--nys-color-danger-strong, #721c1c);
 }
 
+:host([intent="emergency"]) {
+  --_nys-badge-background-color: var(--nys-color-emergency, #721c1c);
+  --_nys-badge-border-color: var(--nys-color-danger-strong, #721c1c);
+  --_nys-badge-color: var(--nys-color-white, #ffffff);
+
+  .nys-badge {
+    --nys-icon-color: var(--nys-color-white, #ffffff);
+  }
+}
+
 :host([intent="info"]) {
   --_nys-badge-background-color: var(--nys-color-info-weak, #e5effa);
   --_nys-badge-border-color: var(--nys-color-info-strong, #002971);
@@ -84,6 +94,10 @@
 
 :host([strong][intent="danger"]) {
   --_nys-badge-border-color: var(--nys-color-danger, #b52c2c);
+}
+
+:host([strong][intent="emergency"]) {
+  --_nys-badge-border-color: var(--nys-color-emergency, #721c1c);
 }
 
 :host([strong][intent="warning"]) {

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -44,7 +44,8 @@
   --_nys-badge-border-color: var(--nys-color-base, #62666a);
 }
 
-:host([intent="danger"]) {
+:host([intent="danger"]),
+:host([intent="error"]) {
   --_nys-badge-background-color: var(--nys-color-danger-weak, #f7eaea);
   --_nys-badge-border-color: var(--nys-color-danger-strong, #721c1c);
 }
@@ -92,7 +93,8 @@
   --_nys-badge-border-color: var(--nys-color-success, #1e752e);
 }
 
-:host([strong][intent="danger"]) {
+:host([strong][intent="danger"]),
+:host([strong][intent="error"]) {
   --_nys-badge-border-color: var(--nys-color-danger, #b52c2c);
 }
 

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -44,9 +44,9 @@
   --_nys-badge-border-color: var(--nys-color-base, #62666a);
 }
 
-:host([intent="error"]) {
-  --_nys-badge-background-color: var(--nys-color-error-weak, #f7eaea);
-  --_nys-badge-border-color: var(--nys-color-error-strong, #721c1c);
+:host([intent="emergency"]) {
+  --_nys-badge-background-color: var(--nys-color-emergency-weak, #f7eaea);
+  --_nys-badge-border-color: var(--nys-color-emergency, #721c1c);
 }
 
 :host([intent="info"]) {

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -59,8 +59,8 @@
   --_nys-badge-border-color: var(--nys-color-warning-strong, #6a5700);
 }
 
-/* Variant */
-:host([variant="strong"]) {
+/* Strong Styling */
+:host([strong]) {
   --_nys-badge-background-color: var(--_nys-badge-border-color);
   --_nys-badge-color: var(--nys-color-white, #ffffff);
 
@@ -69,11 +69,11 @@
   }
 }
 
-:host([variant="strong"][intent="success"]) {
+:host([strong][intent="success"]) {
   --_nys-badge-border-color: var(--nys-color-success, #1e752e);
 }
 
-:host([variant="strong"][intent="warning"]) {
+:host([strong][intent="warning"]) {
   --_nys-badge-border-color: var(--nys-color-warning, #face00);
   --_nys-badge-color: var(--nys-color-ink, #000000);
 

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -44,9 +44,9 @@
   --_nys-badge-border-color: var(--nys-color-base, #62666a);
 }
 
-:host([intent="emergency"]) {
-  --_nys-badge-background-color: var(--nys-color-emergency-weak, #f7eaea);
-  --_nys-badge-border-color: var(--nys-color-emergency, #721c1c);
+:host([intent="danger"]) {
+  --_nys-badge-background-color: var(--nys-color-danger-weak, #f7eaea);
+  --_nys-badge-border-color: var(--nys-color-danger-strong, #721c1c);
 }
 
 :host([intent="info"]) {

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -39,7 +39,7 @@
 }
 
 /* Intent */
-:host([intent="neutral"]) {
+:host([intent="base"]) {
   --_nys-badge-background-color: var(--nys-color-base-weak, #f6f6f6);
   --_nys-badge-border-color: var(--nys-color-base, #62666a);
 }

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -82,6 +82,10 @@
   --_nys-badge-border-color: var(--nys-color-success, #1e752e);
 }
 
+:host([strong][intent="danger"]) {
+  --_nys-badge-border-color: var(--nys-color-danger, #b52c2c);
+}
+
 :host([strong][intent="warning"]) {
   --_nys-badge-border-color: var(--nys-color-warning, #face00);
   --_nys-badge-color: var(--nys-color-ink, #000000);

--- a/packages/nys-badge/src/nys-badge.scss
+++ b/packages/nys-badge/src/nys-badge.scss
@@ -49,6 +49,11 @@
   --_nys-badge-border-color: var(--nys-color-error-strong, #721c1c);
 }
 
+:host([intent="info"]) {
+  --_nys-badge-background-color: var(--nys-color-info-weak, #e5effa);
+  --_nys-badge-border-color: var(--nys-color-info-strong, #002971);
+}
+
 :host([intent="success"]) {
   --_nys-badge-background-color: var(--nys-color-success-weak, #e8f1ea);
   --_nys-badge-border-color: var(--nys-color-success-strong, #0f3d18);
@@ -67,6 +72,10 @@
   .nys-badge {
     --nys-icon-color: var(--nys-color-white, #ffffff);
   }
+}
+
+:host([strong][intent="info"]) {
+  --_nys-badge-border-color: var(--nys-color-info, #004dd1);
 }
 
 :host([strong][intent="success"]) {

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -31,7 +31,15 @@ export const Basic: Story = {
     size: { control: { type: "select" }, options: ["sm", "md"] },
     intent: {
       control: { type: "select" },
-      options: ["base", "info", "success", "warning", "danger", "emergency"],
+      options: [
+        "base",
+        "info",
+        "success",
+        "warning",
+        "danger",
+        "error",
+        "emergency",
+      ],
     },
   },
   render: (args) => {

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -31,7 +31,7 @@ export const Basic: Story = {
     size: { control: { type: "select" }, options: ["sm", "md"] },
     intent: {
       control: { type: "select" },
-      options: ["base", "emergency", "info", "success", "warning"],
+      options: ["base", "danger", "info", "success", "warning"],
     },
   },
   render: (args) => {
@@ -109,17 +109,17 @@ export const WarningIntent: Story = {
   },
 };
 
-export const EmergencyIntent: Story = {
+export const DangerIntent: Story = {
   render: () => {
     return html`
-      <nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>
+      <nys-badge label="Danger" intent="danger" prefixIcon></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>`,
+<nys-badge label="Danger" intent="danger" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },
@@ -192,22 +192,17 @@ export const StrongWarning: Story = {
   },
 };
 
-export const StrongEmergency: Story = {
+export const StrongDanger: Story = {
   render: () => {
     return html`
-      <nys-badge
-        strong
-        label="Emergency"
-        intent="emergency"
-        prefixIcon
-      ></nys-badge>
+      <nys-badge strong label="Danger" intent="danger" prefixIcon></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge strong label="Emergency" intent="emergency" prefixIcon></nys-badge>`,
+<nys-badge strong label="Danger" intent="danger" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -21,7 +21,7 @@ export const Basic: Story = {
   args: {
     name: "",
     size: "md",
-    intent: "neutral",
+    intent: "base",
     prefixLabel: "",
     label: "Basic badge",
     srText: "",
@@ -31,7 +31,7 @@ export const Basic: Story = {
     size: { control: { type: "select" }, options: ["sm", "md"] },
     intent: {
       control: { type: "select" },
-      options: ["neutral", "error", "success", "warning"],
+      options: ["base", "error", "success", "warning"],
     },
     variant: { control: { type: "select" }, options: ["strong", ""] },
   },
@@ -110,17 +110,17 @@ export const SuccessIntent: Story = {
   },
 };
 
-export const StrongNeutral: Story = {
+export const StrongBase: Story = {
   render: () => {
     return html`
-      <nys-badge variant="strong" label="Neutral" prefixIcon></nys-badge>
+      <nys-badge variant="strong" label="Base" prefixIcon></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge variant="strong" label="Neutral" prefixIcon></nys-badge>`,
+<nys-badge variant="strong" label="Base" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -31,7 +31,7 @@ export const Basic: Story = {
     size: { control: { type: "select" }, options: ["sm", "md"] },
     intent: {
       control: { type: "select" },
-      options: ["base", "danger", "info", "success", "warning"],
+      options: ["base", "info", "success", "warning", "danger", "emergency"],
     },
   },
   render: (args) => {
@@ -120,6 +120,23 @@ export const DangerIntent: Story = {
       source: {
         code: `
 <nys-badge label="Danger" intent="danger" prefixIcon></nys-badge>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const EmergencyIntent: Story = {
+  render: () => {
+    return html`
+      <nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>
+    `;
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -25,15 +25,14 @@ export const Basic: Story = {
     prefixLabel: "",
     label: "Basic badge",
     srText: "",
-    variant: "",
+    strong: false,
   },
   argTypes: {
     size: { control: { type: "select" }, options: ["sm", "md"] },
     intent: {
       control: { type: "select" },
-      options: ["base", "error", "success", "warning"],
+      options: ["base", "error", "info", "success", "warning"],
     },
-    variant: { control: { type: "select" }, options: ["strong", ""] },
   },
   render: (args) => {
     return html`
@@ -44,7 +43,7 @@ export const Basic: Story = {
         prefixLabel=${args.prefixLabel}
         label=${args.label}
         srText=${args.srText}
-        variant=${args.variant}
+        ?strong=${args.strong}
       ></nys-badge>
     `;
   },
@@ -70,6 +69,23 @@ export const ErrorIntent: Story = {
       source: {
         code: `
 <nys-badge label="Error" intent="error" prefixIcon></nys-badge>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const InfoIntent: Story = {
+  render: () => {
+    return html`
+      <nys-badge label="Info" intent="info" prefixIcon></nys-badge>
+    `;
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-badge label="Info" intent="info" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },
@@ -112,15 +128,13 @@ export const SuccessIntent: Story = {
 
 export const StrongBase: Story = {
   render: () => {
-    return html`
-      <nys-badge variant="strong" label="Base" prefixIcon></nys-badge>
-    `;
+    return html` <nys-badge strong label="Base" prefixIcon></nys-badge> `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge variant="strong" label="Base" prefixIcon></nys-badge>`,
+<nys-badge strong label="Base" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },
@@ -130,19 +144,31 @@ export const StrongBase: Story = {
 export const StrongError: Story = {
   render: () => {
     return html`
-      <nys-badge
-        variant="strong"
-        label="Error"
-        intent="error"
-        prefixIcon
-      ></nys-badge>
+      <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge variant="strong" label="Error" intent="error" prefixIcon></nys-badge>`,
+<nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const StrongInfo: Story = {
+  render: () => {
+    return html`
+      <nys-badge strong label="Info" intent="info" prefixIcon></nys-badge>
+    `;
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-badge strong label="Info" intent="info" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },
@@ -152,19 +178,14 @@ export const StrongError: Story = {
 export const StrongWarning: Story = {
   render: () => {
     return html`
-      <nys-badge
-        variant="strong"
-        label="Warning"
-        intent="warning"
-        prefixIcon
-      ></nys-badge>
+      <nys-badge strong label="Warning" intent="warning" prefixIcon></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge variant="strong" label="Warning" intent="warning" prefixIcon></nys-badge>`,
+<nys-badge strong label="Warning" intent="warning" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },
@@ -174,19 +195,14 @@ export const StrongWarning: Story = {
 export const StrongSuccess: Story = {
   render: () => {
     return html`
-      <nys-badge
-        variant="strong"
-        label="Success"
-        intent="success"
-        prefixIcon
-      ></nys-badge>
+      <nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge variant="strong" label="Success" intent="success" prefixIcon></nys-badge>`,
+<nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -58,23 +58,6 @@ export const Basic: Story = {
   },
 };
 
-export const ErrorIntent: Story = {
-  render: () => {
-    return html`
-      <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
-    `;
-  },
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-badge label="Error" intent="error" prefixIcon></nys-badge>`,
-        type: "auto",
-      },
-    },
-  },
-};
-
 export const InfoIntent: Story = {
   render: () => {
     return html`
@@ -86,23 +69,6 @@ export const InfoIntent: Story = {
       source: {
         code: `
 <nys-badge label="Info" intent="info" prefixIcon></nys-badge>`,
-        type: "auto",
-      },
-    },
-  },
-};
-
-export const WarningIntent: Story = {
-  render: () => {
-    return html`
-      <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
-    `;
-  },
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },
@@ -126,6 +92,40 @@ export const SuccessIntent: Story = {
   },
 };
 
+export const WarningIntent: Story = {
+  render: () => {
+    return html`
+      <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
+    `;
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
+export const ErrorIntent: Story = {
+  render: () => {
+    return html`
+      <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
+    `;
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-badge label="Error" intent="error" prefixIcon></nys-badge>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
 export const StrongBase: Story = {
   render: () => {
     return html` <nys-badge strong label="Base" prefixIcon></nys-badge> `;
@@ -135,23 +135,6 @@ export const StrongBase: Story = {
       source: {
         code: `
 <nys-badge strong label="Base" prefixIcon></nys-badge>`,
-        type: "auto",
-      },
-    },
-  },
-};
-
-export const StrongError: Story = {
-  render: () => {
-    return html`
-      <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
-    `;
-  },
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },
@@ -175,6 +158,23 @@ export const StrongInfo: Story = {
   },
 };
 
+export const StrongSuccess: Story = {
+  render: () => {
+    return html`
+      <nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>
+    `;
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>`,
+        type: "auto",
+      },
+    },
+  },
+};
+
 export const StrongWarning: Story = {
   render: () => {
     return html`
@@ -192,17 +192,17 @@ export const StrongWarning: Story = {
   },
 };
 
-export const StrongSuccess: Story = {
+export const StrongError: Story = {
   render: () => {
     return html`
-      <nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>
+      <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>`,
+<nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },

--- a/packages/nys-badge/src/nys-badge.stories.ts
+++ b/packages/nys-badge/src/nys-badge.stories.ts
@@ -31,7 +31,7 @@ export const Basic: Story = {
     size: { control: { type: "select" }, options: ["sm", "md"] },
     intent: {
       control: { type: "select" },
-      options: ["base", "error", "info", "success", "warning"],
+      options: ["base", "emergency", "info", "success", "warning"],
     },
   },
   render: (args) => {
@@ -109,17 +109,17 @@ export const WarningIntent: Story = {
   },
 };
 
-export const ErrorIntent: Story = {
+export const EmergencyIntent: Story = {
   render: () => {
     return html`
-      <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
+      <nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge label="Error" intent="error" prefixIcon></nys-badge>`,
+<nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },
@@ -192,17 +192,22 @@ export const StrongWarning: Story = {
   },
 };
 
-export const StrongError: Story = {
+export const StrongEmergency: Story = {
   render: () => {
     return html`
-      <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
+      <nys-badge
+        strong
+        label="Emergency"
+        intent="emergency"
+        prefixIcon
+      ></nys-badge>
     `;
   },
   parameters: {
     docs: {
       source: {
         code: `
-<nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>`,
+<nys-badge strong label="Emergency" intent="emergency" prefixIcon></nys-badge>`,
         type: "auto",
       },
     },

--- a/packages/nys-badge/src/nys-badge.test.ts
+++ b/packages/nys-badge/src/nys-badge.test.ts
@@ -63,7 +63,7 @@ describe("nys-badge", () => {
       html`<nys-badge
         label="My Label"
         intent="success"
-        variant="strong"
+        strong
         prefixIcon
       ></nys-badge>`,
     );

--- a/packages/nys-badge/src/nys-badge.test.ts
+++ b/packages/nys-badge/src/nys-badge.test.ts
@@ -135,14 +135,14 @@ describe("nys-badge", () => {
   // WCAG 1.4.1 Use of Color: semantic intent must not be conveyed by color
   // (and a decorative aria-hidden icon) alone. A screen-reader-only text
   // alternative is rendered for non-base intents.
-  it("renders a screen-reader-only intent label for emergency intent", async () => {
+  it("renders a screen-reader-only intent label for danger intent", async () => {
     const el = await fixture<NysBadge>(
-      html`<nys-badge label="Payment failed" intent="emergency"></nys-badge>`,
+      html`<nys-badge label="Payment failed" intent="danger"></nys-badge>`,
     );
     await el.updateComplete;
     const srOnly = el.shadowRoot!.querySelector(".nys-badge__sr-only");
     expect(srOnly).to.exist;
-    expect(srOnly!.textContent).to.equal("Emergency: ");
+    expect(srOnly!.textContent).to.equal("Danger: ");
   });
 
   it("renders a screen-reader-only intent label for success intent", async () => {
@@ -178,7 +178,7 @@ describe("nys-badge", () => {
     const el = await fixture<NysBadge>(
       html`<nys-badge
         label="Payment failed"
-        intent="emergency"
+        intent="danger"
         srText="action required"
       ></nys-badge>`,
     );

--- a/packages/nys-badge/src/nys-badge.test.ts
+++ b/packages/nys-badge/src/nys-badge.test.ts
@@ -41,13 +41,13 @@ describe("nys-badge", () => {
     expect(el.suffixIcon).to.be.true;
   });
 
-  it("default intent is neutral", async () => {
+  it("default intent is base", async () => {
     const el = await fixture<NysBadge>(
       html`<nys-badge label="My Label"></nys-badge>`,
     );
     await el.updateComplete;
 
-    expect(el.intent).to.equal("neutral");
+    expect(el.intent).to.equal("base");
 
     const computed = getComputedStyle(el);
     const backgroundColor = computed.getPropertyValue(
@@ -134,7 +134,7 @@ describe("nys-badge", () => {
 
   // WCAG 1.4.1 Use of Color: semantic intent must not be conveyed by color
   // (and a decorative aria-hidden icon) alone. A screen-reader-only text
-  // alternative is rendered for non-neutral intents.
+  // alternative is rendered for non-base intents.
   it("renders a screen-reader-only intent label for error intent", async () => {
     const el = await fixture<NysBadge>(
       html`<nys-badge label="Payment failed" intent="error"></nys-badge>`,
@@ -165,9 +165,9 @@ describe("nys-badge", () => {
     expect(srOnly!.textContent).to.equal("Warning: ");
   });
 
-  it("does not render an intent label for neutral intent", async () => {
+  it("does not render an intent label for base intent", async () => {
     const el = await fixture<NysBadge>(
-      html`<nys-badge label="Draft" intent="neutral"></nys-badge>`,
+      html`<nys-badge label="Draft" intent="base"></nys-badge>`,
     );
     await el.updateComplete;
     const srOnly = el.shadowRoot!.querySelector(".nys-badge__sr-only");
@@ -189,7 +189,7 @@ describe("nys-badge", () => {
     expect(srOnly[0].textContent).to.equal(": action required");
   });
 
-  it("passes the a11y audit with a non-neutral intent", async () => {
+  it("passes the a11y audit with a non-base intent", async () => {
     const el = await fixture<NysBadge>(
       html`<nys-badge
         label="Approved"

--- a/packages/nys-badge/src/nys-badge.test.ts
+++ b/packages/nys-badge/src/nys-badge.test.ts
@@ -135,14 +135,14 @@ describe("nys-badge", () => {
   // WCAG 1.4.1 Use of Color: semantic intent must not be conveyed by color
   // (and a decorative aria-hidden icon) alone. A screen-reader-only text
   // alternative is rendered for non-base intents.
-  it("renders a screen-reader-only intent label for error intent", async () => {
+  it("renders a screen-reader-only intent label for emergency intent", async () => {
     const el = await fixture<NysBadge>(
-      html`<nys-badge label="Payment failed" intent="error"></nys-badge>`,
+      html`<nys-badge label="Payment failed" intent="emergency"></nys-badge>`,
     );
     await el.updateComplete;
     const srOnly = el.shadowRoot!.querySelector(".nys-badge__sr-only");
     expect(srOnly).to.exist;
-    expect(srOnly!.textContent).to.equal("Error: ");
+    expect(srOnly!.textContent).to.equal("Emergency: ");
   });
 
   it("renders a screen-reader-only intent label for success intent", async () => {
@@ -178,7 +178,7 @@ describe("nys-badge", () => {
     const el = await fixture<NysBadge>(
       html`<nys-badge
         label="Payment failed"
-        intent="error"
+        intent="emergency"
         srText="action required"
       ></nys-badge>`,
     );

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -98,10 +98,24 @@ export class NysBadge extends NysElement {
   static styles = unsafeCSS(styles);
 
   /** Unique identifier. */
-  @property({ type: String, reflect: true }) id = "";
+  @property({
+    type: String,
+    reflect: true,
+    converter: {
+      toAttribute: (value: string) => (value ? value : undefined),
+    },
+  })
+  id = "";
 
   /** Name attribute for form association. */
-  @property({ type: String, reflect: true }) name = "";
+  @property({
+    type: String,
+    reflect: true,
+    converter: {
+      toAttribute: (value: string) => (value ? value : undefined),
+    },
+  })
+  name = "";
 
   /**
    * Badge size: `sm` (smaller text) or `md` (default).

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -38,9 +38,9 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge label="Success" intent="success" prefixIcon></nys-badge>
  * ```
  *
- * @example Strong Neutral
+ * @example Strong Base
  * ```html
- * <nys-badge variant="strong" label="Neutral" prefixIcon></nys-badge>
+ * <nys-badge variant="strong" label="Base" prefixIcon></nys-badge>
  * ```
  *
  * @example Strong Error
@@ -95,14 +95,14 @@ export class NysBadge extends NysElement {
   @property({ type: String, reflect: true }) size: "sm" | "md" = "md";
 
   /**
-   * Semantic intent affecting color: `neutral`, `error`, `success`, or `warning`.
-   * @default "neutral"
+   * Semantic intent affecting color: `base`, `error`, `success`, or `warning`.
+   * @default "base"
    */
   @property({ type: String, reflect: true }) intent:
-    | "neutral"
+    | "base"
     | "error"
     | "success"
-    | "warning" = "neutral";
+    | "warning" = "base";
 
   /** Secondary label displayed before the main label. */
   @property({ type: String }) prefixLabel = "";
@@ -177,7 +177,7 @@ export class NysBadge extends NysElement {
 
   // Map of default icons by intent
   private static readonly DEFAULT_ICONS: Record<string, string> = {
-    neutral: "info",
+    base: "info",
     error: "emergency_home",
     success: "check_circle",
     warning: "warning",
@@ -185,7 +185,7 @@ export class NysBadge extends NysElement {
 
   // WCAG 1.4.1 (Use of Color): intent is otherwise conveyed only by color and a
   // decorative (aria-hidden) icon. Provide a screen-reader-only text alternative
-  // so the semantic meaning is not color-only. Skipped for "neutral" (no
+  // so the semantic meaning is not color-only. Skipped for "base" (no
   // semantic meaning) and when the author supplies their own srText override.
   private static readonly INTENT_SR_TEXT: Record<string, string> = {
     error: "Error",

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -38,9 +38,9 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
  * ```
  *
- * @example Emergency Intent
+ * @example Danger Intent
  * ```html
- * <nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>
+ * <nys-badge label="Danger" intent="danger" prefixIcon></nys-badge>
  * ```
  *
  * @example Strong Base
@@ -63,9 +63,9 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge strong label="Warning" intent="warning" prefixIcon></nys-badge>
  * ```
  *
- * @example Strong Emergency
+ * @example Strong Danger
  * ```html
- * <nys-badge strong label="Emergency" intent="emergency" prefixIcon></nys-badge>
+ * <nys-badge strong label="Danger" intent="danger" prefixIcon></nys-badge>
  * ```
  *
  * @example Custom Prefix Icon
@@ -105,12 +105,12 @@ export class NysBadge extends NysElement {
   @property({ type: String, reflect: true }) size: "sm" | "md" = "md";
 
   /**
-   * Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`.
+   * Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`.
    * @default "info"
    */
   @property({ type: String, reflect: true }) intent:
     | "base"
-    | "emergency"
+    | "danger"
     | "info"
     | "success"
     | "warning" = "base";
@@ -190,7 +190,7 @@ export class NysBadge extends NysElement {
   // Map of default icons by intent
   private static readonly DEFAULT_ICONS: Record<string, string> = {
     base: "info",
-    emergency: "emergency_home",
+    danger: "error",
     info: "info",
     success: "check_circle",
     warning: "warning",
@@ -201,7 +201,7 @@ export class NysBadge extends NysElement {
   // so the semantic meaning is not color-only. Skipped for "base" (no
   // semantic meaning) and when the author supplies their own srText override.
   private static readonly INTENT_SR_TEXT: Record<string, string> = {
-    emergency: "Emergency",
+    danger: "Danger",
     info: "Info",
     success: "Success",
     warning: "Warning",

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -23,19 +23,9 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge label="Basic badge"></nys-badge>
  * ```
  *
- * @example Error Intent
- * ```html
- * <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
- * ```
- *
  * @example Info Intent
  * ```html
  * <nys-badge label="Info" intent="info" prefixIcon></nys-badge>
- * ```
- *
- * @example Warning Intent
- * ```html
- * <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
  * ```
  *
  * @example Success Intent
@@ -43,14 +33,19 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge label="Success" intent="success" prefixIcon></nys-badge>
  * ```
  *
+ * @example Warning Intent
+ * ```html
+ * <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
+ * ```
+ *
+ * @example Error Intent
+ * ```html
+ * <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
+ * ```
+ *
  * @example Strong Base
  * ```html
  * <nys-badge strong label="Base" prefixIcon></nys-badge>
- * ```
- *
- * @example Strong Error
- * ```html
- * <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
  * ```
  *
  * @example Strong Info
@@ -58,14 +53,19 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge strong label="Info" intent="info" prefixIcon></nys-badge>
  * ```
  *
+ * @example Strong Success
+ * ```html
+ * <nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>
+ * ```
+ *
  * @example Strong Warning
  * ```html
  * <nys-badge strong label="Warning" intent="warning" prefixIcon></nys-badge>
  * ```
  *
- * @example Strong Success
+ * @example Strong Error
  * ```html
- * <nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>
+ * <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
  * ```
  *
  * @example Custom Prefix Icon

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -28,6 +28,11 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
  * ```
  *
+ * @example Info Intent
+ * ```html
+ * <nys-badge label="Info" intent="info" prefixIcon></nys-badge>
+ * ```
+ *
  * @example Warning Intent
  * ```html
  * <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
@@ -46,6 +51,11 @@ import styles from "./nys-badge.scss?inline";
  * @example Strong Error
  * ```html
  * <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
+ * ```
+ *
+ * @example Strong Info
+ * ```html
+ * <nys-badge strong label="Info" intent="info" prefixIcon></nys-badge>
  * ```
  *
  * @example Strong Warning
@@ -95,12 +105,13 @@ export class NysBadge extends NysElement {
   @property({ type: String, reflect: true }) size: "sm" | "md" = "md";
 
   /**
-   * Semantic intent affecting color: `base`, `error`, `success`, or `warning`.
-   * @default "base"
+   * Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`.
+   * @default "info"
    */
   @property({ type: String, reflect: true }) intent:
     | "base"
     | "error"
+    | "info"
     | "success"
     | "warning" = "base";
 
@@ -113,7 +124,7 @@ export class NysBadge extends NysElement {
   /** Screen reader text appended after the label for additional context. */
   @property({ type: String }) srText = "";
 
-  /** Strong visual with bolder text and background. */
+  /** Strong visual intent with bolder text and background. */
   @property({ type: Boolean, reflect: true }) strong = false;
 
   // Icons (string or boolean)
@@ -180,6 +191,7 @@ export class NysBadge extends NysElement {
   private static readonly DEFAULT_ICONS: Record<string, string> = {
     base: "info",
     error: "emergency_home",
+    info: "info",
     success: "check_circle",
     warning: "warning",
   };
@@ -190,6 +202,7 @@ export class NysBadge extends NysElement {
   // semantic meaning) and when the author supplies their own srText override.
   private static readonly INTENT_SR_TEXT: Record<string, string> = {
     error: "Error",
+    info: "Info",
     success: "Success",
     warning: "Warning",
   };

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -38,9 +38,9 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge label="Warning" intent="warning" prefixIcon></nys-badge>
  * ```
  *
- * @example Error Intent
+ * @example Emergency Intent
  * ```html
- * <nys-badge label="Error" intent="error" prefixIcon></nys-badge>
+ * <nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>
  * ```
  *
  * @example Strong Base
@@ -63,9 +63,9 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge strong label="Warning" intent="warning" prefixIcon></nys-badge>
  * ```
  *
- * @example Strong Error
+ * @example Strong Emergency
  * ```html
- * <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
+ * <nys-badge strong label="Emergency" intent="emergency" prefixIcon></nys-badge>
  * ```
  *
  * @example Custom Prefix Icon
@@ -105,12 +105,12 @@ export class NysBadge extends NysElement {
   @property({ type: String, reflect: true }) size: "sm" | "md" = "md";
 
   /**
-   * Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`.
+   * Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`.
    * @default "info"
    */
   @property({ type: String, reflect: true }) intent:
     | "base"
-    | "error"
+    | "emergency"
     | "info"
     | "success"
     | "warning" = "base";
@@ -190,7 +190,7 @@ export class NysBadge extends NysElement {
   // Map of default icons by intent
   private static readonly DEFAULT_ICONS: Record<string, string> = {
     base: "info",
-    error: "emergency_home",
+    emergency: "emergency_home",
     info: "info",
     success: "check_circle",
     warning: "warning",
@@ -201,7 +201,7 @@ export class NysBadge extends NysElement {
   // so the semantic meaning is not color-only. Skipped for "base" (no
   // semantic meaning) and when the author supplies their own srText override.
   private static readonly INTENT_SR_TEXT: Record<string, string> = {
-    error: "Error",
+    emergency: "Emergency",
     info: "Info",
     success: "Success",
     warning: "Warning",

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -43,6 +43,11 @@ import styles from "./nys-badge.scss?inline";
  * <nys-badge label="Danger" intent="danger" prefixIcon></nys-badge>
  * ```
  *
+ * @example Emergency Intent
+ * ```html
+ * <nys-badge label="Emergency" intent="emergency" prefixIcon></nys-badge>
+ * ```
+ *
  * @example Strong Base
  * ```html
  * <nys-badge strong label="Base" prefixIcon></nys-badge>
@@ -105,15 +110,16 @@ export class NysBadge extends NysElement {
   @property({ type: String, reflect: true }) size: "sm" | "md" = "md";
 
   /**
-   * Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`.
+   * Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`.
    * @default "info"
    */
   @property({ type: String, reflect: true }) intent:
     | "base"
-    | "danger"
     | "info"
     | "success"
-    | "warning" = "base";
+    | "warning"
+    | "danger"
+    | "emergency" = "base";
 
   /** Secondary label displayed before the main label. */
   @property({ type: String }) prefixLabel = "";
@@ -190,10 +196,11 @@ export class NysBadge extends NysElement {
   // Map of default icons by intent
   private static readonly DEFAULT_ICONS: Record<string, string> = {
     base: "info",
-    danger: "error",
     info: "info",
     success: "check_circle",
     warning: "warning",
+    danger: "error",
+    emergency: "emergency_home",
   };
 
   // WCAG 1.4.1 (Use of Color): intent is otherwise conveyed only by color and a
@@ -201,10 +208,11 @@ export class NysBadge extends NysElement {
   // so the semantic meaning is not color-only. Skipped for "base" (no
   // semantic meaning) and when the author supplies their own srText override.
   private static readonly INTENT_SR_TEXT: Record<string, string> = {
-    danger: "Danger",
     info: "Info",
     success: "Success",
     warning: "Warning",
+    danger: "Danger",
+    emergency: "Emergency",
   };
 
   /**

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -110,7 +110,7 @@ export class NysBadge extends NysElement {
   @property({ type: String, reflect: true }) size: "sm" | "md" = "md";
 
   /**
-   * Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`.
+   * Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. `error` has been deprecated and support will be removed in a future release. Use `danger` instead
    * @default "info"
    */
   @property({ type: String, reflect: true }) intent:
@@ -119,6 +119,7 @@ export class NysBadge extends NysElement {
     | "success"
     | "warning"
     | "danger"
+    | "error"
     | "emergency" = "base";
 
   /** Secondary label displayed before the main label. */
@@ -200,6 +201,7 @@ export class NysBadge extends NysElement {
     success: "check_circle",
     warning: "warning",
     danger: "error",
+    error: "error",
     emergency: "emergency_home",
   };
 
@@ -212,6 +214,7 @@ export class NysBadge extends NysElement {
     success: "Success",
     warning: "Warning",
     danger: "Danger",
+    error: "Danger",
     emergency: "Emergency",
   };
 

--- a/packages/nys-badge/src/nys-badge.ts
+++ b/packages/nys-badge/src/nys-badge.ts
@@ -40,22 +40,22 @@ import styles from "./nys-badge.scss?inline";
  *
  * @example Strong Base
  * ```html
- * <nys-badge variant="strong" label="Base" prefixIcon></nys-badge>
+ * <nys-badge strong label="Base" prefixIcon></nys-badge>
  * ```
  *
  * @example Strong Error
  * ```html
- * <nys-badge variant="strong" label="Error" intent="error" prefixIcon></nys-badge>
+ * <nys-badge strong label="Error" intent="error" prefixIcon></nys-badge>
  * ```
  *
  * @example Strong Warning
  * ```html
- * <nys-badge variant="strong" label="Warning" intent="warning" prefixIcon></nys-badge>
+ * <nys-badge strong label="Warning" intent="warning" prefixIcon></nys-badge>
  * ```
  *
  * @example Strong Success
  * ```html
- * <nys-badge variant="strong" label="Success" intent="success" prefixIcon></nys-badge>
+ * <nys-badge strong label="Success" intent="success" prefixIcon></nys-badge>
  * ```
  *
  * @example Custom Prefix Icon
@@ -113,7 +113,8 @@ export class NysBadge extends NysElement {
   /** Screen reader text appended after the label for additional context. */
   @property({ type: String }) srText = "";
 
-  @property({ type: String, reflect: true }) variant: "strong" | "" = "";
+  /** Strong visual with bolder text and background. */
+  @property({ type: Boolean, reflect: true }) strong = false;
 
   // Icons (string or boolean)
   private _prefixIcon: string | boolean = "";

--- a/packages/react/NysBadge.d.ts
+++ b/packages/react/NysBadge.d.ts
@@ -36,7 +36,7 @@ export interface NysBadgeProps extends Pick<
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: NysBadgeElement["size"];
 
-  /** Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`. */
+  /** Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`. */
   intent?: NysBadgeElement["intent"];
 
   /** Secondary label displayed before the main label. */

--- a/packages/react/NysBadge.d.ts
+++ b/packages/react/NysBadge.d.ts
@@ -36,7 +36,7 @@ export interface NysBadgeProps extends Pick<
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: NysBadgeElement["size"];
 
-  /** Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`. */
+  /** Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. */
   intent?: NysBadgeElement["intent"];
 
   /** Secondary label displayed before the main label. */

--- a/packages/react/NysBadge.d.ts
+++ b/packages/react/NysBadge.d.ts
@@ -36,7 +36,7 @@ export interface NysBadgeProps extends Pick<
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: NysBadgeElement["size"];
 
-  /** Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. */
+  /** Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. `error` has been deprecated and support will be removed in a future release. Use `danger` instead */
   intent?: NysBadgeElement["intent"];
 
   /** Secondary label displayed before the main label. */

--- a/packages/react/NysBadge.d.ts
+++ b/packages/react/NysBadge.d.ts
@@ -36,7 +36,7 @@ export interface NysBadgeProps extends Pick<
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: NysBadgeElement["size"];
 
-  /** Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`. */
+  /** Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`. */
   intent?: NysBadgeElement["intent"];
 
   /** Secondary label displayed before the main label. */

--- a/packages/react/NysBadge.d.ts
+++ b/packages/react/NysBadge.d.ts
@@ -18,6 +18,9 @@ export interface NysBadgeProps extends Pick<
   | "onFocus"
   | "onBlur"
 > {
+  /** Strong visual intent with bolder text and background. */
+  strong?: boolean;
+
   /** undefined */
   prefixIcon?: string | boolean;
 
@@ -33,7 +36,7 @@ export interface NysBadgeProps extends Pick<
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: NysBadgeElement["size"];
 
-  /** Semantic intent affecting color: `base`, `error`, `success`, or `warning`. */
+  /** Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`. */
   intent?: NysBadgeElement["intent"];
 
   /** Secondary label displayed before the main label. */
@@ -44,9 +47,6 @@ export interface NysBadgeProps extends Pick<
 
   /** Screen reader text appended after the label for additional context. */
   srText?: NysBadgeElement["srText"];
-
-  /** undefined */
-  variant?: NysBadgeElement["variant"];
 
   /** A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the class selectors or functions like the method `Document.getElementsByClassName()`. */
   className?: string;

--- a/packages/react/NysBadge.d.ts
+++ b/packages/react/NysBadge.d.ts
@@ -33,7 +33,7 @@ export interface NysBadgeProps extends Pick<
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: NysBadgeElement["size"];
 
-  /** Semantic intent affecting color: `neutral`, `error`, `success`, or `warning`. */
+  /** Semantic intent affecting color: `base`, `error`, `success`, or `warning`. */
   intent?: NysBadgeElement["intent"];
 
   /** Secondary label displayed before the main label. */

--- a/packages/react/NysBadge.js
+++ b/packages/react/NysBadge.js
@@ -3,6 +3,7 @@ import "../../dist/nysds.es.js";
 
 export const NysBadge = forwardRef((props, forwardedRef) => {
   const {
+    strong,
     prefixIcon,
     suffixIcon,
     id,
@@ -12,7 +13,6 @@ export const NysBadge = forwardRef((props, forwardedRef) => {
     prefixLabel,
     label,
     srText,
-    variant,
     ...filteredProps
   } = props;
 
@@ -27,12 +27,12 @@ export const NysBadge = forwardRef((props, forwardedRef) => {
       prefixLabel: props.prefixLabel,
       label: props.label,
       srText: props.srText,
-      variant: props.variant,
       class: props.className,
       exportparts: props.exportparts,
       for: props.htmlFor,
       part: props.part,
       tabindex: props.tabIndex,
+      strong: props.strong ? true : undefined,
       prefixicon: props.prefixIcon ? true : undefined,
       suffixicon: props.suffixIcon ? true : undefined,
       style: { ...props.style },

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -186,8 +186,8 @@ export type NysBadgeProps = {
   name?: string;
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: "sm" | "md";
-  /** Semantic intent affecting color: `neutral`, `error`, `success`, or `warning`. */
-  intent?: "neutral" | "error" | "success" | "warning";
+  /** Semantic intent affecting color: `base`, `error`, `success`, or `warning`. */
+  intent?: "base" | "error" | "success" | "warning";
   /** Secondary label displayed before the main label. */
   prefixLabel?: string;
   /** Primary label text displayed in the badge. */

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -186,8 +186,8 @@ export type NysBadgeProps = {
   name?: string;
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: "sm" | "md";
-  /** Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. */
-  intent?: "base" | "info" | "success" | "warning" | "danger" | "emergency";
+  /** Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. `error` has been deprecated and support will be removed in a future release. Use `danger` instead */
+  intent?: "base" | "info" | "success" | "warning" | "danger" | "error" | "emergency";
   /** Secondary label displayed before the main label. */
   prefixLabel?: string;
   /** Primary label text displayed in the badge. */

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -186,8 +186,8 @@ export type NysBadgeProps = {
   name?: string;
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: "sm" | "md";
-  /** Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`. */
-  intent?: "base" | "danger" | "info" | "success" | "warning";
+  /** Semantic intent affecting color: `base`, `info`, `success`, `warning` `danger`, `emergency`. */
+  intent?: "base" | "info" | "success" | "warning" | "danger" | "emergency";
   /** Secondary label displayed before the main label. */
   prefixLabel?: string;
   /** Primary label text displayed in the badge. */

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -186,8 +186,8 @@ export type NysBadgeProps = {
   name?: string;
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: "sm" | "md";
-  /** Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`. */
-  intent?: "base" | "emergency" | "info" | "success" | "warning";
+  /** Semantic intent affecting color: `base`, `danger`, `info`, `success`, or `warning`. */
+  intent?: "base" | "danger" | "info" | "success" | "warning";
   /** Secondary label displayed before the main label. */
   prefixLabel?: string;
   /** Primary label text displayed in the badge. */

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -186,16 +186,16 @@ export type NysBadgeProps = {
   name?: string;
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: "sm" | "md";
-  /** Semantic intent affecting color: `base`, `error`, `success`, or `warning`. */
-  intent?: "base" | "error" | "success" | "warning";
+  /** Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`. */
+  intent?: "base" | "error" | "info" | "success" | "warning";
   /** Secondary label displayed before the main label. */
   prefixLabel?: string;
   /** Primary label text displayed in the badge. */
   label?: string;
   /** Screen reader text appended after the label for additional context. */
   srText?: string;
-  /**  */
-  variant?: "strong" | "";
+  /** Strong visual intent with bolder text and background. */
+  strong?: boolean;
   /**  */
   prefixicon?: string | boolean;
   /**  */

--- a/packages/react/nysds-jsx.d.ts
+++ b/packages/react/nysds-jsx.d.ts
@@ -186,8 +186,8 @@ export type NysBadgeProps = {
   name?: string;
   /** Badge size: `sm` (smaller text) or `md` (default). */
   size?: "sm" | "md";
-  /** Semantic intent affecting color: `base`, `error`, `info`, `success`, or `warning`. */
-  intent?: "base" | "error" | "info" | "success" | "warning";
+  /** Semantic intent affecting color: `base`, `emergency`, `info`, `success`, or `warning`. */
+  intent?: "base" | "emergency" | "info" | "success" | "warning";
   /** Secondary label displayed before the main label. */
   prefixLabel?: string;
   /** Primary label text displayed in the badge. */


### PR DESCRIPTION
# Summary

`neutral` is now `base`
new `emergency`, `info`
`error` now `danger`

## Breaking change

:warning: This is a **breaking change**.

`intent="error"` is no longer valid and needs to be updated to `intent="danger"` right now it is still supported but it is considered deprecated and support will be removed in a later release

`variant="strong"` is now just boolean `strong`

## Screenshots
<img width="305" height="201" alt="image" src="https://github.com/user-attachments/assets/b1333e8b-4e2c-44fb-8920-6a27ad6e7d63" />
