### PR TITLE
Fix: MCP `get_utility_classes` advertised classes that do not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "clean:all": "npm run clean:dist && npm run clean:node && npm run clean:cache && find packages -name '*.tsbuildinfo' -delete 2>/dev/null || true && npm run clean:turbo",
     "code-connect": "dotenv -- npx figma connect publish",
     "cem": "npx cem analyze --config src/scripts/custom-elements-manifest.config.mjs && cp ./custom-elements.json dist/ && node src/scripts/patch-react-utils.js",
-    "verify:a11y-names": "node src/scripts/verify-a11y-names.mjs"
+    "verify:a11y-names": "node src/scripts/verify-a11y-names.mjs",
+    "verify:utility-docs": "npm run build:mcp && node src/scripts/verify-utility-docs.mjs"
   },
   "repository": {
     "type": "git",

--- a/packages/mcp-server/src/tools/utility-tools.ts
+++ b/packages/mcp-server/src/tools/utility-tools.ts
@@ -2,10 +2,203 @@
  * Utility Tools
  *
  * MCP tools for NYSDS utility classes.
+ *
+ * The class lists this tool returns are RENDERED from the scale constants
+ * below. Those constants mirror the Sass sources that actually generate the
+ * stylesheet:
+ *
+ *   - packages/styles/src/utilities/_config.scss     ($spacing, $opacity-values,
+ *                                                     $zindex-values, $display-values,
+ *                                                     $breakpoints, $flex-columns)
+ *   - packages/styles/src/utilities/_layout-grid.scss ($responsive-gap-suffixes)
+ *   - packages/styles/src/core/typography.scss        ($body-sizes, $ui-sizes,
+ *                                                     $ui-underline-styles, $display-sizes)
+ *
+ * Do not hand-write a class name into the markdown. Add it to a scale and let
+ * the renderer emit it, so a name can never appear here without a scale entry
+ * behind it.
+ *
+ * `npm run verify:utility-docs` compiles the stylesheet and asserts that every
+ * class this tool names exists in it. Run it after touching any scale.
  */
 
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/* ------------------------------------------------------------------ *
+ * Scales — mirror the Sass sources listed above.
+ * ------------------------------------------------------------------ */
+
+type SpacingEntry = readonly [key: string, px: string, rem?: string];
+
+/**
+ * `$spacing` in _config.scss. The utilities emit literal pixel values, not
+ * `var(--nys-space-*)` references, so the rendered docs quote pixels.
+ *
+ * There is deliberately no `0` key: `nys-margin-0` and `nys-padding-0` are
+ * not generated.
+ */
+const SPACING: readonly SpacingEntry[] = [
+  ["1px", "1px"],
+  ["2px", "2px"],
+  ["50", "4px", "0.25rem"],
+  ["100", "8px", "0.5rem"],
+  ["150", "12px", "0.75rem"],
+  ["200", "16px", "1rem"],
+  ["250", "20px", "1.25rem"],
+  ["300", "24px", "1.5rem"],
+  ["400", "32px", "2rem"],
+  ["500", "40px", "2.5rem"],
+  ["600", "48px", "3rem"],
+  ["700", "56px", "3.5rem"],
+  ["800", "64px", "4rem"],
+  ["1200", "96px", "6rem"],
+];
+
+/** `$responsive-gap-suffixes` in _layout-grid.scss. */
+const RESPONSIVE_GAP_KEYS: readonly string[] = [
+  "400",
+  "500",
+  "600",
+  "700",
+  "800",
+  "1200",
+];
+
+/** `$opacity-values` in _config.scss. */
+const OPACITY: readonly number[] = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+/** `$zindex-values` in _config.scss. */
+const ZINDEX: ReadonlyArray<readonly [name: string, value: string]> = [
+  ["0", "0"],
+  ["100", "100"],
+  ["200", "200"],
+  ["300", "300"],
+  ["400", "400"],
+  ["500", "500"],
+  ["auto", "auto"],
+  ["bottom", "-100"],
+  ["top", "99999"],
+];
+
+/** `$display-values` in _config.scss. */
+const DISPLAY: readonly string[] = [
+  "none",
+  "block",
+  "inline",
+  "inline-block",
+  "flex",
+  "inline-flex",
+  "table",
+  "table-cell",
+  "table-row",
+];
+
+/** `$breakpoints` in _config.scss. */
+const BREAKPOINTS: ReadonlyArray<
+  readonly [name: string, em: string, px: string]
+> = [
+  ["mobile-lg", "30em", "480px"],
+  ["tablet", "40em", "640px"],
+  ["desktop", "64em", "1024px"],
+  ["widescreen", "87.5em", "1400px"],
+];
+
+/** Typography scales in core/typography.scss. */
+const HEADING_LEVELS: readonly number[] = [1, 2, 3, 4, 5, 6];
+const BODY_SIZES: readonly string[] = ["xs", "sm", "md"];
+const UI_SIZES: readonly string[] = ["xs", "sm", "md", "lg", "xl"];
+const DISPLAY_SIZES: readonly string[] = ["sm", "md", "lg", "xl"];
+/** `$ui-underline-styles` — only these size/weight pairs are generated. */
+const UI_UNDERLINE: ReadonlyArray<readonly [size: string, weight: string]> = [
+  ["sm", "semibold"],
+  ["md", "semibold"],
+  ["md", "regular"],
+  ["lg", "semibold"],
+];
+
+const FLEX_ALIGN: readonly string[] = [
+  "start",
+  "center",
+  "end",
+  "baseline",
+  "stretch",
+];
+const FLEX_JUSTIFY: readonly string[] = [
+  "start",
+  "center",
+  "end",
+  "space-between",
+  "space-around",
+  "space-evenly",
+];
+
+/* ------------------------------------------------------------------ *
+ * Renderers
+ * ------------------------------------------------------------------ */
+
+const spacingKeys = SPACING.map(([key]) => key);
+const bullets = (lines: readonly string[]) => lines.join("\n");
+const inlineList = (items: readonly string[]) =>
+  items.map((i) => `\`${i}\``).join(", ");
+
+const spacingValueRows = bullets(
+  SPACING.map(
+    ([key, px, rem]) => `- \`${key}\` - ${px}${rem ? ` (${rem})` : ""}`,
+  ),
+);
+
+const gapValueRows = bullets(
+  SPACING.map(([key, px, rem]) => {
+    const size = `${px}${rem ? ` (${rem})` : ""}`;
+    // Gaps in the responsive set are capped at 2rem below 64em. For 400 the
+    // cap equals the full value, so only note it where it actually differs.
+    const capped =
+      RESPONSIVE_GAP_KEYS.includes(key) && Number.parseInt(px, 10) > 32;
+    return capped
+      ? `- \`nys-grid-gap-${key}\` - ${size} at 64em and up, capped at 32px (2rem) below that`
+      : `- \`nys-grid-gap-${key}\` - ${size}`;
+  }),
+);
+
+const opacityRows = bullets(
+  OPACITY.map((v) => {
+    const label =
+      v === 0
+        ? "Fully transparent"
+        : v === 100
+          ? "Fully opaque"
+          : `${v}% opaque`;
+    return `- \`nys-opacity-${v}\` - opacity: ${v / 100} (${label})`;
+  }),
+);
+
+const zindexRows = bullets(
+  ZINDEX.map(([name, value]) => `- \`nys-z-${name}\` - z-index: ${value}`),
+);
+
+const displayRows = bullets(
+  DISPLAY.map((v) => `- \`nys-display-${v}\` - display: ${v}`),
+);
+
+const breakpointRows = bullets(
+  BREAKPOINTS.map(
+    ([name, em, px]) => `- \`nys-${name}:\` - ${em} (${px}) and up`,
+  ),
+);
+
+const headingRows = bullets(
+  HEADING_LEVELS.map(
+    (n) => `- \`nys-font-h${n}\` - Heading level ${n} type style`,
+  ),
+);
+
+const underlineRows = bullets(
+  UI_UNDERLINE.flatMap(([size, weight]) => [
+    `- \`nys-font-ui-${size}-${weight}-underline\` - UI ${size} ${weight}, 7% underline`,
+    `- \`nys-font-ui-${size}-${weight}-underline-strong\` - UI ${size} ${weight}, 14% underline`,
+  ]),
+);
 
 const UTILITY_DOCS = {
   grid: `## Grid System
@@ -29,20 +222,11 @@ NYSDS provides a 12-column responsive grid system.
 - \`nys-grid-col-fill\` - Column fills remaining space
 
 ### Gap Classes
-- \`nys-grid-gap-0\` - No gap
-- \`nys-grid-gap-2px\` - 2px gap
-- \`nys-grid-gap-50\` - 4px gap (0.25rem)
-- \`nys-grid-gap-100\` - 8px gap (0.5rem)
-- \`nys-grid-gap-150\` - 12px gap (0.75rem)
-- \`nys-grid-gap-200\` - 16px gap (1rem)
-- \`nys-grid-gap-250\` - 20px gap (1.25rem)
-- \`nys-grid-gap-300\` - 24px gap (1.5rem)
-- \`nys-grid-gap-400\` - 32px gap (2rem)
-- \`nys-grid-gap-500\` - 40px gap (2.5rem)
-- \`nys-grid-gap-600\` - 48px gap (3rem)
-- \`nys-grid-gap-700\` - 56px gap (3.5rem)
-- \`nys-grid-gap-800\` - 64px gap (4rem)
-- \`nys-grid-gap-1200\` - 96px gap (6rem)
+Gap classes apply to \`nys-grid-row\`. Use \`nys-grid-gap-x-*\` or
+\`nys-grid-gap-y-*\` for a single axis. There is no \`nys-grid-gap-0\`; omit
+the gap class instead.
+
+${gapValueRows}
 
 ### Offset Classes
 - \`nys-grid-offset-[1-12]\` - Offset column by 1-12 columns
@@ -65,6 +249,7 @@ NYSDS provides a 12-column responsive grid system.
 
 ### Display
 - \`nys-display-flex\` - Sets display: flex
+- \`nys-display-inline-flex\` - Sets display: inline-flex
 
 ### Direction
 - \`nys-flex-row\` - Row direction (default)
@@ -75,20 +260,25 @@ NYSDS provides a 12-column responsive grid system.
 - \`nys-flex-no-wrap\` - Prevent wrapping
 
 ### Alignment (Cross Axis)
-- \`nys-flex-align-start\` - Align items to start
-- \`nys-flex-align-center\` - Align items to center
-- \`nys-flex-align-end\` - Align items to end
-- \`nys-flex-align-stretch\` - Stretch items to fill
+${bullets(FLEX_ALIGN.map((v) => `- \`nys-flex-align-${v}\` - align-items: ${v}`))}
+
+### Self Alignment
+${bullets(FLEX_ALIGN.map((v) => `- \`nys-flex-align-self-${v}\` - align-self: ${v}`))}
 
 ### Justification (Main Axis)
