### PR TITLE
FIX: Combobox form required when not explicitly set

### DIFF
--- a/packages/nys-combobox/src/nys-combobox.test.ts
+++ b/packages/nys-combobox/src/nys-combobox.test.ts
@@ -221,6 +221,22 @@ describe("nys-combobox", () => {
     expect(input?.hasAttribute("required")).to.be.false;
   });
 
+  it("does not trigger validation error on blur when required is not set and value is empty", async () => {
+    const el = await fixture<NysCombobox>(html`
+      <nys-combobox>
+        <option value="apple">Apple</option>
+      </nys-combobox>
+    `);
+    const input = el.shadowRoot?.querySelector("input") as HTMLInputElement;
+
+    input.dispatchEvent(new Event("blur"));
+    await el.updateComplete;
+
+    const errorMessage = el.shadowRoot?.querySelector("nys-errormessage");
+    expect(errorMessage?.hasAttribute("showError")).to.be.false;
+    expect(el.showError).to.be.false;
+  });
+
   // Width tests (Width story)
   it("defaults to full width when width is unset", async () => {
     const el = await fixture<NysCombobox>(html`<nys-combobox></nys-combobox>`);

--- a/packages/nys-combobox/src/nys-combobox.ts
+++ b/packages/nys-combobox/src/nys-combobox.ts
@@ -422,7 +422,9 @@ export class NysCombobox extends NysFormControlElement {
     let message = "";
 
     const isInvalid =
-      this._input && !this._options.some((opt) => opt.value === this.value);
+      this._input &&
+      this.value &&
+      !this._options.some((opt) => opt.value === this.value);
 
     if (validity.valueMissing || isInvalid) {
       message = "This field is required";


### PR DESCRIPTION
Combobox was getting marked as required when not explicitly set forcing a selection. Fixed