### PR TITLE
Run the codegen Node test suite in CI

### DIFF
--- a/.github/workflows/test-node-js.yaml
+++ b/.github/workflows/test-node-js.yaml
@@ -39,6 +39,10 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
     - name: Build Packages
       run: npm run build:all
+    - name: Test codegen
+      # Node-only suites (node:test). They are excluded from the Web Test
+      # Runner glob because that runner executes files in Playwright browsers.
+      run: npm test -w @nysds/codegen
     - name: Test Components
       run: npm run test:ai
       # continue-on-error: true


### PR DESCRIPTION
The seven suites in `packages/codegen/test` import `node:test` and the package's built `dist/`. PR #1883 excluded them from the Web Test Runner glob because that runner executes files in Playwright browsers, which left them with no CI coverage at all.

This adds a `Test codegen` step after `Build Packages` that runs `npm test -w @nysds/codegen`. The package script runs `tsc -b` and then `node --test`, so it needs the manifest from `build:all` and nothing else. The `site-live` suite skips itself when the docs-site checkout is absent.

Workflows only trigger on PRs into develop or main, so this PR shows no checks. It runs on PR #1874 once merged into the branch.