-- \`nys-flex-justify-start\` - Justify to start
-- \`nys-flex-justify-center\` - Justify to center
-- \`nys-flex-justify-end\` - Justify to end
+${bullets(FLEX_JUSTIFY.map((v) => `- \`nys-flex-justify-${v}\` - justify-content: ${v}`))}
 
 ### Flex Sizing
 - \`nys-flex-[1-12]\` - Flex grow/shrink values
 - \`nys-flex-auto\` - flex: auto (grow and shrink)
 - \`nys-flex-fill\` - Fill available space
+
+### Gaps
+Available on the spacing scale: ${inlineList(spacingKeys)}
+
+- \`nys-flex-gap-{value}\` - gap on both axes
+- \`nys-flex-row-gap-{value}\` - row-gap only
+- \`nys-flex-column-gap-{value}\` - column-gap only
 
 ### Example: Button Group
 \`\`\`html
@@ -116,21 +306,11 @@ Pattern: \`nys-{property}-{direction}-{value}\`
 - (none) - All sides
 
 ### Values
-- \`0\` - 0
-- \`1px\` - 1px
-- \`2px\` - 2px
-- \`50\` - var(--nys-space-50) = 0.125rem (2px)
-- \`100\` - var(--nys-space-100) = 0.25rem (4px)
-- \`150\` - var(--nys-space-150) = 0.375rem (6px)
-- \`200\` - var(--nys-space-200) = 0.5rem (8px)
-- \`250\` - var(--nys-space-250) = 0.625rem (10px)
-- \`300\` - var(--nys-space-300) = 0.75rem (12px)
-- \`400\` - var(--nys-space-400) = 1rem (16px)
-- \`500\` - var(--nys-space-500) = 1.25rem (20px)
-- \`600\` - var(--nys-space-600) = 1.5rem (24px)
-- \`700\` - var(--nys-space-700) = 2rem (32px)
-- \`800\` - var(--nys-space-800) = 2.5rem (40px)
-- \`1200\` - var(--nys-space-1200) = 4rem (64px)
+The utilities emit literal pixel values. There is no zero and no \`auto\`
+value — \`nys-margin-0\` and \`nys-padding-0\` are not generated. Omit the
+class instead.
+
+${spacingValueRows}
 
 ### Examples
 \`\`\`html
@@ -146,11 +326,7 @@ Pattern: \`nys-{property}-{direction}-{value}\`
 
   display: `## Display Utilities
 
-- \`nys-display-none\` - Hide element
-- \`nys-display-block\` - Block display
-- \`nys-display-inline\` - Inline display
-- \`nys-display-inline-block\` - Inline-block display
-- \`nys-display-flex\` - Flex display
+${displayRows}
 
 ### Example: Hide on Mobile
 \`\`\`html
@@ -161,39 +337,52 @@ Pattern: \`nys-{property}-{direction}-{value}\`
 
   opacity: `## Opacity Utilities
 
-- \`nys-opacity-0\` - Fully transparent
-- \`nys-opacity-25\` - 25% opacity
-- \`nys-opacity-50\` - 50% opacity
-- \`nys-opacity-75\` - 75% opacity
-- \`nys-opacity-100\` - Fully opaque`,
+The scale steps by 10 — there is no \`nys-opacity-25\` or \`nys-opacity-75\`.
+
+${opacityRows}`,
 
   zindex: `## Z-Index Utilities
 
-- \`nys-z-0\` - z-index: 0
-- \`nys-z-10\` - z-index: 10
-- \`nys-z-20\` - z-index: 20
-- \`nys-z-30\` - z-index: 30
-- \`nys-z-40\` - z-index: 40
-- \`nys-z-50\` - z-index: 50
-- \`nys-z-auto\` - z-index: auto`,
+The scale steps by 100, not by 10. \`nys-z-10\` through \`nys-z-50\` do not
+exist — the comparable values are \`nys-z-100\` through \`nys-z-500\`.
+
+${zindexRows}`,
 
   typography: `## Typography Utilities
 
-### Text Alignment
-- \`nys-text-left\` - Left align text
-- \`nys-text-center\` - Center align text
-- \`nys-text-right\` - Right align text
+NYSDS ships a role-based type scale, not atomic text modifiers. Each class
+sets font-family, size, and line-height together, matching the text styles in
+the NYSDS Foundations Figma file.
 
-### Font Weight
-- \`nys-font-normal\` - Normal weight
-- \`nys-font-medium\` - Medium weight
-- \`nys-font-semibold\` - Semibold weight
-- \`nys-font-bold\` - Bold weight
+There are NO text-alignment, text-transform, or font-weight utilities
+(no \`nys-text-center\`, no \`nys-font-bold\`). Use CSS for those.
 
-### Text Transform
-- \`nys-text-uppercase\` - Uppercase text
-- \`nys-text-lowercase\` - Lowercase text
-- \`nys-text-capitalize\` - Capitalize text`,
+### Headings
+${headingRows}
+
+### Body
+${bullets(BODY_SIZES.map((s) => `- \`nys-font-body-${s}\` - Body text, ${s}`))}
+
+### UI
+${bullets(UI_SIZES.map((s) => `- \`nys-font-ui-${s}\` - UI text, ${s}`))}
+
+### UI Underline
+${underlineRows}
+
+### Display
+${bullets(DISPLAY_SIZES.map((s) => `- \`nys-font-display-${s}\` - Display text, ${s}`))}
+
+### Agency
+- \`nys-font-agency\` - Agency / application title
+
+### Font family hooks
+These are attribute selectors, not standalone classes. They set only
+font-family on any element whose class list contains the substring, so pair
+them with a size class:
+
+- \`[class*="nys-font-mono-"]\` - monospace family
+- \`[class*="nys-font-sans-"]\` - sans-serif family
+- \`[class*="nys-font-serif-"]\` - serif family`,
 
   responsive: `## Responsive Breakpoints
 
@@ -201,9 +390,7 @@ NYSDS utility classes support responsive prefixes.
 
 ### Breakpoints
 - (no prefix) - All screen sizes (mobile-first)
-- \`nys-mobile-lg:\` - 30em (480px) and up
-- \`nys-tablet:\` - 40em (640px) and up
-- \`nys-desktop:\` - 64em (1024px) and up
+${breakpointRows}
 
 ### Pattern
 \`nys-{breakpoint}:nys-{class}\`
@@ -247,6 +434,37 @@ When adding spacing around NYSDS components, use utility classes rather than wra
 <nys-button label="Submit"></nys-button>
 \`\`\``,
 };
+
+/**
+ * Classes the reference deliberately names in order to say they do NOT exist.
+ *
+ * These are the names people reach for out of habit from other frameworks.
+ * Saying so explicitly is more useful than silence, but it means the docs
+ * mention class names the stylesheet does not define, which would otherwise
+ * trip the verifier.
+ *
+ * `verify-utility-docs.mjs` asserts each of these is genuinely absent, so if
+ * NYSDS ever adds one, the stale warning fails the check instead of quietly
+ * misinforming people.
+ */
+const KNOWN_ABSENT: readonly string[] = [
+  "nys-text-center",
+  "nys-font-bold",
+  "nys-z-10",
+  "nys-z-50",
+  "nys-opacity-25",
+  "nys-opacity-75",
+  "nys-margin-0",
+  "nys-padding-0",
+  "nys-grid-gap-0",
+];
+
+/**
+ * Exported so `src/scripts/verify-utility-docs.mjs` can assert that every class
+ * named in this reference exists in the compiled stylesheet — and that every
+ * class named in KNOWN_ABSENT still does not.
+ */
+export { UTILITY_DOCS, KNOWN_ABSENT };
 
 export function registerUtilityTools(server: McpServer): void {
   // get_utility_classes - Comprehensive utility class reference

--- a/src/scripts/verify-utility-docs.mjs
+++ b/src/scripts/verify-utility-docs.mjs
@@ -1,0 +1,133 @@
+// Verifies that every utility class named by the MCP `get_utility_classes` tool
+// actually exists in the compiled stylesheet.
+//
+// Why this exists: the tool's reference used to be a hand-maintained markdown
+// string. It drifted — advertising ~18 classes that had never existed
+// (`nys-text-center`, `nys-font-bold`, `nys-z-50`, `nys-opacity-25`,
+// `nys-margin-0`, ...) plus a spacing table at half the real values. Nothing in
+// the build could notice, because no code ever compared the prose to the CSS.
+// This script closes that loop: it renders the docs, harvests every class name
+// out of them, compiles the real stylesheet, and fails on any name the
+// stylesheet does not define.
+//
+// Run AFTER `npm run build:mcp`.  Usage: node src/scripts/verify-utility-docs.mjs
+import * as sass from "sass";
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+const STYLES_SRC = resolve(process.cwd(), "packages/styles/src");
+const MCP_DIST = resolve(
+  process.cwd(),
+  "packages/mcp-server/dist/tools/utility-tools.js",
+);
+
+/* 1. Compile the utility + typography layers. These are the only layers that
+ *    emit `nys-*` utility classes; skipping core/tokens keeps the script from
+ *    depending on a built @nysds/tokens. */
+let css;
+try {
+  css = sass.compileString(
+    '@use "utilities" as *;\n@use "core/typography" as *;\n',
+    {
+      loadPaths: [STYLES_SRC],
+      style: "compressed",
+      silenceDeprecations: ["global-builtin", "import"],
+    },
+  ).css;
+} catch (err) {
+  console.error(`Could not compile ${STYLES_SRC}:\n${err.message}`);
+  process.exit(1);
+}
+
+/* 2. Every class the stylesheet actually defines. Selectors escape `:` in
+ *    responsive variants (`.nys-tablet\:nys-display-block`), so unescape. */
+const defined = new Set(
+  [...css.matchAll(/\.((?:[A-Za-z0-9_-]|\\.)+)/g)].map((m) =>
+    m[1].replace(/\\(.)/g, "$1"),
+  ),
+);
+
+/* 3. Every class the MCP docs name. Two sources: `class="..."` attributes in
+ *    the HTML examples, and single-token inline code spans. Tag names in the
+ *    examples (`<nys-button>`) are excluded by construction. */
+let UTILITY_DOCS, KNOWN_ABSENT;
+try {
+  ({ UTILITY_DOCS, KNOWN_ABSENT } = await import(pathToFileURL(MCP_DIST).href));
+} catch {
+  console.error(
+    `Could not import ${MCP_DIST}\nRun \`npm run build:mcp\` first.`,
+  );
+  process.exit(1);
+}
+
+const claimed = new Map(); // class name -> categories that named it
+
+for (const [category, text] of Object.entries(UTILITY_DOCS)) {
+  const tokens = [];
+  for (const m of text.matchAll(/class="([^"]+)"/g)) {
+    tokens.push(...m[1].split(/\s+/));
+  }
+  for (const m of text.matchAll(/`([^`\n]+)`/g)) {
+    tokens.push(m[1]);
+  }
+
+  for (const raw of tokens) {
+    const token = raw.trim();
+    if (!token.startsWith("nys-")) continue;
+    // Patterns and prefixes, not concrete class names:
+    //   nys-{property}-...   nys-grid-col-[1-12]   nys-tablet:   nys-font-mono-
+    if (/[{}[\]*]/.test(token)) continue;
+    if (token.endsWith(":") || token.endsWith("-")) continue;
+    if (KNOWN_ABSENT.includes(token)) continue;
+    if (!claimed.has(token)) claimed.set(token, new Set());
+    claimed.get(token).add(category);
+  }
+}
+
+/* 4. Compare, both directions. */
+const missing = [...claimed.entries()].filter(([cls]) => !defined.has(cls));
+// A warning that says "nys-text-center does not exist" becomes a lie the day
+// someone adds it, so assert the absences too.
+const staleWarnings = KNOWN_ABSENT.filter((cls) => defined.has(cls));
+
+console.log(
+  `Checked ${claimed.size} class names from ${Object.keys(UTILITY_DOCS).length} doc sections ` +
+    `against ${defined.size} classes in the compiled stylesheet.`,
+);
+console.log(
+  `Checked ${KNOWN_ABSENT.length} documented-as-absent class names are still absent.`,
+);
+
+if (missing.length === 0 && staleWarnings.length === 0) {
+  console.log("PASS - every documented utility class exists.");
+  process.exit(0);
+}
+
+if (staleWarnings.length > 0) {
+  console.error(
+    `\nFAIL - ${staleWarnings.length} class(es) documented as non-existent now exist:\n`,
+  );
+  for (const cls of staleWarnings) {
+    console.error(`  ${cls}`);
+  }
+  console.error(
+    "\nThe stylesheet gained a class the reference tells people not to use.\n" +
+      "Remove it from KNOWN_ABSENT and document it properly.",
+  );
+}
+
+if (missing.length > 0) {
+  console.error(
+    `\nFAIL - ${missing.length} documented class(es) do not exist:\n`,
+  );
+  for (const [cls, categories] of missing) {
+    console.error(`  ${cls}  (named in: ${[...categories].sort().join(", ")})`);
+  }
+  console.error(
+    "\nEither the class was removed from the stylesheet or the doc scale in\n" +
+      "packages/mcp-server/src/tools/utility-tools.ts names something that was\n" +
+      "never generated. Fix the scale, rebuild the MCP server, and re-run.",
+  );
+}
+
+process.exit(1);


### PR DESCRIPTION
Fixes #1877. Fixes #1836.

## What was wrong

`get_utility_classes` is the tool agents are pointed at to choose NYSDS utility classes. Its reference was a hand-maintained markdown string in `utility-tools.ts`, and nothing in the build ever compared that prose to the CSS. It drifted:

- **18 advertised classes never existed.** Applying them does nothing.
- **The entire Typography section was fabricated.** NYSDS ships no text-alignment, text-transform, or font-weight utilities under any name, yet the tool listed ten of them.
- **The spacing table was at roughly half the real values**, which is #1836.

The invented names are Tailwind's, with a `nys-` prefix — `text-left`, `font-bold`, `opacity-0/25/50/75/100`, `z-0/10/20/30/40/50`. That pattern suggests these blocks were written from memory of a generic utility framework rather than read out of `packages/styles`.

`nys-z-50` was the worst of them: it reads like a valid low stacking value, silently does nothing, and the real scale is two orders of magnitude away at `nys-z-500`.

## What changed

**Docs are now rendered from scale constants** that mirror `_config.scss`, `_layout-grid.scss`, and `core/typography.scss`. A class name can no longer appear in the reference without a scale entry behind it.

| Category | Fix |
| --- | --- |
| typography | Replaced 10 invented modifiers with the real role-based scale (headings, body, ui, ui-underline, display, agency) |
| z-index | Real scale steps by 100, not 10; added `bottom`/`top` |
| opacity | Real scale steps by 10; `25` and `75` never existed |
| spacing | Corrected every value; dropped the non-existent `0`; stopped describing classes as `var(--nys-space-*)` when they emit literal px |
| grid | Dropped `nys-grid-gap-0`; documented the `-x`/`-y` variants and the 2rem cap below 64em |
| display | Added `inline-flex` and the table values |
| flex | Added baseline/self alignment, `space-between`/`around`/`evenly`, and the gap scales |
| responsive | Added the `nys-widescreen:` prefix |

Classes the reference deliberately names **in order to warn people off them** are declared in `KNOWN_ABSENT`.

## The guard

`npm run verify:utility-docs` compiles the stylesheet, harvests every class name out of the rendered docs, and fails on any the stylesheet does not define. It checks both directions — it also asserts every `KNOWN_ABSENT` entry is still absent, so a "this class does not exist" warning can't quietly become a lie if someone adds one later.

```
Checked 111 class names from 9 doc sections against 2150 classes in the compiled stylesheet.
Checked 9 documented-as-absent class names are still absent.
PASS - every documented utility class exists.
```

It compiles only the utilities + typography layers, so it does not depend on a built `@nysds/tokens`.

## Verification

- `verify:utility-docs` passes; **negative-tested** by injecting a fabricated class name and by claiming an existing class was absent — it caught both and exited 1.
- `tsc -p packages/mcp-server` clean; eslint clean; prettier applied.
- Rendered output for every category reviewed by hand.
- Original defect confirmed in a browser before the fix (loaded published `@nysds/styles@1.20.1`, scanned all selectors, diffed computed styles against a bare sibling): 18 of 24 advertised classes matched no rule, with three known-good controls passing. Re-checked after the fix: **0 fabricated classes are still presented as usable.**

## Notes for review

- This is a **docs-only change to the MCP server**. No CSS, tokens, or component behavior is touched, and no consuming project needs to migrate.
- It closes two issues because both live in the same constant and the same release; happy to split if you'd rather land them separately.
- Deliberately **not** in scope: `order`, `float`, `overflow`, `position`, and `clearfix` utilities all ship but have never been documented by this tool. That's additive rather than a correctness fix, so I left it out with a release pending — worth a follow-up.
